### PR TITLE
Add upload-codescene-coverage action

### DIFF
--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -15,3 +15,9 @@
 
 ## v1.4.0
 - Fail when `format` input is not `cobertura` or `lcov`.
+
+## v1.4.1
+- Improved error message when the coverage file is missing.
+- Added restore keys to cache the CLI across minor versions.
+- Removed redundant checksum validation before executing the installer.
+- Reworded README reference to CHANGELOG.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `__auto__` default for `path` input and infer file name based on format.
 
 ## v1.2.0
-- Cache CodeScene CLI using the version extracted from the install script.
+- Cache CodeScene CLI using the version extracted from the installer script.
 
 ## v1.3.0
 - Validate installer checksum before execution and reuse the downloaded script

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -8,3 +8,7 @@
 
 ## v1.2.0
 - Cache CodeScene CLI using the version extracted from the install script.
+
+## v1.3.0
+- Validate installer checksum before execution and reuse the downloaded script
+  for version detection.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -5,3 +5,6 @@
 
 ## v1.1.0
 - Add `__auto__` default for `path` input and infer file name based on format.
+
+## v1.2.0
+- Cache CodeScene CLI using the version extracted from the install script.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v1.0.0
+- Initial version.
+
+## v1.1.0
+- Add `__auto__` default for `path` input and infer file name based on format.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -12,3 +12,6 @@
 ## v1.3.0
 - Validate installer checksum before execution and reuse the downloaded script
   for version detection.
+
+## v1.4.0
+- Fail when `format` input is not `cobertura` or `lcov`.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -1,0 +1,21 @@
+# Upload CodeScene Coverage
+
+Upload coverage reports to CodeScene and cache the CLI for faster runs.
+
+## Inputs
+
+| Name  | Description                                | Required | Default |
+| ----- | ------------------------------------------ | -------- | ------- |
+| path  | Coverage file path (set to `__auto__` to infer) | no       | `__auto__` |
+| format | Coverage format (`cobertura` or `lcov`)     | no       | `cobertura` |
+
+If `path` is left as `__auto__`, the action will look for `lcov.info` when
+`format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.
+
+## Example
+
+```yaml
+- uses: ./.github/actions/upload-codescene-coverage@v1
+```
+
+See [CHANGELOG](CHANGELOG.md) for release history.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -29,5 +29,5 @@ None
     format: cobertura
 ```
 
-Refer to [CHANGELOG](CHANGELOG.md) for release history.
+Release history is available in [CHANGELOG](CHANGELOG.md).
 

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -24,6 +24,10 @@ None
 
 ```yaml
 - uses: ./.github/actions/upload-codescene-coverage@v1
+  with:
+    path: coverage.xml
+    format: cobertura
 ```
 
-See [CHANGELOG](CHANGELOG.md) for release history.
+Refer to [CHANGELOG](CHANGELOG.md) for release history.
+

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -12,7 +12,8 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 If `path` is left as `__auto__`, the action will look for `lcov.info` when
 `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.
 The CodeScene CLI is cached using its release version extracted from the
-installer script.
+installer script. If `CODESCENE_CLI_SHA256` is provided, the installer
+is validated before execution.
 
 ## Outputs
 

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -11,6 +11,12 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 
 If `path` is left as `__auto__`, the action will look for `lcov.info` when
 `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.
+The CodeScene CLI is cached using its release version extracted from the
+installer script.
+
+## Outputs
+
+None
 
 ## Example
 

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -13,7 +13,8 @@ If `path` is left as `__auto__`, the action will look for `lcov.info` when
 `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.
 The CodeScene CLI is cached using its release version extracted from the
 installer script. If `CODESCENE_CLI_SHA256` is provided, the installer
-is validated before execution.
+is validated before execution. Any other value for `format` results in an
+error.
 
 ## Outputs
 

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -27,6 +27,13 @@ runs:
         echo "path=$file" >> "$GITHUB_OUTPUT"
       shell: bash
 
+    - name: Get CLI version
+      id: cli-version
+      run: |
+        version=$(curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | grep -oE 'version="[0-9a-f]+"' | cut -d'"' -f2)
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4
       with:
@@ -38,7 +45,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/cs-coverage
-        key: ${{ runner.os }}-cs-coverage
+        key: ${{ runner.os }}-cs-coverage-${{ steps.cli-version.outputs.version }}
 
     - name: Install CodeScene Coverage CLI
       if: env.CS_ACCESS_TOKEN != '' && steps.cs-cache.outputs.cache-hit != 'true'

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -1,0 +1,72 @@
+name: Upload CodeScene Coverage
+description: Upload coverage reports to CodeScene
+inputs:
+  path:
+    description: Coverage file path
+    required: false
+    # sentinel value, replaced based on format if unchanged
+    default: __auto__
+  format:
+    description: Coverage format (cobertura or lcov)
+    required: false
+    default: cobertura
+runs:
+  using: composite
+  steps:
+    - name: Determine coverage file
+      id: cov-file
+      run: |
+        file="${{ inputs.path }}"
+        if [ "$file" = "__auto__" ]; then
+          if [ "${{ inputs.format }}" = "lcov" ]; then
+            file="lcov.info"
+          else
+            file="coverage.xml"
+          fi
+        fi
+        echo "path=$file" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: ${{ steps.cov-file.outputs.path }}
+
+    - name: Cache CodeScene Coverage CLI
+      id: cs-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/bin/cs-coverage
+        key: ${{ runner.os }}-cs-coverage
+
+    - name: Install CodeScene Coverage CLI
+      if: env.CS_ACCESS_TOKEN != '' && steps.cs-cache.outputs.cache-hit != 'true'
+      run: |
+        curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+        if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
+          echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
+        fi
+      shell: bash
+
+    - name: Add cs-coverage to PATH
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: Upload coverage to CodeScene
+      if: env.CS_ACCESS_TOKEN != ''
+      run: |
+        file="${{ steps.cov-file.outputs.path }}"
+        if [ ! -f "$file" ]; then
+          echo "$file not found!"
+          exit 1
+        fi
+        cs-coverage upload \
+          --format "${{ inputs.format }}" \
+          --metric "line-coverage" \
+          "$file"
+      shell: bash
+
+env:
+  CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+  CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -42,7 +42,6 @@ runs:
       id: installer
       run: |
         script=$(mktemp)
-        trap 'rm -f "$script"' EXIT
         curl -fsSL -o "$script" https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
         if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
           echo "${CODESCENE_CLI_SHA256}  $script" | sha256sum -c -
@@ -54,7 +53,7 @@ runs:
         echo "major_minor=$major_minor" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    - name: Upload coverage artifact
+    - name: Upload coverage GitHub artifact
       uses: actions/upload-artifact@v4
       with:
         name: coverage

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -48,8 +48,10 @@ runs:
           echo "${CODESCENE_CLI_SHA256}  $script" | sha256sum -c -
         fi
         version=$(grep -oE 'version="([0-9]+\.[0-9]+\.[0-9]+)"' "$script" | cut -d'"' -f2)
+        major_minor=${version%.*}
         echo "script=$script" >> "$GITHUB_OUTPUT"
         echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "major_minor=$major_minor" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Upload coverage artifact
@@ -64,14 +66,13 @@ runs:
       with:
         path: ~/.local/bin/cs-coverage
         key: ${{ runner.os }}-cs-coverage-${{ steps.installer.outputs.version }}
+        restore-keys: |
+          ${{ runner.os }}-cs-coverage-${{ steps.installer.outputs.major_minor }}
 
     - name: Install CodeScene Coverage CLI
       if: env.CS_ACCESS_TOKEN != '' && steps.cs-cache.outputs.cache-hit != 'true'
       run: |
         script="${{ steps.installer.outputs.script }}"
-        if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-          echo "${CODESCENE_CLI_SHA256}  $script" | sha256sum -c -
-        fi
         bash "$script" -y
         rm "$script"
       shell: bash
@@ -86,7 +87,10 @@ runs:
         command -v cs-coverage >/dev/null 2>&1 || { echo "cs-coverage CLI not found" >&2; exit 1; }
         file="${{ steps.cov-file.outputs.path }}"
         if [ ! -f "$file" ]; then
-          echo "$file not found!"
+          echo "Coverage file not found!" >&2
+          echo "  Expected file: $file" >&2
+          echo "  Current working directory: $(pwd)" >&2
+          echo "  Expected format: ${{ inputs.format }}" >&2
           exit 1
         fi
         cs-coverage upload \

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -42,8 +42,12 @@ runs:
       id: installer
       run: |
         script=$(mktemp)
+        trap 'rm -f "$script"' EXIT
         curl -fsSL -o "$script" https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
-        version=$(grep -oE 'version="[0-9a-f]+"' "$script" | cut -d'"' -f2)
+        if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
+          echo "${CODESCENE_CLI_SHA256}  $script" | sha256sum -c -
+        fi
+        version=$(grep -oE 'version="([0-9]+\.[0-9]+\.[0-9]+)"' "$script" | cut -d'"' -f2)
         echo "script=$script" >> "$GITHUB_OUTPUT"
         echo "version=$version" >> "$GITHUB_OUTPUT"
       shell: bash
@@ -79,6 +83,7 @@ runs:
     - name: Upload coverage to CodeScene
       if: env.CS_ACCESS_TOKEN != ''
       run: |
+        command -v cs-coverage >/dev/null 2>&1 || { echo "cs-coverage CLI not found" >&2; exit 1; }
         file="${{ steps.cov-file.outputs.path }}"
         if [ ! -f "$file" ]; then
           echo "$file not found!"

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -13,6 +13,17 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate inputs
+      run: |
+        case "${{ inputs.format }}" in
+          cobertura|lcov) ;;
+          *)
+            echo "Unsupported format: ${{ inputs.format }}" >&2
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Determine coverage file
       id: cov-file
       run: |

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -27,10 +27,13 @@ runs:
         echo "path=$file" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    - name: Get CLI version
-      id: cli-version
+    - name: Download installer
+      id: installer
       run: |
-        version=$(curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | grep -oE 'version="[0-9a-f]+"' | cut -d'"' -f2)
+        script=$(mktemp)
+        curl -fsSL -o "$script" https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
+        version=$(grep -oE 'version="[0-9a-f]+"' "$script" | cut -d'"' -f2)
+        echo "script=$script" >> "$GITHUB_OUTPUT"
         echo "version=$version" >> "$GITHUB_OUTPUT"
       shell: bash
 
@@ -45,15 +48,17 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/cs-coverage
-        key: ${{ runner.os }}-cs-coverage-${{ steps.cli-version.outputs.version }}
+        key: ${{ runner.os }}-cs-coverage-${{ steps.installer.outputs.version }}
 
     - name: Install CodeScene Coverage CLI
       if: env.CS_ACCESS_TOKEN != '' && steps.cs-cache.outputs.cache-hit != 'true'
       run: |
-        curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+        script="${{ steps.installer.outputs.script }}"
         if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-          echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
+          echo "${CODESCENE_CLI_SHA256}  $script" | sha256sum -c -
         fi
+        bash "$script" -y
+        rm "$script"
       shell: bash
 
     - name: Add cs-coverage to PATH

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # shared-actions
 GitHub Actions
+
+## Available actions
+
+| Name | Path | Latest major |
+| ---- | ---- | ------------ |
+| Export Postgres URL | `.github/export-postgres-url` | v1 |
+| Generate coverage | `.github/generate-coverage` | v1 |
+| Setup Rust | `.github/actions/setup-rust` | v1 |
+| Upload CodeScene Coverage | `.github/actions/upload-codescene-coverage` | v1 |


### PR DESCRIPTION
## Summary
- add action to upload coverage to CodeScene
- document usage and release history
- make coverage path autodetect based on format

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851a0ace784832299f8e2845b362401

## Summary by Sourcery

Add a new composite GitHub Action (`upload-codescene-coverage`) to streamline uploading coverage reports to CodeScene, featuring path autodetection, CLI caching, installer checksum validation, and input validation.

New Features:
- Introduce `upload-codescene-coverage` composite GitHub Action to upload coverage reports to CodeScene
- Support automatic detection of coverage file path based on specified format

Enhancements:
- Cache the CodeScene CLI by extracting its version from the installer script for faster subsequent runs
- Validate installer checksum via `CODESCENE_CLI_SHA256` and reuse the downloaded script for version detection
- Fail early on unsupported `format` input values

Documentation:
- Update main README to list the new action and add dedicated README and CHANGELOG for the action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Action for uploading coverage reports to CodeScene, supporting automatic detection of coverage files, caching, and secure installation of the CLI tool.
- **Documentation**
	- Added a README and changelog for the new action, including usage instructions and release history.
	- Updated the main README to list the new action among available repository actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->