### PR TITLE
Fix `if` syntax

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,6 +24,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
     - name: Install system dependencies
-      if: ${{ inputs.install-postgres-deps }}
-      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+      if: inputs.install-postgres-deps
+      run: apt-get update && apt-get install -y --no-install-recommends libpq-dev
       shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -25,5 +25,5 @@ runs:
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
     - name: Install system dependencies
       if: inputs.install-postgres-deps
-      run: apt-get update && apt-get install -y --no-install-recommends libpq-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       shell: bash


### PR DESCRIPTION
## Summary by Sourcery

Correct the conditional syntax in the GitHub Action step and simplify the apt-get command invocation

Bug Fixes:
- Use the proper `if: inputs.install-postgres-deps` syntax instead of the `${{ }}` expression
- Remove the unnecessary `sudo` prefix from the apt-get commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the setup process for installing system dependencies during workflows.
  - Updated the installation commands for PostgreSQL dependencies to improve compatibility in automation environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->