### PR TITLE
Add Windows Postgres deps to setup-rust

### DIFF
--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## v1.0.3
+
+- Install PostgreSQL client libraries on Windows via Chocolatey.
+
 ## v1.0.2
 
 - Document `BUILD_PROFILE` environment variable and fix README example

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -22,11 +22,11 @@ uses: ./.github/actions/setup-rust@v1
     install-postgres-deps: true
 ```
 
-When `install-postgres-deps` is enabled, the action installs PostgreSQL client
-libraries via the package manager for the runner OS. On Linux, it uses
-`apt` (`libpq-dev`). On Windows, Chocolatey installs `postgresql17`
-and exposes its headers and import libraries via `PG_INCLUDE` and
-`PG_LIB` environment variables.
+When `install-postgres-deps` is enabled, the action installs PostgreSQL
+client libraries via the package manager for the runner OS. On Linux,
+it uses `apt` (`libpq-dev`). On Windows, Chocolatey installs
+`postgresql17` and exposes its headers and import libraries through
+`PG_INCLUDE` and `PG_LIB` environment variables.
 
 ## Caching
 

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -22,6 +22,12 @@ uses: ./.github/actions/setup-rust@v1
     install-postgres-deps: true
 ```
 
+When `install-postgres-deps` is enabled, the action installs PostgreSQL client
+libraries using the package manager of the underlying runner. On Linux this is
+`apt` (`libpq-dev`), while on Windows Chocolatey is used to install the
+`postgresql17` package and expose its headers and import libraries via
+`PG_INCLUDE` and `PG_LIB` environment variables.
+
 ## Caching
 
 This action caches `~/.cargo/registry`, `~/.cargo/git` and the build output in

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -23,10 +23,10 @@ uses: ./.github/actions/setup-rust@v1
 ```
 
 When `install-postgres-deps` is enabled, the action installs PostgreSQL client
-libraries using the package manager of the underlying runner. On Linux this is
-`apt` (`libpq-dev`), while on Windows Chocolatey is used to install the
-`postgresql17` package and expose its headers and import libraries via
-`PG_INCLUDE` and `PG_LIB` environment variables.
+libraries via the package manager for the runner OS. On Linux, it uses
+`apt` (`libpq-dev`). On Windows, Chocolatey installs `postgresql17`
+and exposes its headers and import libraries via `PG_INCLUDE` and
+`PG_LIB` environment variables.
 
 ## Caching
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,6 +36,6 @@ runs:
 
         # Tell the rest of the job where the headers and import library are
         $pgRoot = "${Env:ProgramFiles}\PostgreSQL\17"
-        echo "PG_INCLUDE=$pgRoot\include"  >> $Env:GITHUB_ENV
-        echo "PG_LIB=$pgRoot\lib"          >> $Env:GITHUB_ENV
+        "PG_INCLUDE=$pgRoot\include" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+        "PG_LIB=$pgRoot\lib"          | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
         echo "$pgRoot\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
     - name: Install libpq (headers + import library)
       if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Windows' }}
-      shell: powershell
+      shell: pwsh
       run: |
         # Install PostgreSQL 17 but suppress the server service – we only need the client bits
         choco install postgresql17 --no-progress -y --params '/Password:postgres /NoService /SkipStackBuilder'

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,17 +24,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
     - name: Install system dependencies
-      if: inputs.install-postgres-deps && runner.os == 'Linux'
+      if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Linux' }}
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       shell: bash
     - name: Install libpq (headers + import library)
-      if: inputs.install-postgres-deps && runner.os == 'Windows'
+      if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Windows' }}
       shell: powershell
       run: |
         # Install PostgreSQL 17 but suppress the server service – we only need the client bits
-        choco install postgresql17 \
-                     --no-progress -y \
-                     --params '/Password:postgres /NoService /SkipStackBuilder'
+        choco install postgresql17 --no-progress -y --params '/Password:postgres /NoService /SkipStackBuilder'
 
         # Tell the rest of the job where the headers and import library are
         $pgRoot = "${Env:ProgramFiles}\PostgreSQL\17"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,6 +24,20 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
     - name: Install system dependencies
-      if: inputs.install-postgres-deps
+      if: inputs.install-postgres-deps && runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       shell: bash
+    - name: Install libpq (headers + import library)
+      if: inputs.install-postgres-deps && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        # Install PostgreSQL 17 but suppress the server service – we only need the client bits
+        choco install postgresql17 \
+                     --no-progress -y \
+                     --params '/Password:postgres /NoService /SkipStackBuilder'
+
+        # Tell the rest of the job where the headers and import library are
+        $pgRoot = "${Env:ProgramFiles}\PostgreSQL\17"
+        echo "PG_INCLUDE=$pgRoot\include"  >> $Env:GITHUB_ENV
+        echo "PG_LIB=$pgRoot\lib"          >> $Env:GITHUB_ENV
+        echo "$pgRoot\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
## Summary
- install libpq via Chocolatey on Windows runners
- document OS-specific behaviour for `install-postgres-deps`
- note change in changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855621c71d8832281627e34b59301aa

## Summary by Sourcery

Enable installing PostgreSQL dependencies on Windows using Chocolatey alongside existing Linux support and document the new behavior

New Features:
- Support installing PostgreSQL client libraries on Windows runners via Chocolatey

Enhancements:
- Set PG_INCLUDE and PG_LIB env vars and add PostgreSQL bin to PATH on Windows

Documentation:
- Document OS-specific behavior for install-postgres-deps in the README
- Add v1.0.3 changelog entry for Windows Postgres deps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- PostgreSQL client libraries are now installed on Windows runners using Chocolatey when the relevant option is enabled in the GitHub Action.
- **Documentation**
	- Updated README with detailed information about the platform-specific installation of PostgreSQL dependencies.
	- Added a changelog entry for the new PostgreSQL dependency installation behaviour on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->