### PR TITLE
Fix upload-codescene-coverage env

### DIFF
--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -21,3 +21,11 @@
 - Added restore keys to cache the CLI across minor versions.
 - Removed redundant checksum validation before executing the installer.
 - Reworded README reference to CHANGELOG.
+
+## v1.4.2
+- Fixed action load failure by removing unsupported `secrets` and `vars`
+  references in `action.yml`.
+- Documented required environment variables in the README.
+
+## v1.4.3
+- Added details about caching behavior and usage recommendations to the README.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -16,6 +16,11 @@ installer script. If `CODESCENE_CLI_SHA256` is provided, the installer
 is validated before execution. Any other value for `format` results in an
 error.
 
+## Environment variables
+
+- `CS_ACCESS_TOKEN` – CodeScene project access token (required)
+- `CODESCENE_CLI_SHA256` – SHA‑256 checksum for the installer (optional)
+
 ## Outputs
 
 None
@@ -28,6 +33,36 @@ None
     path: coverage.xml
     format: cobertura
 ```
+
+## Caching
+
+The CodeScene Coverage CLI is stored in `~/.local/bin/cs-coverage` and cached
+with [actions/cache](https://github.com/actions/cache). The cache key combines
+the runner OS and the CLI version extracted from the installer script. The cache
+is restored at the start of the job and saved after the job finishes.
+
+### Requirements
+
+- `CS_ACCESS_TOKEN` must be provided so the installer can download the CLI and
+  to authenticate uploads.
+- `CODESCENE_CLI_SHA256` should be set to the published checksum of the
+  installer to guard against tampering (optional).
+
+### Extent and limitations
+
+- GitHub limits each cache to 5 GB per operating system; old entries may be
+  evicted as new ones are created.
+- Caches are scoped to the runner OS, so Windows, macOS, and Linux caches are
+  independent.
+- If the CLI version changes or no cache entry exists, the installer runs again
+  and a new cache entry is created.
+
+### Effective use
+
+- Pin the installer checksum whenever possible to avoid using a compromised
+  download.
+- Keep your coverage file path consistent across jobs so subsequent steps can
+  locate it reliably.
 
 Release history is available in [CHANGELOG](CHANGELOG.md).
 

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -98,6 +98,3 @@ runs:
           "$file"
       shell: bash
 
-env:
-  CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-  CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary
- remove invalid env section from the action
- document the required env vars in the README
- document caching details like in setup-rust
- note fix in CHANGELOG

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6855ef4a8da483228d0c48d79a756c1b