### PR TITLE
Install sqlite in setup-rust

### DIFF
--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## v1.0.4
 
-- Install SQLite development libraries on Windows via MSYS2.
+- Install SQLite development libraries on Windows via MSYS2 alongside the GCC
+  toolchain.
 
 ## v1.0.3
 

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ## v1.0.4
 
-- Install SQLite development libraries on Windows via MSYS2 alongside the GCC
-  toolchain.
+- Optionally install SQLite development libraries on Windows via MSYS2 using the
+  `install-sqlite-deps` input.
 
 ## v1.0.3
 

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## v1.0.4
+
+- Install SQLite development libraries on Windows via MSYS2.
+
 ## v1.0.3
 
 - Install PostgreSQL client libraries on Windows via Chocolatey.

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -35,8 +35,8 @@ When `install-sqlite-deps` is enabled, the action installs SQLite
 development files using MSYS2 on Windows.
 
 Enable SQLite support on Windows by setting up an MSYS2 environment
-with the MinGW toolchain and the `mingw-w64-x86_64-sqlite3` package so
-the static library and headers are available when compiling crates that
+with the MinGW toolchain and the `mingw-w64-x86_64-sqlite3` package,
+so the static library and headers are available when compiling crates that
 depend on SQLite.
 
 ```yaml

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -1,13 +1,15 @@
 # Setup Rust
 
 Install the Rust toolchain and cache your build dependencies. Optionally
-install PostgreSQL system libraries for crates that require them.
+install PostgreSQL and SQLite system libraries for crates that require
+them.
 
 ## Inputs
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
 | install-postgres-deps | Install PostgreSQL system dependencies | no | `false` |
+| install-sqlite-deps | Install SQLite development libraries (Windows) | no | `false` |
 | BUILD_PROFILE | Build profile used for caching | no | `release` |
 
 ## Outputs
@@ -20,6 +22,7 @@ None
 uses: ./.github/actions/setup-rust@v1
   with:
     install-postgres-deps: true
+    install-sqlite-deps: true
 ```
 
 When `install-postgres-deps` is enabled, the action installs PostgreSQL
@@ -28,10 +31,13 @@ it uses `apt` (`libpq-dev`). On Windows, Chocolatey installs
 `postgresql17` and exposes its headers and import libraries through
 `PG_INCLUDE` and `PG_LIB` environment variables.
 
-SQLite is also available on Windows. The action sets up an MSYS2
-environment and installs both the `mingw-w64-x86_64-toolchain` and
-`mingw-w64-x86_64-sqlite3` packages so the static library and headers
-are available when compiling crates that depend on SQLite.
+When `install-sqlite-deps` is enabled, the action installs SQLite
+development files using MSYS2 on Windows.
+
+Enable SQLite support on Windows by setting up an MSYS2 environment
+with the MinGW toolchain and the `mingw-w64-x86_64-sqlite3` package so
+the static library and headers are available when compiling crates that
+depend on SQLite.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -34,7 +34,7 @@ it uses `apt` (`libpq-dev`). On Windows, Chocolatey installs
 When `install-sqlite-deps` is enabled, the action installs SQLite
 development files using MSYS2 on Windows.
 
-Enable SQLite support on Windows by setting up an MSYS2 environment
+SQLite support on Windows is enabled by setting up an MSYS2 environment
 with the MinGW toolchain and the `mingw-w64-x86_64-sqlite3` package,
 so the static library and headers are available when compiling crates that
 depend on SQLite.

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -29,13 +29,13 @@ it uses `apt` (`libpq-dev`). On Windows, Chocolatey installs
 `PG_INCLUDE` and `PG_LIB` environment variables.
 
 SQLite is also available on Windows. The action sets up an MSYS2
-environment and installs the `mingw-w64-x86_64-sqlite3` package so the
-static library and headers are available when compiling crates that
-depend on SQLite.
+environment and installs both the `mingw-w64-x86_64-toolchain` and
+`mingw-w64-x86_64-sqlite3` packages so the static library and headers
+are available when compiling crates that depend on SQLite.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite
-      - name: Set up MSYS2 and SQLite
+      - name: Install MSYS2 toolchain and SQLite
         uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -28,6 +28,28 @@ it uses `apt` (`libpq-dev`). On Windows, Chocolatey installs
 `postgresql17` and exposes its headers and import libraries through
 `PG_INCLUDE` and `PG_LIB` environment variables.
 
+SQLite is also available on Windows. The action sets up an MSYS2
+environment and installs the `mingw-w64-x86_64-sqlite3` package so the
+static library and headers are available when compiling crates that
+depend on SQLite.
+
+```yaml
+      # Bring in MSYS2 plus the MinGW build of SQLite
+      - name: Set up MSYS2 and SQLite
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-sqlite3       # ships libsqlite3.a + headers
+
+      # Build inside the MSYS2 shell so the linker sees /mingw64/lib
+      - name: Build
+        shell: msys2 {0}
+        run: cargo build --workspace --all-targets --verbose
+```
+
 ## Caching
 
 This action caches `~/.cargo/registry`, `~/.cargo/git` and the build output in

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -39,3 +39,13 @@ runs:
         "PG_INCLUDE=$pgRoot\include" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
         "PG_LIB=$pgRoot\lib"         | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
         echo "$pgRoot\bin"           | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Install SQLite (MSYS2)
+      if: ${{ runner.os == 'Windows' }}
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-sqlite3

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Install PostgreSQL system dependencies
     required: false
     default: false
+  install-sqlite-deps:
+    description: Install SQLite development libraries on Windows
+    required: false
+    default: false
 runs:
   using: composite
   steps:
@@ -41,7 +45,7 @@ runs:
         echo "$pgRoot\bin"           | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install MSYS2 toolchain and SQLite
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ inputs.install-sqlite-deps == 'true' && runner.os == 'Windows' }}
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -40,7 +40,7 @@ runs:
         "PG_LIB=$pgRoot\lib"         | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
         echo "$pgRoot\bin"           | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: Install SQLite (MSYS2)
+    - name: Install MSYS2 toolchain and SQLite
       if: ${{ runner.os == 'Windows' }}
       uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
## Summary
- install sqlite3 via MSYS2 on Windows
- document sqlite support
- note sqlite installation in changelog

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855f08e12b083228b0b08386d6dca7c

## Summary by Sourcery

Enable optional installation of SQLite development libraries on Windows by adding a new `install-sqlite-deps` input and MSYS2 installation step, and update documentation and changelog accordingly.

New Features:
- Add `install-sqlite-deps` input to optionally install SQLite development libraries on Windows via MSYS2

Documentation:
- Document SQLite support and MSYS2 installation steps in README
- Add CHANGELOG entry for SQLite support in v1.0.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated changelog and README with instructions for optional SQLite development library installation on Windows via MSYS2.

- **Chores**
  - Added an input to enable installation of SQLite development libraries and toolchain on Windows runners using MSYS2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->