### PR TITLE
Fix upload-codescene-coverage env

### DIFF
--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -23,14 +23,8 @@
 - Reworded README reference to CHANGELOG.
 
 ## v1.4.2
-- Fixed action load failure by removing unsupported `secrets` and `vars`
-  references in `action.yml`.
-- Documented required environment variables in the README.
-
-## v1.4.3
-- Added details about caching behavior and usage recommendations to the README.
-
-## v1.4.4
+- Fixed action load failure by removing unsupported `secrets` and `vars` references in `action.yml`.
+- Documented required environment variables and caching usage in the README.
 - Wrapped README lines to 80 columns for consistency.
 
 ## v1.4.5

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -35,3 +35,9 @@
 
 ## v1.4.5
 - Shortened cache description line to avoid exceeding 80 columns.
+
+## v1.5.0
+- Added `access-token` and `installer-checksum` inputs, surfacing required
+  variables in the UI.
+- Documented the restore-keys caching pattern and expanded example usage in the
+  README.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -21,3 +21,11 @@
 - Added restore keys to cache the CLI across minor versions.
 - Removed redundant checksum validation before executing the installer.
 - Reworded README reference to CHANGELOG.
+
+## v1.4.2
+- Fixed action load failure by removing unsupported `secrets` and `vars`
+  references in `action.yml`.
+- Documented required environment variables in the README.
+
+## v1.4.3
+- Added details about caching behavior and usage recommendations to the README.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -32,3 +32,6 @@
 
 ## v1.4.4
 - Wrapped README lines to 80 columns for consistency.
+
+## v1.4.5
+- Shortened cache description line to avoid exceeding 80 columns.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -29,3 +29,6 @@
 
 ## v1.4.3
 - Added details about caching behavior and usage recommendations to the README.
+
+## v1.4.4
+- Wrapped README lines to 80 columns for consistency.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -49,9 +49,9 @@ restore key allows reuse across patch releases:
 uses: actions/cache@v4
 with:
   path: ~/.local/bin/cs-coverage
-  key: ${{ runner.os }}-cs-coverage-${{ version }}
+  key: cs-coverage-cache-${{ runner.os }}-${{ version }}
   restore-keys: |
-    ${{ runner.os }}-cs-coverage-${{ major_minor }}
+    cs-coverage-cache-${{ runner.os }}-${{ major_minor }}
 ```
 
 ### Requirements

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -38,8 +38,8 @@ None
 
 The CodeScene Coverage CLI is stored in `~/.local/bin/cs-coverage` and cached
 with [actions/cache](https://github.com/actions/cache). The cache key combines
-the runner OS and the CLI version extracted from the installer script. The cache
-is restored at the start of the job and saved after the job finishes.
+the runner OS and the CLI version extracted from the installer script.
+The cache is restored at the start of the job and saved after the job finishes.
 
 ### Requirements
 

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -6,8 +6,8 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 
 | Name  | Description                                | Required | Default |
 | ----- | ------------------------------------------ | -------- | ------- |
-| path  | Coverage file path (set to `__auto__` to infer) | no       | `__auto__` |
-| format | Coverage format (`cobertura` or `lcov`)     | no       | `cobertura` |
+| path  | Coverage file path; use `__auto__` to infer | no       | `__auto__` |
+| format | Coverage format (`cobertura` or `lcov`) | no       | `cobertura` |
 
 If `path` is left as `__auto__`, the action will look for `lcov.info` when
 `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -16,6 +16,11 @@ installer script. If `CODESCENE_CLI_SHA256` is provided, the installer
 is validated before execution. Any other value for `format` results in an
 error.
 
+## Environment variables
+
+- `CS_ACCESS_TOKEN` – CodeScene project access token (required)
+- `CODESCENE_CLI_SHA256` – SHA‑256 checksum for the installer (optional)
+
 ## Outputs
 
 None
@@ -28,6 +33,36 @@ None
     path: coverage.xml
     format: cobertura
 ```
+
+## Caching
+
+The CodeScene Coverage CLI is stored in `~/.local/bin/cs-coverage` and cached
+with [actions/cache](https://github.com/actions/cache). The cache key combines
+the runner OS and the CLI version extracted from the installer script. The cache
+is restored at the start of the job and saved after the job finishes.
+
+### Requirements
+
+- `CS_ACCESS_TOKEN` must be provided so the installer can download the CLI and
+  to authenticate uploads.
+- `CODESCENE_CLI_SHA256` should be set to the published checksum of the
+  installer to guard against tampering (optional).
+
+### Extent and limitations
+
+- GitHub limits each cache to 5 GB per operating system; old entries may be
+  evicted as new ones are created.
+- Caches are scoped to the runner OS, so Windows, macOS, and Linux caches are
+  independent.
+- If the CLI version changes or no cache entry exists, the installer runs again
+  and a new cache entry is created.
+
+### Effective use
+
+- Pin the installer checksum whenever possible to avoid using a compromised
+  download.
+- Keep your coverage file path consistent across jobs so subsequent steps can
+  locate it reliably.
 
 Release history is available in [CHANGELOG](CHANGELOG.md).
 

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -10,8 +10,17 @@ inputs:
     description: Coverage format (cobertura or lcov)
     required: false
     default: cobertura
+  access-token:
+    description: CodeScene project access token
+    required: true
+  installer-checksum:
+    description: SHA-256 checksum of the installer script
+    required: false
 runs:
   using: composite
+  env:
+    CS_ACCESS_TOKEN: ${{ inputs.access-token }}
+    CODESCENE_CLI_SHA256: ${{ inputs.installer-checksum }}
   steps:
     - name: Validate inputs
       run: |

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -98,6 +98,3 @@ runs:
           "$file"
       shell: bash
 
-env:
-  CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-  CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -73,9 +73,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/cs-coverage
-        key: ${{ runner.os }}-cs-coverage-${{ steps.installer.outputs.version }}
+        key: cs-coverage-cache-${{ runner.os }}-${{ steps.installer.outputs.version }}
         restore-keys: |
-          ${{ runner.os }}-cs-coverage-${{ steps.installer.outputs.major_minor }}
+          cs-coverage-cache-${{ runner.os }}-${{ steps.installer.outputs.major_minor }}
 
     - name: Install CodeScene Coverage CLI
       if: env.CS_ACCESS_TOKEN != '' && steps.cs-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- remove invalid env section from the action
- document the required env vars in the README
- document caching details like in setup-rust
- note fix in CHANGELOG

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6855ef4a8da483228d0c48d79a756c1b

## Summary by Sourcery

Fix `upload-codescene-coverage` action by removing invalid environment references, adding required inputs for authentication and integrity, and enhancing caching patterns with documentation and formatting updates.

New Features:
- Add `access-token` and `installer-checksum` inputs to the action, exposing them as environment variables.

Bug Fixes:
- Remove unsupported `secrets` and `vars` references in `action.yml` to prevent load failures.

Enhancements:
- Standardize cache key prefixes and introduce a fallback restore-keys pattern for caching the CLI.
- Wrap README lines to 80 characters and shorten cache descriptions for consistency.
- Bump action version to v1.5.0.

Documentation:
- Document required environment variables and expanded caching usage in the action README.
- Update changelog entries to reflect new inputs, caching patterns, and formatting adjustments.