### PR TITLE
Add ratchet coverage action

### DIFF
--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.4
+
+- Switch to `cargo-llvm-cov` for coverage generation.
+
 ## v1.0.3
 
 - Remove Linux-only gating so the action runs on all runners.

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ## v1.0.1
 
-- Add `args` input and include it in tarpaulin command
-- Validate numeric coverage values before comparison
-- Handle integer coverage values in output parsing
+- Add `args` input and include it in tarpaulin command.
+- Validate numeric coverage values before comparison.
+- Handle integer coverage values in output parsing.
 
 ## v1.0.0
 

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v1.0.1
+
+- Add `args` input and include it in tarpaulin command
+- Validate numeric coverage values before comparison
+
+## v1.0.0
+
+- Initial version with caching and baseline ratcheting.

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## v1.0.3
+
+- Remove Linux-only gating so the action runs on all runners.
+
 ## v1.0.2
 
-- Skip gracefully on non-Linux runners
+- Skip gracefully on non-Linux runners.
 
 ## v1.0.1
 

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## v1.0.3
 
-- Remove Linux-only gating so the action runs on all runners.
+- Remove Linux-only gating, so the action runs on all runners.
 
 ## v1.0.2
 

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `args` input and include it in tarpaulin command
 - Validate numeric coverage values before comparison
+- Fail early on non-Linux runners
+- Handle integer coverage values in output parsing
 
 ## v1.0.0
 

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## v1.0.2
+
+- Skip gracefully on non-Linux runners
+
 ## v1.0.1
 
 - Add `args` input and include it in tarpaulin command
 - Validate numeric coverage values before comparison
-- Fail early on non-Linux runners
 - Handle integer coverage values in output parsing
 
 ## v1.0.0

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -13,8 +13,7 @@
 - Skip gracefully on non-Linux runners.
 
 ## v1.0.1
-
-- Add `args` input and include it in tarpaulin command.
+- Add the `args` input and include it in the tarpaulin command.
 - Validate numeric coverage values before comparison.
 - Handle integer coverage values in output parsing.
 

--- a/.github/actions/ratchet-coverage/README.md
+++ b/.github/actions/ratchet-coverage/README.md
@@ -26,10 +26,8 @@ coverage percentage falls below a stored baseline.
     args: --workspace
 ```
 
-`cargo tarpaulin` only runs on Linux hosts, so this action executes the
-coverage check on `ubuntu-latest` runners and prints a message on other
-platforms. When running on Windows, `bc` is installed via MSYS2 so the
-float comparison works the same everywhere.
+On Windows runners `bc` is installed via MSYS2 so the float comparison works
+the same across platforms.
 
 ### How it works
 
@@ -39,9 +37,5 @@ The action restores the previous coverage baseline using
 the new percentage with the stored baseline. The job fails if coverage drops.
 On success, the baseline file is updated and saved back to the cache for future
 runs.
-
-### Requirements
-
-- Use `ubuntu-latest` for the coverage run because `cargo tarpaulin` only supports Linux. On other platforms the step is skipped.
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/ratchet-coverage/README.md
+++ b/.github/actions/ratchet-coverage/README.md
@@ -1,6 +1,6 @@
 # Ratchet coverage
 
-Generate code coverage using `cargo tarpaulin` and fail the workflow if the
+Generate code coverage using `cargo llvm-cov` and fail the workflow if the
 coverage percentage falls below a stored baseline.
 
 ## Inputs
@@ -8,13 +8,13 @@ coverage percentage falls below a stored baseline.
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
 | baseline-file | File used to persist the baseline coverage percentage between runs | no | `.coverage-baseline` |
-| args | Additional arguments passed to `cargo tarpaulin` | no | `''` |
+| args | Additional arguments passed to `cargo llvm-cov` | no | `''` |
 
 ## Outputs
 
 | Name | Description |
 | --- | --- |
-| percent | Coverage percentage reported by `cargo tarpaulin` |
+| percent | Coverage percentage reported by `cargo llvm-cov` |
 
 ## Example
 
@@ -33,9 +33,22 @@ the same across platforms.
 
 The action restores the previous coverage baseline using
 [actions/cache](https://github.com/actions/cache) and installs
-`cargo-tarpaulin` if necessary. After running the coverage command, it compares
+`cargo-llvm-cov` if necessary. After running the coverage command, it compares
 the new percentage with the stored baseline. The job fails if coverage drops.
 On success, the baseline file is updated and saved back to the cache for future
 runs.
+
+## Caching
+
+Two caches are used: one for the baseline file and another for cargo
+artifacts and the `cargo-llvm-cov` binary. The baseline cache is restored when
+the action starts and saved again after updating the file. The cargo cache
+uses the operating system and the checksum of `Cargo.lock` to avoid rebuilds.
+
+### Requirements
+
+- The Rust toolchain must already be installed (for example via the
+  [setup-rust](../setup-rust) action).
+- Windows runners automatically install `bc` using MSYS2.
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/ratchet-coverage/README.md
+++ b/.github/actions/ratchet-coverage/README.md
@@ -26,7 +26,7 @@ coverage percentage falls below a stored baseline.
     args: --workspace
 ```
 
-On Windows runners `bc` is installed via MSYS2 so the float comparison works
+On Windows runners `bc` is installed via MSYS2, so the float comparison works
 the same across platforms.
 
 ### How it works

--- a/.github/actions/ratchet-coverage/README.md
+++ b/.github/actions/ratchet-coverage/README.md
@@ -26,8 +26,10 @@ coverage percentage falls below a stored baseline.
     args: --workspace
 ```
 
-`cargo tarpaulin` only runs on Linux hosts, so use this action on
-`ubuntu-latest` runners.
+`cargo tarpaulin` only runs on Linux hosts, so this action executes the
+coverage check on `ubuntu-latest` runners and prints a message on other
+platforms. When running on Windows, `bc` is installed via MSYS2 so the
+float comparison works the same everywhere.
 
 ### How it works
 
@@ -40,6 +42,6 @@ runs.
 
 ### Requirements
 
-- Run on `ubuntu-latest` since `cargo tarpaulin` only supports Linux. The action fails early on other platforms.
+- Use `ubuntu-latest` for the coverage run because `cargo tarpaulin` only supports Linux. On other platforms the step is skipped.
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/ratchet-coverage/README.md
+++ b/.github/actions/ratchet-coverage/README.md
@@ -8,7 +8,7 @@ coverage percentage falls below a stored baseline.
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
 | baseline-file | File used to persist the baseline coverage percentage between runs | no | `.coverage-baseline` |
-| args | Additional arguments passed to `cargo tarpaulin` | no | `""` |
+| args | Additional arguments passed to `cargo tarpaulin` | no | `''` |
 
 ## Outputs
 
@@ -34,15 +34,12 @@ coverage percentage falls below a stored baseline.
 The action restores the previous coverage baseline using
 [actions/cache](https://github.com/actions/cache) and installs
 `cargo-tarpaulin` if necessary. After running the coverage command, it compares
-the new percentage with the stored baseline. The job fails if coverage drops. On
-success, the baseline file is updated and saved back to the cache for future
-runs. On Windows, the `bc` utility is installed via
-[`msys2/setup-msys2`](https://github.com/msys2/setup-msys2) so the comparison
-script works the same on all platforms.
+the new percentage with the stored baseline. The job fails if coverage drops.
+On success, the baseline file is updated and saved back to the cache for future
+runs.
 
 ### Requirements
 
-- Run on `ubuntu-latest` since `cargo tarpaulin` only supports Linux.
-- Ensure `bc` is available (the action installs it on Windows).
+- Run on `ubuntu-latest` since `cargo tarpaulin` only supports Linux. The action fails early on other platforms.
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/ratchet-coverage/README.md
+++ b/.github/actions/ratchet-coverage/README.md
@@ -1,0 +1,48 @@
+# Ratchet coverage
+
+Generate code coverage using `cargo tarpaulin` and fail the workflow if the
+coverage percentage falls below a stored baseline.
+
+## Inputs
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| baseline-file | File used to persist the baseline coverage percentage between runs | no | `.coverage-baseline` |
+| args | Additional arguments passed to `cargo tarpaulin` | no | `""` |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| percent | Coverage percentage reported by `cargo tarpaulin` |
+
+## Example
+
+```yaml
+- uses: ./.github/actions/setup-rust@v1
+- uses: ./.github/actions/ratchet-coverage@v1
+  with:
+    baseline-file: .cache/coverage-baseline
+    args: --workspace
+```
+
+`cargo tarpaulin` only runs on Linux hosts, so use this action on
+`ubuntu-latest` runners.
+
+### How it works
+
+The action restores the previous coverage baseline using
+[actions/cache](https://github.com/actions/cache) and installs
+`cargo-tarpaulin` if necessary. After running the coverage command, it compares
+the new percentage with the stored baseline. The job fails if coverage drops. On
+success, the baseline file is updated and saved back to the cache for future
+runs. On Windows, the `bc` utility is installed via
+[`msys2/setup-msys2`](https://github.com/msys2/setup-msys2) so the comparison
+script works the same on all platforms.
+
+### Requirements
+
+- Run on `ubuntu-latest` since `cargo tarpaulin` only supports Linux.
+- Ensure `bc` is available (the action installs it on Windows).
+
+Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -78,7 +78,7 @@ runs:
       shell: bash
     - name: Save baseline
       if: success()
-      uses: actions/cache/save@v4
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.baseline-file }}
         key: ratchet-baseline-${{ runner.os }}

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -17,16 +17,16 @@ runs:
   using: composite
   steps:
     - if: runner.os != 'Linux'
-      run: |
-        echo "Ratchet coverage runs only on Linux" >&2
-        exit 1
+      run: echo "Skipping ratchet coverage: cargo tarpaulin only runs on Linux"
       shell: bash
     - name: Restore baseline
+      if: runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         path: ${{ inputs.baseline-file }}
         key: ratchet-baseline-${{ runner.os }}
     - name: Cache cargo artifacts
+      if: runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         path: |
@@ -38,9 +38,17 @@ runs:
         restore-keys: |
           ${{ runner.os }}-tarpaulin-
     - name: Install cargo-tarpaulin
+      if: runner.os == 'Linux'
       run: cargo install cargo-tarpaulin
       shell: bash
+    - if: runner.os == 'Windows'
+      name: Install bc (MSYS2)
+      uses: msys2/setup-msys2@v2
+      with:
+        install: bc
+        path-type: inherit
     - name: Run coverage
+      if: runner.os == 'Linux'
       id: cov
       run: |
         set -euo pipefail
@@ -50,6 +58,7 @@ runs:
         echo "percent=$percent" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Ratchet coverage
+      if: runner.os == 'Linux'
       run: |
         set -euo pipefail
         file="${{ inputs.baseline-file }}"
@@ -77,7 +86,7 @@ runs:
         printf '%.2f' "$current" > "$file"
       shell: bash
     - name: Save baseline
-      if: success()
+      if: success() && runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         path: ${{ inputs.baseline-file }}

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -1,17 +1,17 @@
 name: Ratchet coverage
-description: Run cargo tarpaulin and fail if coverage decreases
+description: Run cargo llvm-cov and fail if coverage decreases
 inputs:
   baseline-file:
     description: Path to store the coverage baseline
     required: false
     default: .coverage-baseline
   args:
-    description: Additional arguments passed to cargo tarpaulin
+    description: Additional arguments passed to cargo llvm-cov
     required: false
     default: ''
 outputs:
   percent:
-    description: Coverage percentage reported by cargo tarpaulin
+    description: Coverage percentage reported by cargo llvm-cov
     value: ${{ steps.cov.outputs.percent }}
 runs:
   using: composite
@@ -25,15 +25,15 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          ~/.cargo/bin/cargo-tarpaulin
+          ~/.cargo/bin/cargo-llvm-cov
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-llvmcov-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-tarpaulin-
-    - name: Install cargo-tarpaulin
-      run: cargo install cargo-tarpaulin
+          ${{ runner.os }}-llvmcov-
+    - name: Install cargo-llvm-cov
+      run: cargo install cargo-llvm-cov
       shell: bash
     - if: runner.os == 'Windows'
       name: Install bc (MSYS2)
@@ -45,7 +45,7 @@ runs:
       id: cov
       run: |
         set -euo pipefail
-        output=$(cargo tarpaulin --out lcov ${{ inputs.args }})
+        output=$(cargo llvm-cov --summary-only ${{ inputs.args }})
         echo "$output"
         percent=$(echo "$output" | grep -oE '[0-9]+(\.[0-9]+)?(?=%)' | head -n1)
         echo "percent=$percent" >> "$GITHUB_OUTPUT"

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -83,6 +83,7 @@ runs:
           exit 1
         fi
 
+        mkdir -p "$(dirname "$file")"
         printf '%.2f' "$current" > "$file"
       shell: bash
     - name: Save baseline

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -16,6 +16,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - if: runner.os != 'Linux'
+      run: |
+        echo "Ratchet coverage runs only on Linux" >&2
+        exit 1
+      shell: bash
     - name: Restore baseline
       uses: actions/cache@v4
       with:
@@ -35,19 +40,13 @@ runs:
     - name: Install cargo-tarpaulin
       run: cargo install cargo-tarpaulin
       shell: bash
-    - if: runner.os == 'Windows'
-      name: Install bc (MSYS2)
-      uses: msys2/setup-msys2@v2
-      with:
-        install: bc
-        path-type: inherit
     - name: Run coverage
       id: cov
       run: |
         set -euo pipefail
         output=$(cargo tarpaulin --out lcov ${{ inputs.args }})
         echo "$output"
-        percent=$(echo "$output" | grep -oE '[0-9]+\.[0-9]+(?=%)' | head -n1)
+        percent=$(echo "$output" | grep -oE '[0-9]+(\.[0-9]+)?(?=%)' | head -n1)
         echo "percent=$percent" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Ratchet coverage

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -16,17 +16,12 @@ outputs:
 runs:
   using: composite
   steps:
-    - if: runner.os != 'Linux'
-      run: echo "Skipping ratchet coverage: cargo tarpaulin only runs on Linux"
-      shell: bash
     - name: Restore baseline
-      if: runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         path: ${{ inputs.baseline-file }}
         key: ratchet-baseline-${{ runner.os }}
     - name: Cache cargo artifacts
-      if: runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         path: |
@@ -38,7 +33,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-tarpaulin-
     - name: Install cargo-tarpaulin
-      if: runner.os == 'Linux'
       run: cargo install cargo-tarpaulin
       shell: bash
     - if: runner.os == 'Windows'
@@ -48,7 +42,6 @@ runs:
         install: bc
         path-type: inherit
     - name: Run coverage
-      if: runner.os == 'Linux'
       id: cov
       run: |
         set -euo pipefail
@@ -58,7 +51,6 @@ runs:
         echo "percent=$percent" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Ratchet coverage
-      if: runner.os == 'Linux'
       run: |
         set -euo pipefail
         file="${{ inputs.baseline-file }}"
@@ -87,7 +79,7 @@ runs:
         printf '%.2f' "$current" > "$file"
       shell: bash
     - name: Save baseline
-      if: success() && runner.os == 'Linux'
+      if: success()
       uses: actions/cache@v4
       with:
         path: ${{ inputs.baseline-file }}

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -1,0 +1,85 @@
+name: Ratchet coverage
+description: Run cargo tarpaulin and fail if coverage decreases
+inputs:
+  baseline-file:
+    description: Path to store the coverage baseline
+    required: false
+    default: .coverage-baseline
+  args:
+    description: Additional arguments passed to cargo tarpaulin
+    required: false
+    default: ''
+outputs:
+  percent:
+    description: Coverage percentage reported by cargo tarpaulin
+    value: ${{ steps.cov.outputs.percent }}
+runs:
+  using: composite
+  steps:
+    - name: Restore baseline
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.baseline-file }}
+        key: ratchet-baseline-${{ runner.os }}
+    - name: Cache cargo artifacts
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/cargo-tarpaulin
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-tarpaulin-
+    - name: Install cargo-tarpaulin
+      run: cargo install cargo-tarpaulin
+      shell: bash
+    - if: runner.os == 'Windows'
+      name: Install bc (MSYS2)
+      uses: msys2/setup-msys2@v2
+      with:
+        install: bc
+        path-type: inherit
+    - name: Run coverage
+      id: cov
+      run: |
+        set -euo pipefail
+        output=$(cargo tarpaulin --out lcov ${{ inputs.args }})
+        echo "$output"
+        percent=$(echo "$output" | grep -oE '[0-9]+\.[0-9]+(?=%)' | head -n1)
+        echo "percent=$percent" >> "$GITHUB_OUTPUT"
+      shell: bash
+    - name: Ratchet coverage
+      run: |
+        set -euo pipefail
+        file="${{ inputs.baseline-file }}"
+        current="${{ steps.cov.outputs.percent }}"
+        baseline=0
+        if [ -f "$file" ]; then
+          baseline=$(cat "$file")
+        fi
+        echo "Current coverage: $current%"
+        echo "Baseline coverage: $baseline%"
+
+        if ! echo "$current" | grep -Eq '^[0-9]+(\.[0-9]+)?$'; then
+          echo "Invalid coverage value: $current" >&2
+          exit 1
+        fi
+        if ! echo "$baseline" | grep -Eq '^[0-9]+(\.[0-9]+)?$'; then
+          baseline=0
+        fi
+
+        if (( $(bc -l <<<"$current < $baseline") )); then
+          echo "Coverage decreased" >&2
+          exit 1
+        fi
+
+        printf '%.2f' "$current" > "$file"
+      shell: bash
+    - name: Save baseline
+      if: success()
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.baseline-file }}
+        key: ratchet-baseline-${{ runner.os }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+.github/actions/export-postgres-url/ @leynos
+.github/actions/generate-coverage/ @leynos
+.github/actions/setup-rust/ @leynos
+.github/actions/upload-codescene-coverage/ @leynos
+.github/actions/ratchet-coverage/ @leynos

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ GitHub Actions
 | Generate coverage | `.github/actions/generate-coverage` | v1 |
 | Setup Rust | `.github/actions/setup-rust` | v1 |
 | Upload CodeScene Coverage | `.github/actions/upload-codescene-coverage` | v1 |
+| Ratchet coverage | `.github/actions/ratchet-coverage` | v1 |


### PR DESCRIPTION
## Summary
- add `args` input to ratchet coverage action
- validate numeric values before `bc` comparison
- document `args` input with default value
- update changelog with v1.0.1 notes
- ensure `bc` installed on Windows runners
- expand README with caching and requirements info

## Testing
- `shellcheck .github/actions/ratchet-coverage/action.yml` *(fails: SC2296, SC1130, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685833bc868c8322bc657544a8d76023

## Summary by Sourcery

Add a new GitHub composite action for ratcheting Rust coverage baselines with configurable arguments, cross-platform float comparisons, and caching support.

New Features:
- Introduce a new `ratchet-coverage` action to run `cargo llvm-cov`, compare against a stored baseline, and fail on coverage regressions
- Add an `args` input for passing custom arguments to `cargo llvm-cov`
- Cache the coverage baseline and cargo artifacts between runs for faster workflows
- Automatically install `bc` on Windows runners to support float comparisons

Enhancements:
- Validate that both current and baseline coverage values are numeric before performing comparisons

Documentation:
- Add a dedicated README for the `ratchet-coverage` action and update the main README with usage, caching, and requirements details
- Update the CHANGELOG with v1.0.1 release notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new GitHub Action, "Ratchet coverage", for automated Rust code coverage checks and baseline enforcement with caching and validation.
- **Documentation**
  - Added comprehensive documentation and usage instructions for the new action, including a changelog and README.
  - Updated the main README to list the new action.
- **Chores**
  - Added a CODEOWNERS file assigning ownership of GitHub Actions directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->