### PR TITLE
Fix env block in upload-codescene-coverage action

### DIFF
--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -40,3 +40,7 @@
 - Ensure `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` environment variables are
   derived from the corresponding inputs. This prevents action load failures
   caused by unsupported `secrets` or `vars` expressions.
+
+## v1.5.2
+- Remove unsupported `env` block from the `runs` section.
+- Export `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` via a setup step.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -18,9 +18,8 @@ installer script. If the optional `installer-checksum` input is set,
 the installer is validated before execution. Any other value for
 `format` results in an error.
 
-The provided `access-token` and `installer-checksum` inputs become the
-`CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` environment variables
-available to steps within the action.
+The action exports the `access-token` and `installer-checksum` inputs as
+`CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` for use by later steps.
 
 ## Environment variables
 

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -21,8 +21,8 @@ runs:
   steps:
     - name: Export env for later steps
       run: |
-        echo "CS_ACCESS_TOKEN=${{ inputs.access-token }}" >> "$GITHUB_ENV"
-        echo "CODESCENE_CLI_SHA256=${{ inputs.installer-checksum }}" >> "$GITHUB_ENV"
+        printf 'CS_ACCESS_TOKEN=%s\n' "${{ inputs.access-token }}" >>"${GITHUB_ENV}"
+        printf 'CODESCENE_CLI_SHA256=%s\n' "${{ inputs.installer-checksum }}" >>"${GITHUB_ENV}"
       shell: bash
     - name: Validate inputs
       run: |

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -18,11 +18,12 @@ inputs:
     required: false
 runs:
   using: composite
-  # derive environment from inputs; actions cannot access `secrets` or `vars`
-  env:
-    CS_ACCESS_TOKEN: ${{ inputs.access-token }}
-    CODESCENE_CLI_SHA256: ${{ inputs.installer-checksum }}
   steps:
+    - name: Export env for later steps
+      run: |
+        echo "CS_ACCESS_TOKEN=${{ inputs.access-token }}" >> "$GITHUB_ENV"
+        echo "CODESCENE_CLI_SHA256=${{ inputs.installer-checksum }}" >> "$GITHUB_ENV"
+      shell: bash
     - name: Validate inputs
       run: |
         case "${{ inputs.format }}" in


### PR DESCRIPTION
## Summary
- export env vars in a step instead of using unsupported `env` under `runs`
- update docs and changelog for upload-codescene-coverage action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859d14ecb78832280b31ef9170847af

## Summary by Sourcery

Fix the env block in the composite action by exporting CS_ACCESS_TOKEN and CODESCENE_CLI_SHA256 via an initial setup step and update related documentation.

Bug Fixes:
- Remove unsupported env block from the `runs` section of the upload-codescene-coverage action
- Export `access-token` and `installer-checksum` inputs to GITHUB_ENV for use in later steps

Documentation:
- Update README to describe the new environment variable export step
- Add a v1.5.2 entry to CHANGELOG detailing the removal of the env block and addition of the export step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity in the documentation regarding how environment variables are exported for use in later steps.
  - Added a changelog entry for the latest update.

- **Chores**
  - Updated the workflow to export environment variables through a dedicated setup step rather than directly in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->