### PR TITLE
Add Python support to coverage action

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v1.1.0
+- Support Python projects by running `slipcover` when `pyproject.toml` is present.
+- Expose `file` and `format` outputs.
+
+## v1.0.0
+- Initial version using `cargo llvm-cov` for Rust projects.

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -1,0 +1,32 @@
+# Generate coverage
+
+Run code coverage for Rust or Python projects. The action uses
+`cargo llvm-cov` when a `Cargo.toml` is present and `slipcover` with
+`pytest` when a `pyproject.toml` is present.
+
+## Inputs
+
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| features | Cargo features to enable (Rust) | no | |
+| with-default-features | Enable default Cargo features (Rust) | no | `true` |
+| output-path | Output file path | yes | |
+| format | Coverage format (`lcov`, `cobertura` or `coveragepy`) | no | `lcov` |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| file | Path to the generated coverage file |
+| format | Format of the coverage file |
+
+## Example
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    format: cobertura
+```
+
+Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -1,5 +1,5 @@
 name: Generate coverage
-description: Run cargo llvm-cov with configurable features
+description: Run test coverage for Rust or Python projects
 inputs:
   features:
     description: Cargo features to enable
@@ -15,11 +15,38 @@ inputs:
     description: Coverage format
     required: false
     default: lcov
+outputs:
+  file:
+    description: Path to the generated coverage file
+    value: ${{ steps.out.outputs.file }}
+  format:
+    description: Format of the coverage file
+    value: ${{ steps.out.outputs.format }}
 runs:
   using: composite
   steps:
-    - run: |
+    - id: detect
+      run: |
         set -euo pipefail
+        if [ -f Cargo.toml ]; then
+          echo "lang=rust" >> "$GITHUB_OUTPUT"
+        elif [ -f pyproject.toml ]; then
+          echo "lang=python" >> "$GITHUB_OUTPUT"
+        else
+          echo "Neither Cargo.toml nor pyproject.toml found" >&2
+          exit 1
+        fi
+      shell: bash
+    - if: steps.detect.outputs.lang == 'rust'
+      run: |
+        set -euo pipefail
+        case "${{ inputs.format }}" in
+          lcov|cobertura) ;;
+          *)
+            echo "Unsupported format: ${{ inputs.format }}" >&2
+            exit 1
+            ;;
+        esac
         args=(--workspace)
         if [[ "${{ inputs.with-default-features }}" == "false" ]]; then
           args+=(--no-default-features)
@@ -30,4 +57,32 @@ runs:
         args+=(--${{ inputs.format }})
         args+=(--output-path "${{ inputs.output-path }}")
         cargo llvm-cov "${args[@]}"
+      shell: bash
+    - if: steps.detect.outputs.lang == 'python'
+      run: |
+        set -euo pipefail
+        case "${{ inputs.format }}" in
+          cobertura)
+            python -m slipcover \
+              --branch \
+              --xml \
+              --out "${{ inputs.output-path }}" \
+              -m pytest -v
+            ;;
+          coveragepy)
+            python -m slipcover \
+              --branch \
+              -m pytest -v
+            mv .coverage "${{ inputs.output-path }}"
+            ;;
+          *)
+            echo "Unsupported format: ${{ inputs.format }}" >&2
+            exit 1
+            ;;
+        esac
+      shell: bash
+    - id: out
+      run: |
+        echo "file=${{ inputs.output-path }}" >> "$GITHUB_OUTPUT"
+        echo "format=${{ inputs.format }}" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
## Summary
- expand `generate-coverage` to detect Cargo or Python projects
- run `slipcover` for Python test coverage
- expose coverage file path and format
- document behaviour and release notes for the action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a07bcf9008322b09c3cb0a5073c12