### PR TITLE
Refactor coverage action

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.2 (2025-06-25)
 
-- Merge detection and validation into a single step to simplify the workflow.
+- Merge detection and validation into a single step to simplify the workflow, routing the `lang` output directly from the `detect` step.
 - Enable strict mode in the detection step and explicitly use Bash.
 
 ## v1.1.1 (2025-06-24)

--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
+## v1.1.2 (2025-06-25)
+
+- Merge detection and validation into a single step to simplify the workflow.
+
+## v1.1.1 (2025-06-24)
+
+- Automatically install `slipcover` and `pytest` using `setup-uv` when running
+  Python coverage.
+
 ## v1.1.0 (2025-06-23)
 
 - Support Python projects by running `slipcover` when `pyproject.toml` is present.
 - Expose `file` and `format` outputs.
 - Default coverage format changed to `cobertura`.
 - Fail fast if both `Cargo.toml` and `pyproject.toml` exist.
-
-## v1.1.1 (2025-06-24)
-
-- Automatically install `slipcover` and `pytest` using `setup-uv` when running
-  Python coverage.
 
 ## v1.0.0 (2025-06-20)
 

--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.2 (2025-06-25)
 
 - Merge detection and validation into a single step to simplify the workflow.
+- Enable strict mode in the detection step and explicitly use Bash.
 
 ## v1.1.1 (2025-06-24)
 

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -25,7 +25,7 @@ outputs:
     value: ${{ steps.out.outputs.format }}
   lang:
     description: Detected project language
-    value: ${{ steps.out.outputs.lang }}
+    value: ${{ steps.detect.outputs.lang }}
 runs:
   using: composite
   steps:
@@ -36,17 +36,14 @@ runs:
           echo "Found both Cargo.toml and pyproject.toml; not supported" >&2
           exit 1
         elif [ -f Cargo.toml ]; then
-          echo "lang=rust" >> "$GITHUB_OUTPUT"
+          lang=rust
         elif [ -f pyproject.toml ]; then
-          echo "lang=python" >> "$GITHUB_OUTPUT"
+          lang=python
         else
           echo "Neither Cargo.toml nor pyproject.toml found" >&2
           exit 1
         fi
-      shell: bash
-    - id: validate
-      run: |
-        set -euo pipefail
+
         case "${{ inputs.format }}" in
           lcov|cobertura|coveragepy) ;;
           *)
@@ -54,7 +51,7 @@ runs:
             exit 1
             ;;
         esac
-        lang='${{ steps.detect.outputs.lang }}'
+
         if [[ "$lang" == 'rust' && "${{ inputs.format }}" == 'coveragepy' ]]; then
           echo "coveragepy format only supported for Python projects" >&2
           exit 1
@@ -63,6 +60,8 @@ runs:
           echo "lcov format only supported for Rust projects" >&2
           exit 1
         fi
+
+        echo "lang=$lang" >> "$GITHUB_OUTPUT"
       shell: bash
     - if: steps.detect.outputs.lang == 'rust'
       run: |
@@ -119,5 +118,4 @@ runs:
       run: |
         echo "file=${{ inputs.output-path }}" >> "$GITHUB_OUTPUT"
         echo "format=${{ inputs.format }}" >> "$GITHUB_OUTPUT"
-        echo "lang=${{ steps.detect.outputs.lang }}" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -37,7 +37,7 @@ runs:
           exit 1
         elif [ -f Cargo.toml ]; then
           lang=rust
-        elif [ -f pyproject.toml ]; then
+        elif [[ -f pyproject.toml ]]; then
           lang=python
         else
           echo "Neither Cargo.toml nor pyproject.toml found" >&2


### PR DESCRIPTION
## Summary
- merge project detection and format validation into one step in the `generate-coverage` action
- route the `lang` output directly from the detect step
- document the change in the changelog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ad4ab817c832290cc841326fe311e

## Summary by Sourcery

Consolidate detection and validation into one step, route the `lang` output from the detect step, and bump the action version in the changelog

Enhancements:
- Consolidate project language detection and format validation into a single composite step in the generate-coverage action
- Route the `lang` output directly from the detection step instead of the validation step

Documentation:
- Update CHANGELOG to v1.1.2 with the merged detection and validation change