### PR TITLE
Update coverage action features input

### DIFF
--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -32,7 +32,7 @@ flowchart TD
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
-| features | Cargo features to enable (Rust) | no | |
+| features | List of Cargo features to enable (Rust) | no | |
 | with-default-features | Enable default Cargo features (Rust) | no | `true` |
 | output-path | Output file path | yes | |
 | format | Coverage format (`lcov`*, `cobertura` or `coveragepy`*) | no | `cobertura` |
@@ -54,6 +54,9 @@ flowchart TD
   with:
     output-path: coverage.xml
     format: cobertura
+    features:
+      - feat-a
+      - feat-b
 ```
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -2,9 +2,9 @@ name: Generate coverage
 description: Run test coverage for Rust, Python and mixed Rust and Python projects
 inputs:
   features:
-    description: Cargo features to enable
+    description: List of Cargo features to enable
     required: false
-    type: string
+    type: list
   with-default-features:
     description: Enable default features
     required: false
@@ -100,7 +100,8 @@ runs:
           args+=(--no-default-features)
         fi
         if [ -n "${{ inputs.features }}" ]; then
-          args+=(--features "${{ inputs.features }}")
+          features_csv="$(echo "${{ inputs.features }}" | tr '\n' ',' | sed 's/,$//')"
+          args+=(--features "$features_csv")
         fi
         fmt="${{ steps.detect.outputs.fmt }}"
         args+=(--$fmt)


### PR DESCRIPTION
## Summary
- allow `generate-coverage` to accept a list of features
- document the new list format and example usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f0670072483228049342fed90f580

## Summary by Sourcery

Update the generate-coverage GitHub Action to accept a list of Cargo features, convert them to a comma-separated string for invocation, and update documentation to reflect the new list format and usage example.

Enhancements:
- Change the `features` input type from string to list in the action metadata
- Convert the features list into a comma-separated string before passing to Cargo

Documentation:
- Update input description and table in README to describe the new list format
- Add a YAML usage example showing multiple features as list items