### PR TITLE
Clarify coverage action features

### DIFF
--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -75,4 +75,13 @@ For multiple features:
     with-default-features: false
 ```
 
+Comma-separated feature list:
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    features: logging,tracing
+```
+
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -32,7 +32,7 @@ flowchart TD
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
-| features | Cargo features to enable (Rust) | no | |
+| features | Cargo features to enable (Rust). Separate multiple features with spaces or commas. | no | |
 | with-default-features | Enable default Cargo features (Rust) | no | `true` |
 | output-path | Output file path | yes | |
 | format | Coverage format (`lcov`*, `cobertura` or `coveragepy`*) | no | `cobertura` |
@@ -54,6 +54,25 @@ flowchart TD
   with:
     output-path: coverage.xml
     format: cobertura
+```
+
+For a single feature:
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    features: logging
+```
+
+For multiple features:
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    features: logging tracing
+    with-default-features: false
 ```
 
 Release history is available in [CHANGELOG](CHANGELOG.md).


### PR DESCRIPTION
## Summary
- clarify how to list Cargo features in `generate-coverage` docs
- add examples for single and multiple feature sets

## Testing
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a9d8a808322ba8e69a0bfc37621

## Summary by Sourcery

Clarify how to specify Cargo features in the generate-coverage GitHub Action documentation and provide usage examples for single and multiple feature sets.

Documentation:
- Expand the 'features' input description to indicate that multiple features can be separated by spaces or commas.
- Add YAML examples showcasing usage with a single feature and with multiple features (including disabling default features).