### PR TITLE
Fix grep regex for coverage parsing

### DIFF
--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -47,7 +47,7 @@ runs:
         set -euo pipefail
         output=$(cargo llvm-cov --summary-only ${{ inputs.args }})
         echo "$output"
-        percent=$(echo "$output" | grep -oE '[0-9]+(\.[0-9]+)?(?=%)' | head -n1)
+        percent=$(echo "$output" | grep -oE '[0-9]+(\.[0-9]+)?%' | head -n1 | tr -d '%')
         echo "percent=$percent" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Ratchet coverage


### PR DESCRIPTION
## Summary
- fix look-ahead usage in coverage parser

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68692df5ac248322ad1afce17110257b