### PR TITLE
Convert generate-coverage to Python scripts

### DIFF
--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -33,80 +33,14 @@ runs:
   using: composite
   steps:
     - id: detect
-      run: |
-        set -euo pipefail
-
-        if [[ -f Cargo.toml && -f pyproject.toml ]]; then
-          found=both
-        elif [[ -f Cargo.toml ]]; then
-          found=rust
-        elif [[ -f pyproject.toml ]]; then
-          found=python
-        else
-          echo "Neither Cargo.toml nor pyproject.toml found" >&2
-          exit 1
-        fi
-
-        fmt="${{ inputs.format }}"
-        # Normalise to lower-case inside the shell
-        fmt="${fmt,,}"
-        case "$fmt" in
-          lcov|cobertura|coveragepy) ;;
-          *)
-            echo "Unsupported format: ${{ inputs.format }}" >&2
-            exit 1
-            ;;
-        esac
-
-        case "$found/$fmt" in
-          rust/coveragepy)
-            echo "coveragepy format only supported for Python projects" >&2
-            exit 1
-            ;;
-          python/lcov)
-            echo "lcov format only supported for Rust projects" >&2
-            exit 1
-            ;;
-          both/cobertura)
-            ;;
-          both/*)
-            echo "Mixed projects only support cobertura format" >&2
-            exit 1
-            ;;
-        esac
-
-        case $found in
-          both)   lang=mixed ;;
-          rust)   lang=rust  ;;
-          python) lang=python ;;
-        esac
-
-        echo "lang=$lang" >> "$GITHUB_OUTPUT"
-        echo "fmt=$fmt" >> "$GITHUB_OUTPUT"
+      run: uv run --script scripts/generate_coverage/detect.py
       shell: bash
     - id: rust
       if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
-      run: |
-        set -euo pipefail
-        out="${{ inputs.output-path }}"
-        if [[ "${{ steps.detect.outputs.lang }}" == 'mixed' ]]; then
-          base="${{ inputs.output-path%.*}}"
-          ext="${{ inputs.output-path##*.}}"
-          out="${base}.rust.${ext}"
-        fi
-        mkdir -p "$(dirname "$out")"
-        args=(--workspace)
-        if [[ "${{ inputs.with-default-features }}" == "false" ]]; then
-          args+=(--no-default-features)
-        fi
-        if [ -n "${{ inputs.features }}" ]; then
-          args+=(--features "${{ inputs.features }}")
-        fi
-        fmt="${{ steps.detect.outputs.fmt }}"
-        args+=(--$fmt)
-        args+=(--output-path "$out")
-        cargo llvm-cov "${args[@]}"
-        echo "file=$out" >> "$GITHUB_OUTPUT"
+      run: uv run --script scripts/generate_coverage/run_rust.py
+      env:
+        DETECTED_LANG: ${{ steps.detect.outputs.lang }}
+        DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
       shell: bash
     - name: Install uv and set the python version
       if: steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed'
@@ -128,45 +62,20 @@ runs:
 
     - id: python
       if: steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed'
-      run: |
-        set -euo pipefail
-        mkdir -p "$(dirname "${{ inputs.output-path }}")"
-        out="${{ inputs.output-path }}"
-        if [[ "${{ steps.detect.outputs.lang }}" == 'mixed' ]]; then
-          base="${{ inputs.output-path%.*}}"
-          ext="${{ inputs.output-path##*.}}"
-          out="${base}.python.${ext}"
-        fi
-        case "${{ steps.detect.outputs.fmt }}" in
-          cobertura)
-            python -m slipcover \
-              --branch \
-              --xml "$out" \
-              -m pytest -v
-            ;;
-          coveragepy)
-            python -m slipcover \
-              --branch \
-              -m pytest -v
-            mv .coverage "$out"
-            ;;
-        esac
-        echo "file=$out" >> "$GITHUB_OUTPUT"
+      run: uv run --script scripts/generate_coverage/run_python.py
+      env:
+        DETECTED_LANG: ${{ steps.detect.outputs.lang }}
+        DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
       shell: bash
     - if: steps.detect.outputs.lang == 'mixed'
-      run: |
-        set -euo pipefail
-        rust_file="${{ steps.rust.outputs.file }}"
-        python_file="${{ steps.python.outputs.file }}"
-        if [[ ! -f "$rust_file" || ! -f "$python_file" ]]; then
-          echo "Coverage files not found: $rust_file $python_file" >&2
-          exit 1
-        fi
-        uvx merge-cobertura "$rust_file" "$python_file" > "${{ inputs.output-path }}"
-        rm "$rust_file" "$python_file"
+      run: uv run --script scripts/generate_coverage/merge_cobertura.py
+      env:
+        RUST_FILE: ${{ steps.rust.outputs.file }}
+        PYTHON_FILE: ${{ steps.python.outputs.file }}
+        OUTPUT_PATH: ${{ inputs.output-path }}
       shell: bash
     - id: out
-      run: |
-        echo "file=${{ inputs.output-path }}" >> "$GITHUB_OUTPUT"
-        echo "format=${{ steps.detect.outputs.fmt }}" >> "$GITHUB_OUTPUT"
+      run: uv run --script scripts/generate_coverage/set_outputs.py
+      env:
+        DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
       shell: bash

--- a/docs/python-action-scripts.md
+++ b/docs/python-action-scripts.md
@@ -1,0 +1,19 @@
+# Python Action Scripts
+
+Some actions use short helper scripts for logic that would otherwise live in bash.
+These scripts are stored under `scripts/` and executed with [`uv`](https://github.com/astral-sh/uv) using
+`uv run --script`.  Each script declares its own dependencies via the
+special comment header understood by uv.
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["plumbum", "typer"]
+# ///
+```
+
+The [Typer](https://typer.tiangolo.com/) library is used for argument parsing and
+error handling, while [plumbum](https://plumbum.readthedocs.io/) provides simple
+command execution.  By isolating logic in Python we keep the composite action
+YAML minimal and benefit from better readability and testability.

--- a/docs/python-action-scripts.md
+++ b/docs/python-action-scripts.md
@@ -15,5 +15,5 @@ special comment header understood by uv.
 
 The [Typer](https://typer.tiangolo.com/) library is used for argument parsing and
 error handling, while [plumbum](https://plumbum.readthedocs.io/) provides simple
-command execution.  By isolating logic in Python we keep the composite action
-YAML minimal and benefit from better readability and testability.
+command execution.  By isolating logic in Python, the composite action YAML
+remains minimal and benefits from better readability and testability.

--- a/scripts/generate_coverage/detect.py
+++ b/scripts/generate_coverage/detect.py
@@ -3,6 +3,8 @@
 # requires-python = ">=3.12"
 # dependencies = ["typer"]
 # ///
+"""Detect the project language and validate coverage format compatibility."""
+
 from enum import StrEnum
 from pathlib import Path
 
@@ -11,22 +13,37 @@ import typer
 
 
 class CoverageFmt(StrEnum):
+    """Supported coverage report formats."""
+
     LCOV = "lcov"
     COBERTURA = "cobertura"
     COVERAGEPY = "coveragepy"
 
 
 class CoverageFmtParam(click.ParamType):
+    """Custom parameter type for coverage format strings."""
+
     name = "format"
 
     def convert(
-        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+        self,
+        value: str,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
     ) -> CoverageFmt:  # type: ignore[override]
         """Convert the incoming value to a ``CoverageFmt`` enum."""
         try:
             return CoverageFmt(value.lower())
         except ValueError:
             self.fail(f"Unsupported format: {value}", param, ctx)
+
+
+FMT_OPT = typer.Option(
+    CoverageFmt.COBERTURA,
+    envvar="INPUT_FORMAT",
+    type=CoverageFmtParam(),
+)
+GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 
 
 def get_lang() -> str:
@@ -44,10 +61,8 @@ def get_lang() -> str:
 
 
 def main(
-    fmt: CoverageFmt = typer.Option(
-        CoverageFmt.COBERTURA, envvar="INPUT_FORMAT", type=CoverageFmtParam()
-    ),
-    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+    fmt: CoverageFmt = FMT_OPT,
+    github_output: Path = GITHUB_OUTPUT_OPT,
 ) -> None:
     """Detect the project language and write it plus the format to ``GITHUB_OUTPUT``."""
     lang = get_lang()

--- a/scripts/generate_coverage/detect.py
+++ b/scripts/generate_coverage/detect.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["typer"]
+# ///
+from enum import StrEnum
+from pathlib import Path
+
+import click
+import typer
+
+
+class CoverageFmt(StrEnum):
+    LCOV = "lcov"
+    COBERTURA = "cobertura"
+    COVERAGEPY = "coveragepy"
+
+
+class CoverageFmtParam(click.ParamType):
+    name = "format"
+
+    def convert(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> CoverageFmt:  # type: ignore[override]
+        """Convert the incoming value to a ``CoverageFmt`` enum."""
+        try:
+            return CoverageFmt(value.lower())
+        except ValueError:
+            self.fail(f"Unsupported format: {value}", param, ctx)
+
+
+def get_lang() -> str:
+    """Detect whether the project is Rust, Python or mixed."""
+    cargo = Path("Cargo.toml").is_file()
+    python = Path("pyproject.toml").is_file()
+    if cargo and python:
+        return "mixed"
+    if cargo:
+        return "rust"
+    if python:
+        return "python"
+    typer.echo("Neither Cargo.toml nor pyproject.toml found", err=True)
+    raise typer.Exit(code=1)
+
+
+def main(
+    fmt: CoverageFmt = typer.Option(
+        CoverageFmt.COBERTURA, envvar="INPUT_FORMAT", type=CoverageFmtParam()
+    ),
+    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+) -> None:
+    """Detect the project language and write it plus the format to ``GITHUB_OUTPUT``."""
+    lang = get_lang()
+
+    match (lang, fmt):
+        case ("rust", CoverageFmt.COVERAGEPY):
+            typer.echo("coveragepy format only supported for Python projects", err=True)
+            raise typer.Exit(code=1)
+        case ("python", CoverageFmt.LCOV):
+            typer.echo("lcov format only supported for Rust projects", err=True)
+            raise typer.Exit(code=1)
+        case ("mixed", fmt_case) if fmt_case != CoverageFmt.COBERTURA:
+            typer.echo("Mixed projects only support cobertura format", err=True)
+            raise typer.Exit(code=1)
+
+    with github_output.open("a") as fh:
+        fh.write(f"lang={lang}\n")
+        fh.write(f"fmt={fmt.value}\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/generate_coverage/merge_cobertura.py
+++ b/scripts/generate_coverage/merge_cobertura.py
@@ -3,21 +3,27 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
+"""Merge Cobertura XML files from Rust and Python coverage runs."""
+
 from pathlib import Path
 
 import typer
 from plumbum.cmd import uvx
 from plumbum.commands.processes import ProcessExecutionError
 
+RUST_FILE_OPT = typer.Option(
+    ..., envvar="RUST_FILE", exists=True, file_okay=True, dir_okay=False
+)
+PYTHON_FILE_OPT = typer.Option(
+    ..., envvar="PYTHON_FILE", exists=True, file_okay=True, dir_okay=False
+)
+OUTPUT_PATH_OPT = typer.Option(..., envvar="OUTPUT_PATH")
+
 
 def main(
-    rust_file: Path = typer.Option(
-        ..., envvar="RUST_FILE", exists=True, file_okay=True, dir_okay=False
-    ),
-    python_file: Path = typer.Option(
-        ..., envvar="PYTHON_FILE", exists=True, file_okay=True, dir_okay=False
-    ),
-    output_path: Path = typer.Option(..., envvar="OUTPUT_PATH"),
+    rust_file: Path = RUST_FILE_OPT,
+    python_file: Path = PYTHON_FILE_OPT,
+    output_path: Path = OUTPUT_PATH_OPT,
 ) -> None:
     """Merge two cobertura XML files and delete the inputs."""
     try:

--- a/scripts/generate_coverage/merge_cobertura.py
+++ b/scripts/generate_coverage/merge_cobertura.py
@@ -30,7 +30,7 @@ def main(
         output = uvx["merge-cobertura", str(rust_file), str(python_file)]()
     except ProcessExecutionError as exc:
         typer.echo(
-            f"merge-cobertura failed with code {exc.retcode}: {exc.stderr}", err=True
+            f"merge-cobertura failed with code {exc.retcode}: {exc.stderr}", err=True,
         )
         raise typer.Exit(code=exc.retcode or 1) from exc
     output_path.write_text(output)

--- a/scripts/generate_coverage/merge_cobertura.py
+++ b/scripts/generate_coverage/merge_cobertura.py
@@ -12,10 +12,10 @@ from plumbum.cmd import uvx
 from plumbum.commands.processes import ProcessExecutionError
 
 RUST_FILE_OPT = typer.Option(
-    ..., envvar="RUST_FILE", exists=True, file_okay=True, dir_okay=False
+    ..., envvar="RUST_FILE", exists=True, file_okay=True, dir_okay=False,
 )
 PYTHON_FILE_OPT = typer.Option(
-    ..., envvar="PYTHON_FILE", exists=True, file_okay=True, dir_okay=False
+    ..., envvar="PYTHON_FILE", exists=True, file_okay=True, dir_okay=False,
 )
 OUTPUT_PATH_OPT = typer.Option(..., envvar="OUTPUT_PATH")
 

--- a/scripts/generate_coverage/merge_cobertura.py
+++ b/scripts/generate_coverage/merge_cobertura.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["plumbum", "typer"]
+# ///
+from pathlib import Path
+
+import click
+import typer
+from plumbum.cmd import uvx
+from plumbum.commands.processes import ProcessExecutionError
+
+
+class ExistingFile(click.ParamType):
+    name = "file"
+
+    def __init__(self, kind: str) -> None:
+        """Create a validator that ensures the file exists."""
+        self.kind = kind
+
+    def convert(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> Path:  # type: ignore[override]
+        """Validate that the provided path points to an existing file."""
+        path = Path(value)
+        if not path.is_file():
+            self.fail(f"{self.kind} file not found: {value}", param, ctx)
+        return path
+
+
+def main(
+    rust_file: Path = typer.Option(
+        ..., envvar="RUST_FILE", type=ExistingFile("Rust coverage")
+    ),
+    python_file: Path = typer.Option(
+        ..., envvar="PYTHON_FILE", type=ExistingFile("Python coverage")
+    ),
+    output_path: Path = typer.Option(..., envvar="OUTPUT_PATH"),
+) -> None:
+    """Merge two cobertura XML files and delete the inputs."""
+    try:
+        output = uvx["merge-cobertura", str(rust_file), str(python_file)]()
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"merge-cobertura failed with code {exc.retcode}: {exc.stderr}", err=True
+        )
+        raise typer.Exit(code=exc.retcode or 1) from exc
+    output_path.write_text(output)
+    rust_file.unlink()
+    python_file.unlink()
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/generate_coverage/merge_cobertura.py
+++ b/scripts/generate_coverage/merge_cobertura.py
@@ -5,35 +5,17 @@
 # ///
 from pathlib import Path
 
-import click
 import typer
 from plumbum.cmd import uvx
 from plumbum.commands.processes import ProcessExecutionError
 
 
-class ExistingFile(click.ParamType):
-    name = "file"
-
-    def __init__(self, kind: str) -> None:
-        """Create a validator that ensures the file exists."""
-        self.kind = kind
-
-    def convert(
-        self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> Path:  # type: ignore[override]
-        """Validate that the provided path points to an existing file."""
-        path = Path(value)
-        if not path.is_file():
-            self.fail(f"{self.kind} file not found: {value}", param, ctx)
-        return path
-
-
 def main(
     rust_file: Path = typer.Option(
-        ..., envvar="RUST_FILE", type=ExistingFile("Rust coverage")
+        ..., envvar="RUST_FILE", exists=True, file_okay=True, dir_okay=False
     ),
     python_file: Path = typer.Option(
-        ..., envvar="PYTHON_FILE", type=ExistingFile("Python coverage")
+        ..., envvar="PYTHON_FILE", exists=True, file_okay=True, dir_okay=False
     ),
     output_path: Path = typer.Option(..., envvar="OUTPUT_PATH"),
 ) -> None:

--- a/scripts/generate_coverage/run_python.py
+++ b/scripts/generate_coverage/run_python.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["plumbum", "typer"]
+# ///
+from pathlib import Path
+
+import typer
+from plumbum import FG
+from plumbum.cmd import python
+from plumbum.commands.processes import ProcessExecutionError
+
+
+def coverage_cmd_for_fmt(fmt: str, out: Path):
+    """Return the slipcover command for the requested format."""
+    if fmt == "cobertura":
+        return python[
+            "-m",
+            "slipcover",
+            "--branch",
+            "--xml",
+            str(out),
+            "-m",
+            "pytest",
+            "-v",
+        ]
+    return python["-m", "slipcover", "--branch", "-m", "pytest", "-v"]
+
+
+def main(
+    output_path: Path = typer.Option(..., envvar="INPUT_OUTPUT_PATH"),
+    lang: str = typer.Option(..., envvar="DETECTED_LANG"),
+    fmt: str = typer.Option(..., envvar="DETECTED_FMT"),
+    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+) -> None:
+    """Run slipcover coverage and write the output path to ``GITHUB_OUTPUT``."""
+    out = output_path
+    if lang == "mixed":
+        out = output_path.with_name(f"{output_path.stem}.python{output_path.suffix}")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    cmd = coverage_cmd_for_fmt(fmt, out)
+    try:
+        cmd & FG
+    except ProcessExecutionError as exc:
+        raise typer.Exit(code=exc.retcode or 1) from exc
+
+    if fmt == "coveragepy":
+        Path(".coverage").rename(out)
+
+    with github_output.open("a") as fh:
+        fh.write(f"file={out}\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/generate_coverage/run_python.py
+++ b/scripts/generate_coverage/run_python.py
@@ -3,15 +3,23 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
+"""Run Python coverage analysis using slipcover and pytest."""
+
 from pathlib import Path
 
 import typer
 from plumbum import FG
 from plumbum.cmd import python
+from plumbum.commands.base import BoundCommand
 from plumbum.commands.processes import ProcessExecutionError
 
+OUTPUT_PATH_OPT = typer.Option(..., envvar="INPUT_OUTPUT_PATH")
+LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
+FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
+GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 
-def coverage_cmd_for_fmt(fmt: str, out: Path):
+
+def coverage_cmd_for_fmt(fmt: str, out: Path) -> BoundCommand:
     """Return the slipcover command for the requested format."""
     if fmt == "cobertura":
         return python[
@@ -28,10 +36,10 @@ def coverage_cmd_for_fmt(fmt: str, out: Path):
 
 
 def main(
-    output_path: Path = typer.Option(..., envvar="INPUT_OUTPUT_PATH"),
-    lang: str = typer.Option(..., envvar="DETECTED_LANG"),
-    fmt: str = typer.Option(..., envvar="DETECTED_FMT"),
-    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+    output_path: Path = OUTPUT_PATH_OPT,
+    lang: str = LANG_OPT,
+    fmt: str = FMT_OPT,
+    github_output: Path = GITHUB_OUTPUT_OPT,
 ) -> None:
     """Run slipcover coverage and write the output path to ``GITHUB_OUTPUT``."""
     out = output_path

--- a/scripts/generate_coverage/run_python.py
+++ b/scripts/generate_coverage/run_python.py
@@ -46,7 +46,7 @@ def main(
         raise typer.Exit(code=exc.retcode or 1) from exc
 
     if fmt == "coveragepy":
-        Path(".coverage").rename(out)
+        Path(".coverage").replace(out)
 
     with github_output.open("a") as fh:
         fh.write(f"file={out}\n")

--- a/scripts/generate_coverage/run_rust.py
+++ b/scripts/generate_coverage/run_rust.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["plumbum", "typer"]
+# ///
+from pathlib import Path
+
+import typer
+from plumbum.cmd import cargo
+from plumbum.commands.processes import ProcessExecutionError
+
+
+def get_cargo_coverage_cmd(
+    fmt: str, out: Path, features: str, with_default: bool
+) -> list[str]:
+    """Return the cargo llvm-cov command arguments."""
+    args = ["llvm-cov", "--workspace"]
+    if not with_default:
+        args.append("--no-default-features")
+    if features:
+        args += ["--features", features]
+    args += [f"--{fmt}", "--output-path", str(out)]
+    return args
+
+
+def main(
+    output_path: Path = typer.Option(..., envvar="INPUT_OUTPUT_PATH"),
+    features: str = typer.Option("", envvar="INPUT_FEATURES"),
+    with_default: bool = typer.Option(True, envvar="INPUT_WITH_DEFAULT_FEATURES"),
+    lang: str = typer.Option(..., envvar="DETECTED_LANG"),
+    fmt: str = typer.Option(..., envvar="DETECTED_FMT"),
+    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+) -> None:
+    """Run cargo llvm-cov and write the output file path to ``GITHUB_OUTPUT``."""
+    out = output_path
+    if lang == "mixed":
+        out = output_path.with_name(f"{output_path.stem}.rust{output_path.suffix}")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    args = get_cargo_coverage_cmd(fmt, out, features, with_default)
+
+    try:
+        cargo[args]()
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"cargo llvm-cov failed with code {exc.retcode}: {exc.stderr}", err=True
+        )
+        raise typer.Exit(code=exc.retcode or 1) from exc
+
+    with github_output.open("a") as fh:
+        fh.write(f"file={out}\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/generate_coverage/run_rust.py
+++ b/scripts/generate_coverage/run_rust.py
@@ -3,11 +3,20 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
+"""Run Rust coverage using ``cargo llvm-cov``."""
+
 from pathlib import Path
 
 import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
+
+OUTPUT_PATH_OPT = typer.Option(..., envvar="INPUT_OUTPUT_PATH")
+FEATURES_OPT = typer.Option("", envvar="INPUT_FEATURES")
+WITH_DEFAULT_OPT = typer.Option(True, envvar="INPUT_WITH_DEFAULT_FEATURES")
+LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
+FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
+GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 
 
 def get_cargo_coverage_cmd(
@@ -24,12 +33,12 @@ def get_cargo_coverage_cmd(
 
 
 def main(
-    output_path: Path = typer.Option(..., envvar="INPUT_OUTPUT_PATH"),
-    features: str = typer.Option("", envvar="INPUT_FEATURES"),
-    with_default: bool = typer.Option(True, envvar="INPUT_WITH_DEFAULT_FEATURES"),
-    lang: str = typer.Option(..., envvar="DETECTED_LANG"),
-    fmt: str = typer.Option(..., envvar="DETECTED_FMT"),
-    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+    output_path: Path = OUTPUT_PATH_OPT,
+    features: str = FEATURES_OPT,
+    with_default: bool = WITH_DEFAULT_OPT,
+    lang: str = LANG_OPT,
+    fmt: str = FMT_OPT,
+    github_output: Path = GITHUB_OUTPUT_OPT,
 ) -> None:
     """Run cargo llvm-cov and write the output file path to ``GITHUB_OUTPUT``."""
     out = output_path

--- a/scripts/generate_coverage/set_outputs.py
+++ b/scripts/generate_coverage/set_outputs.py
@@ -3,15 +3,21 @@
 # requires-python = ">=3.12"
 # dependencies = ["typer"]
 # ///
+"""Write coverage output metadata for the caller workflow."""
+
 from pathlib import Path
 
 import typer
 
+OUTPUT_PATH_OPT = typer.Option(..., envvar="INPUT_OUTPUT_PATH")
+FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
+GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
+
 
 def main(
-    output_path: Path = typer.Option(..., envvar="INPUT_OUTPUT_PATH"),
-    fmt: str = typer.Option(..., envvar="DETECTED_FMT"),
-    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+    output_path: Path = OUTPUT_PATH_OPT,
+    fmt: str = FMT_OPT,
+    github_output: Path = GITHUB_OUTPUT_OPT,
 ) -> None:
     """Write final outputs to ``GITHUB_OUTPUT`` for the caller workflow."""
     with github_output.open("a") as fh:

--- a/scripts/generate_coverage/set_outputs.py
+++ b/scripts/generate_coverage/set_outputs.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["typer"]
+# ///
+from pathlib import Path
+
+import typer
+
+
+def main(
+    output_path: Path = typer.Option(..., envvar="INPUT_OUTPUT_PATH"),
+    fmt: str = typer.Option(..., envvar="DETECTED_FMT"),
+    github_output: Path = typer.Option(..., envvar="GITHUB_OUTPUT"),
+) -> None:
+    """Write final outputs to ``GITHUB_OUTPUT`` for the caller workflow."""
+    with github_output.open("a") as fh:
+        fh.write(f"file={output_path}\n")
+        fh.write(f"format={fmt}\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## Summary
- replace bash blocks in generate-coverage with Python helpers
- add new helper scripts under `scripts/generate_coverage`
- document Python script approach in `docs/python-action-scripts.md`
- refactor coverage detection logic with `match/case` and helper functions
- extract coverage command generation into dedicated helpers
- add docstrings to coverage helper functions
- run ruff formatting on helper scripts

## Testing
- `uvx ruff format scripts/generate_coverage/`
- `uvx ruff check --select I --fix scripts/generate_coverage/`
- `python -m py_compile scripts/generate_coverage/*.py scripts/ratchet_coverage/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68698603dffc8322b95501253dbb1d10

## Summary by Sourcery

Convert the generate-coverage GitHub Action to use standalone Python helper scripts orchestrated via uv, replacing inline bash logic with reusable modules and improving readability and maintainability.

New Features:
- Add Python scripts in scripts/generate_coverage for project detection, Rust coverage, Python coverage, merging Cobertura reports, and setting outputs.
- Document the Python-based action script approach in docs/python-action-scripts.md

Enhancements:
- Refactor coverage format and language detection using Typer and match/case in a dedicated detect script.
- Extract slipcover and cargo llvm-cov command assembly into separate helper functions for cleaner logic.
- Simplify the composite action YAML by invoking uv-run scripts instead of embedding bash blocks.

Documentation:
- Introduce a guide for Python action scripts and their uv headers in docs/python-action-scripts.md

Chores:
- Add docstrings to helper functions and apply ruff formatting to all Python scripts