### PR TITLE
Add ratcheting option to generate-coverage action

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.0 (2025-07-06)
+
+- Add optional ratcheting support via `with-ratchet`. Coverage percentages for
+  Rust and Python are tracked separately and compared against their respective
+  baselines.
+
 ## v1.2.0 (2025-06-26)
 
 - Support projects containing both Python and Rust. Cobertura reports from

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -36,6 +36,9 @@ flowchart TD
 | with-default-features | Enable default Cargo features (Rust) | no | `true` |
 | output-path | Output file path | yes | |
 | format | Coverage format (`lcov`*, `cobertura` or `coveragepy`*) | no | `cobertura` |
+| with-ratchet | Fail if coverage decreases compared to the stored baseline | no | `false` |
+| baseline-rust-file | Path used to persist the Rust coverage baseline | no | `.coverage-baseline.rust` |
+| baseline-python-file | Path used to persist the Python coverage baseline | no | `.coverage-baseline.python` |
 
 \* `lcov` is only supported for Rust projects, while `coveragepy` is only supported for Python projects. Mixed projects must use `cobertura`.
 
@@ -82,6 +85,15 @@ Comma-separated feature list:
   with:
     output-path: coverage.xml
     features: logging,tracing
+```
+
+Enable ratcheting:
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    with-ratchet: true
 ```
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -19,6 +19,19 @@ inputs:
     required: false
     type: string
     default: cobertura
+  with-ratchet:
+    description: Fail if coverage falls below the stored baseline
+    required: false
+    type: boolean
+    default: false
+  baseline-rust-file:
+    description: Path to store the Rust coverage baseline
+    required: false
+    default: .coverage-baseline.rust
+  baseline-python-file:
+    description: Path to store the Python coverage baseline
+    required: false
+    default: .coverage-baseline.python
 outputs:
   file:
     description: Path to the generated coverage file
@@ -35,6 +48,18 @@ runs:
     - id: detect
       run: uv run --script scripts/generate_coverage/detect.py
       shell: bash
+    - name: Restore Rust baseline
+      if: inputs.with-ratchet == 'true' && (steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed')
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.baseline-rust-file }}
+        key: ratchet-baseline-rust-${{ runner.os }}
+    - name: Restore Python baseline
+      if: inputs.with-ratchet == 'true' && (steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed')
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.baseline-python-file }}
+        key: ratchet-baseline-python-${{ runner.os }}
     - id: rust
       if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
       run: uv run --script scripts/generate_coverage/run_rust.py
@@ -42,6 +67,19 @@ runs:
         DETECTED_LANG: ${{ steps.detect.outputs.lang }}
         DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
       shell: bash
+    - name: Ratchet Rust coverage
+      if: inputs.with-ratchet == 'true' && (steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed')
+      run: uv run --script scripts/ratchet_coverage/ratchet_coverage.py
+      env:
+        INPUT_BASELINE_FILE: ${{ inputs.baseline-rust-file }}
+        CURRENT_PERCENT: ${{ steps.rust.outputs.percent }}
+      shell: bash
+    - name: Save Rust baseline
+      if: success() && inputs.with-ratchet == 'true' && (steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed')
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.baseline-rust-file }}
+        key: ratchet-baseline-rust-${{ runner.os }}
     - name: Install uv and set the python version
       if: steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed'
       uses: astral-sh/setup-uv@v5
@@ -67,6 +105,19 @@ runs:
         DETECTED_LANG: ${{ steps.detect.outputs.lang }}
         DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
       shell: bash
+    - name: Ratchet Python coverage
+      if: inputs.with-ratchet == 'true' && (steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed')
+      run: uv run --script scripts/ratchet_coverage/ratchet_coverage.py
+      env:
+        INPUT_BASELINE_FILE: ${{ inputs.baseline-python-file }}
+        CURRENT_PERCENT: ${{ steps.python.outputs.percent }}
+      shell: bash
+    - name: Save Python baseline
+      if: success() && inputs.with-ratchet == 'true' && (steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed')
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.baseline-python-file }}
+        key: ratchet-baseline-python-${{ runner.os }}
     - if: steps.detect.outputs.lang == 'mixed'
       run: uv run --script scripts/generate_coverage/merge_cobertura.py
       env:


### PR DESCRIPTION
## Summary
- add `with-ratchet` option to generate-coverage
- track Rust and Python baselines separately
- output coverage percentage from language runners
- document new behaviour and bump version

## Testing
- `python -m py_compile scripts/generate_coverage/run_rust.py scripts/generate_coverage/run_python.py`

------
https://chatgpt.com/codex/tasks/task_e_6869cc7ccf608322b3d4dfdce9ebae08