### PR TITLE
Add shellstub and behavioural tests

### DIFF
--- a/.github/actions/generate-coverage/tests/conftest.py
+++ b/.github/actions/generate-coverage/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT))
+
+from shellstub import StubManager
+
+@pytest.fixture
+def shell_stubs(tmp_path, monkeypatch) -> StubManager:
+    dir_ = tmp_path / "stubs"
+    mgr = StubManager(dir_)
+    monkeypatch.setenv("PATH", f"{dir_}{os.pathsep}{os.getenv('PATH')}")
+    monkeypatch.setenv("PYTHONPATH", f"{ROOT}{os.pathsep}{os.getenv('PYTHONPATH','')}")
+    yield mgr

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def run_script(script: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess:
+    cmd = ["uv", "run", "--script", str(script), *args]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+def test_run_rust_success(tmp_path, shell_stubs):
+    out = tmp_path / "cov.lcov"
+    gh = tmp_path / "gh.txt"
+
+    shell_stubs.register(
+        "cargo",
+        stdout="Coverage: 81.5%\n",
+    )
+
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(out),
+        "DETECTED_LANG": "rust",
+        "DETECTED_FMT": "lcov",
+        "GITHUB_OUTPUT": str(gh),
+    }
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_rust.py"
+    res = run_script(script, env)
+    assert res.returncode == 0
+    assert "Coverage" in res.stdout
+
+    calls = shell_stubs.calls_of("cargo")
+    assert len(calls) == 1
+    assert "--output-path" in calls[0].argv
+
+    data = gh.read_text().splitlines()
+    assert f"file={out}" in data
+    assert "percent=81.5" in data
+
+
+def test_run_rust_failure(tmp_path, shell_stubs):
+    shell_stubs.register(
+        "cargo",
+        stderr="boom",
+        exit_code=2,
+    )
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(tmp_path / "out"),
+        "DETECTED_LANG": "rust",
+        "DETECTED_FMT": "lcov",
+        "GITHUB_OUTPUT": str(tmp_path / "gh.txt"),
+    }
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_rust.py"
+    res = run_script(script, env)
+    assert res.returncode == 2
+    assert "cargo llvm-cov failed" in res.stderr
+
+
+
+def test_merge_cobertura(tmp_path, shell_stubs):
+    rust = tmp_path / "r.xml"
+    py = tmp_path / "p.xml"
+    rust.write_text("<r/>")
+    py.write_text("<p/>")
+    out = tmp_path / "merged.xml"
+
+    shell_stubs.register(
+        "uvx",
+        variants=[dict(match=["merge-cobertura", str(rust), str(py)], stdout="<merged/>")]
+    )
+
+    env = {
+        **shell_stubs.env,
+        "RUST_FILE": str(rust),
+        "PYTHON_FILE": str(py),
+        "OUTPUT_PATH": str(out),
+    }
+    script = Path(__file__).resolve().parents[1] / "scripts" / "merge_cobertura.py"
+    res = run_script(script, env)
+    assert res.returncode == 0
+    assert out.read_text() == "<merged/>"
+    assert not rust.exists() and not py.exists()
+    calls = shell_stubs.calls_of("uvx")
+    assert calls and calls[0].argv[:1] == ["merge-cobertura"]
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = .github/actions

--- a/shellstub.py
+++ b/shellstub.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+import json
+import os
+import sys
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Sequence
+
+@dataclass
+class Call:
+    argv: list[str]
+    cwd: str
+    timestamp: str
+
+@dataclass
+class Variant:
+    match: Sequence[str] | None
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+class StubManager:
+    def __init__(self, dir_: Path):
+        self.dir = dir_
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self._calls_file = self.dir / "calls.jsonl"
+        self._specs: dict[str, dict] = {}
+
+    def register(
+        self,
+        name: str,
+        *,
+        variants: list[dict] | None = None,
+        stdout: str = "",
+        stderr: str = "",
+        exit_code: int = 0,
+    ) -> None:
+        if variants is None:
+            variants = [dict(match=None, stdout=stdout, stderr=stderr, exit_code=exit_code)]
+        for v in variants:
+            if callable(v.get("match")):
+                raise NotImplementedError("callable matchers not supported")
+        spec = {"variants": variants}
+        self._specs[name] = spec
+        path = self.dir / name
+        path.write_text(self._wrapper_source(name, spec))
+        path.chmod(0o755)
+
+    def calls_of(self, name: str) -> list[Call]:
+        out: list[Call] = []
+        if not self._calls_file.exists():
+            return out
+        for line in self._calls_file.read_text().splitlines():
+            rec = json.loads(line)
+            if rec["cmd"] == name:
+                out.append(Call(rec["argv"], rec["cwd"], rec["ts"]))
+        return out
+
+    @property
+    def env(self) -> dict[str, str]:
+        return {
+            "PATH": f"{self.dir}{os.pathsep}{os.getenv('PATH', '')}",
+            "PYTHONPATH": os.getenv("PYTHONPATH", ""),
+            **os.environ,
+        }
+
+    def _wrapper_source(self, name: str, spec: dict) -> str:
+        calls_file = str(self._calls_file)
+        spec_json = json.dumps(spec)
+        return f"""#!/usr/bin/env python3
+import json, os, sys, datetime as _dt
+spec = json.loads({spec_json!r})
+calls_file = {calls_file!r}
+argv = sys.argv[1:]
+rec = {{"cmd": {name!r}, "argv": argv, "cwd": os.getcwd(), "ts": _dt.datetime.utcnow().isoformat() + 'Z'}}
+with open(calls_file, 'a') as fh:
+    json.dump(rec, fh); fh.write('\\n')
+chosen = None
+for var in spec['variants']:
+    m = var.get('match')
+    if m is None:
+        chosen = chosen or var
+    elif m == argv:
+        chosen = var; break
+if chosen is None:
+    sys.exit(127)
+sys.stdout.write(chosen.get('stdout', ''))
+sys.stderr.write(chosen.get('stderr', ''))
+sys.exit(chosen.get('exit_code', 0))
+"""


### PR DESCRIPTION
## Summary
- add `shellstub` helper for stubbing command line tools
- configure pytest to search `.github/actions`
- implement behavioural tests for `generate-coverage` scripts using subprocess and stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af1b0fd348322a84c565ee94e79c9