### PR TITLE
Update setup-rust action with cross toolchain options

### DIFF
--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Scope OpenBSD target installation to Linux runners.
 - Fix README example indentation.
 
+## v1.0.7
+
+- Quote boolean defaults in `action.yml` to avoid type mismatches.
+
 ## v1.0.5
 
 - Install macOS cross build toolchain via `with-darwin`.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,27 +1,27 @@
 
 # Changelog
 
-## v1.0.6
+## v1.0.6 - 2025-07-24
 
 - Cache OpenBSD standard library build and only rebuild on cache miss.
 - Make macOS SDK version configurable via `darwin-sdk-version` input.
 - Scope OpenBSD target installation to Linux runners.
 - Fix README example indentation.
 
-## v1.0.7
+## v1.0.7 - 2025-07-24
 
 - Quote boolean defaults in `action.yml` to avoid type mismatches.
 
-## v1.0.8
+## v1.0.8 - 2025-07-24
 
 - Build OpenBSD standard library using the updated `library/std` path.
 
-## v1.0.5
+## v1.0.5 - 2025-07-24
 
 - Install macOS cross build toolchain via `with-darwin`.
 - Build OpenBSD standard library and add target via `with-openbsd`.
 
-## v1.0.4
+## v1.0.4 - 2025-06-21
 
 - Optionally install SQLite development libraries on Windows via MSYS2 using the
   `install-sqlite-deps` input.
@@ -32,17 +32,17 @@
 - New `use-sccache` input controls this behaviour and caches `~/.cache/sccache`.
 - Pin sccache setup via `sccache-action-version` input (default `v0.0.10`).
 
-## v1.0.3
+## v1.0.3 - 2025-06-20
 
 - Install PostgreSQL client libraries on Windows via Chocolatey.
 
-## v1.0.2
+## v1.0.2 - 2025-06-20
 
 - Document `BUILD_PROFILE` environment variable and fix README example
 
-## v1.0.1
+## v1.0.1 - 2025-06-20
 
 - Document caching requirements, limitations and clarify when caches are saved.
 
-## v1.0.0
+## v1.0.0 - 2025-06-20
 - Initial version.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Quote boolean defaults in `action.yml` to avoid type mismatches.
 
+## v1.0.8
+
+- Build OpenBSD standard library using the updated `library/std` path.
+
 ## v1.0.5
 
 - Install macOS cross build toolchain via `with-darwin`.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Changelog
 
+## v1.0.6
+
+- Cache OpenBSD standard library build and only rebuild on cache miss.
+- Make macOS SDK version configurable via `darwin-sdk-version` input.
+- Scope OpenBSD target installation to Linux runners.
+- Fix README example indentation.
+
 ## v1.0.5
 
 - Install macOS cross build toolchain via `with-darwin`.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+## v1.0.5
+
+- Install macOS cross build toolchain via `with-darwin`.
+- Build OpenBSD standard library and add target via `with-openbsd`.
+
 ## v1.0.4
 
 - Optionally install SQLite development libraries on Windows via MSYS2 using the

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -13,6 +13,7 @@ them, and set up macOS or OpenBSD cross-compilers.
 | use-sccache | Enable sccache for non-release runs | no | `true` |
 | sccache-action-version | Version tag for mozilla-actions/sccache-action | no | `v0.0.10` |
 | with-darwin | Install macOS cross build toolchain | no | `false` |
+| darwin-sdk-version | macOS SDK version for osxcross | no | `12.3` |
 | with-openbsd | Build OpenBSD std library for cross-compilation | no | `false` |
 | BUILD_PROFILE | Build profile used for caching | no | `release` |
 
@@ -47,11 +48,12 @@ so the static library and headers are available when compiling crates that
 depend on SQLite.
 
 When `with-darwin` is enabled, the action installs the osxcross toolchain on
-Linux so that Rust crates can be cross-compiled for macOS.
+Linux so that Rust crates can be cross-compiled for macOS. The SDK version can
+be configured via the `darwin-sdk-version` input and defaults to `12.3`.
 
 When `with-openbsd` is enabled, the action builds the OpenBSD standard library
-from the Rust source tree and installs it into `rustup` so that the
-`x86_64-unknown-openbsd` target becomes available.
+from the Rust source tree, installs it into `rustup`, and caches the result so
+that the `x86_64-unknown-openbsd` target is readily available on later runs.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -2,7 +2,7 @@
 
 Install the Rust toolchain and cache your build dependencies. Optionally
 install PostgreSQL and SQLite system libraries for crates that require
-them.
+them, and set up macOS or OpenBSD cross-compilers.
 
 ## Inputs
 
@@ -12,6 +12,9 @@ them.
 | install-sqlite-deps | Install SQLite development libraries (Windows) | no | `false` |
 | use-sccache | Enable sccache for non-release runs | no | `true` |
 | sccache-action-version | Version tag for mozilla-actions/sccache-action | no | `v0.0.10` |
+| with-darwin | Install macOS cross build toolchain | no | `false` |
+| with-openbsd | Build OpenBSD std library for cross-compilation | no | `false` |
+| BUILD_PROFILE | Build profile used for caching | no | `release` |
 
 ## Outputs
 
@@ -25,6 +28,8 @@ uses: ./.github/actions/setup-rust@v1
     install-postgres-deps: 'true'
     install-sqlite-deps: 'true'
     use-sccache: 'false'
+    with-darwin: true
+    with-openbsd: true
 ```
 
 When `install-postgres-deps` is enabled, the action installs PostgreSQL
@@ -40,6 +45,13 @@ SQLite support on Windows is enabled by setting up an MSYS2 environment
 with the MinGW toolchain and the `mingw-w64-x86_64-sqlite3` package,
 so the static library and headers are available when compiling crates that
 depend on SQLite.
+
+When `with-darwin` is enabled, the action installs the osxcross toolchain on
+Linux so that Rust crates can be cross-compiled for macOS.
+
+When `with-openbsd` is enabled, the action builds the OpenBSD standard library
+from the Rust source tree and installs it into `rustup` so that the
+`x86_64-unknown-openbsd` target becomes available.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -49,11 +49,14 @@ depend on SQLite.
 
 When `with-darwin` is enabled, the action installs the osxcross toolchain on
 Linux so that Rust crates can be cross-compiled for macOS. The SDK version can
-be configured via the `darwin-sdk-version` input and defaults to `12.3`.
+be configured via the `darwin-sdk-version` input and defaults to `12.3`. The
+`x86_64-apple-darwin` and `aarch64-apple-darwin` Rust targets are installed so
+that Cargo can produce macOS binaries.
 
-When `with-openbsd` is enabled, the action builds the OpenBSD standard library
-from the Rust source tree, installs it into `rustup`, and caches the result so
-that the `x86_64-unknown-openbsd` target is readily available on later runs.
+When `with-openbsd` is enabled, the action installs the nightly toolchain,
+builds the OpenBSD standard library from the Rust source tree, installs it into
+`rustup`, and caches the result so that the `x86_64-unknown-openbsd` target is
+readily available on later runs.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -20,7 +20,7 @@ inputs:
   with-darwin:
     description: Install macOS cross build toolchain
     required: false
-    default: false
+    default: 'false'
   darwin-sdk-version:
     description: macOS SDK version for osxcross
     required: false
@@ -28,7 +28,7 @@ inputs:
   with-openbsd:
     description: Build OpenBSD std library for cross-compilation
     required: false
-    default: false
+    default: 'false'
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Install macOS cross build toolchain
     required: false
     default: false
+  darwin-sdk-version:
+    description: macOS SDK version for osxcross
+    required: false
+    default: '12.3'
   with-openbsd:
     description: Build OpenBSD std library for cross-compilation
     required: false
@@ -76,17 +80,24 @@ runs:
       if: ${{ inputs.with-darwin == 'true' && runner.os == 'Linux' }}
       uses: mbround18/setup-osxcross@b26146d499c54979ed3d023266865dc188881911
       with:
-        osx-version: '12.3'
-    - name: Clone Rust repo & build OpenBSD std
+        osx-version: ${{ inputs.darwin-sdk-version }}
+    - name: Cache OpenBSD stdlib
       if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
+      id: openbsd-stdlib-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd
+        key: openbsd-stdlib-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
+    - name: Clone Rust repo & build OpenBSD std
+      if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' && steps.openbsd-stdlib-cache.outputs.cache-hit != 'true' }}
       run: |
-        git clone https://github.com/rust-lang/rust.git
+        git clone --depth 1 --single-branch https://github.com/rust-lang/rust.git
         cd rust
+        HOST_TRIPLE=$(rustc -vV | grep '^host:' | awk '{print $2}')
         ./x.py build --stage 1 --target x86_64-unknown-openbsd src/libstd
-        RUSTUP_TOOLCHAIN=nightly-x86_64-unknown-openbsd \
-          mkdir -p ~/.rustup/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-openbsd
-        cp -r build/x86_64-unknown-openbsd/stage1/lib/rustlib/x86_64-unknown-openbsd/* \
-           ~/.rustup/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-openbsd/
+        mkdir -p ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd
+        cp -r build/$HOST_TRIPLE/stage1/lib/rustlib/x86_64-unknown-openbsd/* \
+          ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd/
     - name: Add OpenBSD target
-      if: ${{ inputs.with-openbsd == 'true' }}
+      if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
       run: rustup target add x86_64-unknown-openbsd --toolchain nightly

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -32,11 +32,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install rust
-      uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
-      with:
-        override: true
-        components: rustfmt, clippy, llvm-tools-preview
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
+        with:
+          override: true
+          components: rustfmt, clippy, llvm-tools-preview
+      - name: Install nightly toolchain (needed for OpenBSD cross-compilation)
+        if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
+        run: rustup toolchain install nightly
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:
@@ -76,11 +79,14 @@ runs:
         install: >-
           mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-sqlite3
-    - name: Setup osxcross (macOS SDK + linker)
-      if: ${{ inputs.with-darwin == 'true' && runner.os == 'Linux' }}
-      uses: mbround18/setup-osxcross@b26146d499c54979ed3d023266865dc188881911
-      with:
-        osx-version: ${{ inputs.darwin-sdk-version }}
+      - name: Setup osxcross (macOS SDK + linker)
+        if: ${{ inputs.with-darwin == 'true' && runner.os == 'Linux' }}
+        uses: mbround18/setup-osxcross@b26146d499c54979ed3d023266865dc188881911
+        with:
+          osx-version: ${{ inputs.darwin-sdk-version }}
+      - name: Install Rust macOS targets
+        if: ${{ inputs.with-darwin == 'true' && runner.os == 'Linux' }}
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
     - name: Cache OpenBSD stdlib
       if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
       id: openbsd-stdlib-cache

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -94,7 +94,7 @@ runs:
         git clone --depth 1 --single-branch https://github.com/rust-lang/rust.git
         cd rust
         HOST_TRIPLE=$(rustc -vV | grep '^host:' | awk '{print $2}')
-        ./x.py build --stage 1 --target x86_64-unknown-openbsd src/libstd
+        ./x.py build --stage 1 --target x86_64-unknown-openbsd library/std
         mkdir -p ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd
         cp -r build/$HOST_TRIPLE/stage1/lib/rustlib/x86_64-unknown-openbsd/* \
           ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd/

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: Version tag for mozilla-actions/sccache-action
     required: false
     default: "v0.0.10"
+  with-darwin:
+    description: Install macOS cross build toolchain
+    required: false
+    default: false
+  with-openbsd:
+    description: Build OpenBSD std library for cross-compilation
+    required: false
+    default: false
 runs:
   using: composite
   steps:
@@ -64,3 +72,21 @@ runs:
         install: >-
           mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-sqlite3
+    - name: Setup osxcross (macOS SDK + linker)
+      if: ${{ inputs.with-darwin == 'true' && runner.os == 'Linux' }}
+      uses: mbround18/setup-osxcross@b26146d499c54979ed3d023266865dc188881911
+      with:
+        osx-version: '12.3'
+    - name: Clone Rust repo & build OpenBSD std
+      if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
+      run: |
+        git clone https://github.com/rust-lang/rust.git
+        cd rust
+        ./x.py build --stage 1 --target x86_64-unknown-openbsd src/libstd
+        RUSTUP_TOOLCHAIN=nightly-x86_64-unknown-openbsd \
+          mkdir -p ~/.rustup/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-openbsd
+        cp -r build/x86_64-unknown-openbsd/stage1/lib/rustlib/x86_64-unknown-openbsd/* \
+           ~/.rustup/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/x86_64-unknown-openbsd/
+    - name: Add OpenBSD target
+      if: ${{ inputs.with-openbsd == 'true' }}
+      run: rustup target add x86_64-unknown-openbsd --toolchain nightly


### PR DESCRIPTION
## Summary
- add `with-darwin` and `with-openbsd` inputs
- install osxcross on Linux when `with-darwin` is enabled
- build and install OpenBSD stdlib behind `with-openbsd`
- document new options in README
- record changes in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f39fefe248322867d8dbe54a81cb9

## Summary by Sourcery

Introduce cross-compilation support for macOS and OpenBSD in the setup-rust GitHub Action, and update documentation and changelog accordingly

New Features:
- Add with-darwin input to install osxcross for macOS cross-compilation on Linux
- Add with-openbsd input to build and install the OpenBSD standard library and add the x86_64-unknown-openbsd target

Documentation:
- Document the with-darwin and with-openbsd options in the action’s README

Chores:
- Record the new inputs and features in the changelog under v1.0.5