### PR TITLE
Fix setup-rust docs and openbsd build

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
+## v1.3.2 (2025-07-26)
+
+- Pin `setup-uv` step to v6.4.3.
+
+## v1.3.1 (2025-07-06)
+
+- Parse coverage XML using `defusedxml` for better security.
+- Fix formatting in the Python runner and improve Rust coverage parsing.
+
 ## v1.3.0 (2025-07-06)
 
 - Add optional ratcheting support via `with-ratchet`. Coverage percentages for
   Rust and Python are tracked separately and compared against their respective
   baselines.
 - Improve baseline caching to allow updates and consolidate ratcheting steps.
-
-## v1.3.1 (2025-07-06)
-
-- Parse coverage XML using `defusedxml` for better security.
-- Fix formatting in the Python runner and improve Rust coverage parsing.
 
 ## v1.2.0 (2025-06-26)
 

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -46,7 +46,8 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+      # v6.4.3
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
     - id: detect
       run: uv run --script "${{ github.action_path }}/scripts/detect.py"
       shell: bash

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -21,9 +21,6 @@
 
 - Install macOS cross build toolchain via `with-darwin`.
 - Build OpenBSD standard library and add target via `with-openbsd`.
-
-## v1.0.5 – 2025-07-22
-
 - Integrate `sccache` on non-release runs to speed up compilation.
 - New `use-sccache` input controls this behaviour and caches `~/.cache/sccache`.
 - Pin sccache setup via `sccache-action-version` input (default `v0.0.10`).

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## v1.0.9 - 2025-07-26
+
+- Install `uv` for running helper scripts.
+
 ## v1.0.8 - 2025-07-24
 
 - Build OpenBSD standard library using the updated `library/std` path.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,14 @@
 
 # Changelog
 
+## v1.0.8 - 2025-07-24
+
+- Build OpenBSD standard library using the updated `library/std` path.
+
+## v1.0.7 - 2025-07-24
+
+- Quote boolean defaults in `action.yml` to avoid type mismatches.
+
 ## v1.0.6 - 2025-07-24
 
 - Cache OpenBSD standard library build and only rebuild on cache miss.
@@ -8,29 +16,21 @@
 - Scope OpenBSD target installation to Linux runners.
 - Fix README example indentation.
 
-## v1.0.7 - 2025-07-24
-
-- Quote boolean defaults in `action.yml` to avoid type mismatches.
-
-## v1.0.8 - 2025-07-24
-
-- Build OpenBSD standard library using the updated `library/std` path.
-
 ## v1.0.5 - 2025-07-24
 
 - Install macOS cross build toolchain via `with-darwin`.
 - Build OpenBSD standard library and add target via `with-openbsd`.
-
-## v1.0.4 - 2025-06-21
-
-- Optionally install SQLite development libraries on Windows via MSYS2 using the
-  `install-sqlite-deps` input.
 
 ## v1.0.5 – 2025-07-22
 
 - Integrate `sccache` on non-release runs to speed up compilation.
 - New `use-sccache` input controls this behaviour and caches `~/.cache/sccache`.
 - Pin sccache setup via `sccache-action-version` input (default `v0.0.10`).
+
+## v1.0.4 - 2025-06-21
+
+- Optionally install SQLite development libraries on Windows via MSYS2 using the
+  `install-sqlite-deps` input.
 
 ## v1.0.3 - 2025-06-20
 

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## v1.0.8 - 2025-07-24
 
 - Build OpenBSD standard library using the updated `library/std` path.
+- New `openbsd-nightly` input allows specifying the pinned nightly toolchain.
 
 ## v1.0.7 - 2025-07-24
 

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -15,7 +15,6 @@ them, and set up macOS or OpenBSD cross-compilers.
 | with-darwin | Install macOS cross build toolchain | no | `false` |
 | darwin-sdk-version | macOS SDK version for osxcross | no | `12.3` |
 | with-openbsd | Build OpenBSD std library for cross-compilation | no | `false` |
-| BUILD_PROFILE | Build profile used for caching | no | `release` |
 
 ## Outputs
 
@@ -53,10 +52,10 @@ be configured via the `darwin-sdk-version` input and defaults to `12.3`. The
 `x86_64-apple-darwin` and `aarch64-apple-darwin` Rust targets are installed so
 that Cargo can produce macOS binaries.
 
-When `with-openbsd` is enabled, the action installs the nightly toolchain,
-builds the OpenBSD standard library from the Rust source tree, installs it into
-`rustup`, and caches the result so that the `x86_64-unknown-openbsd` target is
-readily available on later runs.
+When `with-openbsd` is enabled, the action installs the pinned nightly
+toolchain (`nightly-2025-07-20`), builds the OpenBSD standard library from the
+Rust source tree, installs it into `rustup`, and caches the result so that the
+`x86_64-unknown-openbsd` target is readily available on later runs.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -15,6 +15,7 @@ them, and set up macOS or OpenBSD cross-compilers.
 | with-darwin | Install macOS cross build toolchain | no | `false` |
 | darwin-sdk-version | macOS SDK version for osxcross | no | `12.3` |
 | with-openbsd | Build OpenBSD std library for cross-compilation | no | `false` |
+| openbsd-nightly | Nightly toolchain version for OpenBSD build | no | `nightly-2025-07-20` |
 
 ## Outputs
 
@@ -52,10 +53,11 @@ be configured via the `darwin-sdk-version` input and defaults to `12.3`. The
 `x86_64-apple-darwin` and `aarch64-apple-darwin` Rust targets are installed so
 that Cargo can produce macOS binaries.
 
-When `with-openbsd` is enabled, the action installs the pinned nightly
-toolchain (`nightly-2025-07-20`), builds the OpenBSD standard library from the
-Rust source tree, installs it into `rustup`, and caches the result so that the
-`x86_64-unknown-openbsd` target is readily available on later runs.
+When `with-openbsd` is enabled, the action installs the nightly toolchain
+specified by the `openbsd-nightly` input (default `nightly-2025-07-20`), builds
+the OpenBSD standard library from the Rust source tree, installs it into
+`rustup`, and caches the result so that the `x86_64-unknown-openbsd` target is
+readily available on later runs.
 
 ```yaml
       # Bring in MSYS2 plus the MinGW build of SQLite

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -41,6 +41,9 @@ runs:
         with:
           override: true
           components: rustfmt, clippy, llvm-tools-preview
+      - name: Install uv
+        # v6.4.3
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
       - name: Install nightly toolchain (needed for OpenBSD cross-compilation)
         if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
         run: |

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -39,7 +39,11 @@ runs:
           components: rustfmt, clippy, llvm-tools-preview
       - name: Install nightly toolchain (needed for OpenBSD cross-compilation)
         if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
-        run: rustup toolchain install nightly
+        run: |
+          OPENBSD_NIGHTLY=nightly-2025-07-20
+          rustup toolchain install "$OPENBSD_NIGHTLY"
+          echo "OPENBSD_NIGHTLY=$OPENBSD_NIGHTLY" >> "$GITHUB_ENV"
+          echo "NIGHTLY_SYSROOT=$(rustc +$OPENBSD_NIGHTLY --print sysroot)" >> "$GITHUB_ENV"
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:
@@ -92,7 +96,7 @@ runs:
       id: openbsd-stdlib-cache
       uses: actions/cache@v4
       with:
-        path: ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd
+        path: ${{ env.NIGHTLY_SYSROOT }}/lib/rustlib/x86_64-unknown-openbsd
         key: openbsd-stdlib-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
     - name: Clone Rust repo & build OpenBSD std
       if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' && steps.openbsd-stdlib-cache.outputs.cache-hit != 'true' }}
@@ -101,9 +105,13 @@ runs:
         cd rust
         HOST_TRIPLE=$(rustc -vV | grep '^host:' | awk '{print $2}')
         ./x.py build --stage 1 --target x86_64-unknown-openbsd library/std
-        mkdir -p ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd
-        cp -r build/$HOST_TRIPLE/stage1/lib/rustlib/x86_64-unknown-openbsd/* \
-          ~/.rustup/toolchains/nightly/lib/rustlib/x86_64-unknown-openbsd/
+        ARTIFACT_DIR="build/$HOST_TRIPLE/stage1/lib/rustlib/x86_64-unknown-openbsd"
+        if [ ! -d "$ARTIFACT_DIR" ]; then
+          echo "Error: Build artifacts not found at $ARTIFACT_DIR"
+          exit 1
+        fi
+        mkdir -p "$NIGHTLY_SYSROOT/lib/rustlib/x86_64-unknown-openbsd"
+        cp -r "$ARTIFACT_DIR"/* "$NIGHTLY_SYSROOT/lib/rustlib/x86_64-unknown-openbsd/"
     - name: Add OpenBSD target
       if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
-      run: rustup target add x86_64-unknown-openbsd --toolchain nightly
+      run: rustup target add x86_64-unknown-openbsd --toolchain ${{ env.OPENBSD_NIGHTLY }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -44,8 +44,9 @@ runs:
       - name: Install nightly toolchain (needed for OpenBSD cross-compilation)
         if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
         run: |
-          OPENBSD_NIGHTLY=${{ inputs.openbsd-nightly }}
-          rustup toolchain install "$OPENBSD_NIGHTLY"
+          set -euo pipefail
+          OPENBSD_NIGHTLY='${{ inputs.openbsd-nightly }}'
+          rustup toolchain install --profile minimal "$OPENBSD_NIGHTLY"
           echo "OPENBSD_NIGHTLY=$OPENBSD_NIGHTLY" >> "$GITHUB_ENV"
           echo "NIGHTLY_SYSROOT=$(rustc +$OPENBSD_NIGHTLY --print sysroot)" >> "$GITHUB_ENV"
     - name: Cache cargo registry

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Build OpenBSD std library for cross-compilation
     required: false
     default: 'false'
+  openbsd-nightly:
+    description: Nightly toolchain version for OpenBSD build
+    required: false
+    default: 'nightly-2025-07-20'
 runs:
   using: composite
   steps:
@@ -40,7 +44,7 @@ runs:
       - name: Install nightly toolchain (needed for OpenBSD cross-compilation)
         if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
         run: |
-          OPENBSD_NIGHTLY=nightly-2025-07-20
+          OPENBSD_NIGHTLY=${{ inputs.openbsd-nightly }}
           rustup toolchain install "$OPENBSD_NIGHTLY"
           echo "OPENBSD_NIGHTLY=$OPENBSD_NIGHTLY" >> "$GITHUB_ENV"
           echo "NIGHTLY_SYSROOT=$(rustc +$OPENBSD_NIGHTLY --print sysroot)" >> "$GITHUB_ENV"
@@ -106,12 +110,8 @@ runs:
         HOST_TRIPLE=$(rustc -vV | grep '^host:' | awk '{print $2}')
         ./x.py build --stage 1 --target x86_64-unknown-openbsd library/std
         ARTIFACT_DIR="build/$HOST_TRIPLE/stage1/lib/rustlib/x86_64-unknown-openbsd"
-        if [ ! -d "$ARTIFACT_DIR" ]; then
-          echo "Error: Build artifacts not found at $ARTIFACT_DIR"
-          exit 1
-        fi
-        mkdir -p "$NIGHTLY_SYSROOT/lib/rustlib/x86_64-unknown-openbsd"
-        cp -r "$ARTIFACT_DIR"/* "$NIGHTLY_SYSROOT/lib/rustlib/x86_64-unknown-openbsd/"
+        uv run --script "${{ github.action_path }}/scripts/copy_openbsd_stdlib.py" \
+          "$ARTIFACT_DIR" "$NIGHTLY_SYSROOT"
     - name: Add OpenBSD target
       if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
       run: rustup target add x86_64-unknown-openbsd --toolchain ${{ env.OPENBSD_NIGHTLY }}

--- a/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
+++ b/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["typer"]
+# ///
+"""Copy OpenBSD standard library build artifacts into the nightly sysroot."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(artifact_dir: Path, nightly_sysroot: Path) -> None:
+    """Copy artifacts from *artifact_dir* into *nightly_sysroot*."""
+    if not artifact_dir.is_dir():
+        typer.echo(f"Error: Build artifacts not found at {artifact_dir}", err=True)
+        raise typer.Exit(1)
+
+    dest = nightly_sysroot / "lib" / "rustlib" / "x86_64-unknown-openbsd"
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for item in artifact_dir.iterdir():
+        target = dest / item.name
+        if item.is_dir():
+            shutil.copytree(item, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, target)
+
+    typer.echo(f"Copied OpenBSD stdlib from {artifact_dir} to {dest}")
+
+
+if __name__ == "__main__":
+    app()

--- a/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
+++ b/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
@@ -11,9 +11,9 @@ renamed into place so consumers never see a partially copied stdlib.
 
 from __future__ import annotations
 
-from pathlib import Path
 import shutil
 import subprocess
+from pathlib import Path  # noqa: TC003
 
 import typer
 
@@ -33,7 +33,7 @@ def main(artifact_dir: Path, nightly_sysroot: Path) -> None:
 
     tmp.mkdir(parents=True, exist_ok=True)
     cmd = ["rsync", "-a", "--delete", f"{artifact_dir}/", str(tmp)]
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd)  # noqa: S603
 
     if dest.exists():
         shutil.rmtree(dest)

--- a/.github/actions/setup-rust/tests/conftest.py
+++ b/.github/actions/setup-rust/tests/conftest.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from shellstub import StubManager
+
 
 def _find_root(start: Path) -> Path:
     """Return nearest ancestor containing ``pyproject.toml`` or ``.git``."""
@@ -22,10 +24,8 @@ sys.path.insert(0, str(ROOT))
 
 
 @pytest.fixture
-def shell_stubs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def shell_stubs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> StubManager:
     """Return a ``StubManager`` configured for the current test."""
-    from shellstub import StubManager
-
     dir_ = tmp_path / "stubs"
     mgr = StubManager(dir_)
     import shellstub as mod

--- a/.github/actions/setup-rust/tests/conftest.py
+++ b/.github/actions/setup-rust/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Common test utilities for setup-rust scripts."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _find_root(start: Path) -> Path:
+    """Return nearest ancestor containing ``pyproject.toml`` or ``.git``."""
+    for parent in (start, *start.parents):
+        if (parent / "pyproject.toml").exists() or (parent / ".git").exists():
+            return parent
+    raise FileNotFoundError(str(start))
+
+
+ROOT = _find_root(Path(__file__).resolve())
+sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def shell_stubs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Return a ``StubManager`` configured for the current test."""
+    from shellstub import StubManager
+
+    dir_ = tmp_path / "stubs"
+    mgr = StubManager(dir_)
+    import shellstub as mod
+
+    mod._GLOBAL_MANAGER = mgr
+    monkeypatch.setenv("PATH", f"{dir_}{os.pathsep}{os.getenv('PATH')}")
+    monkeypatch.setenv("PYTHONPATH", f"{ROOT}{os.pathsep}{os.getenv('PYTHONPATH', '')}")
+    return mgr

--- a/.github/actions/setup-rust/tests/test_copy_stdlib.py
+++ b/.github/actions/setup-rust/tests/test_copy_stdlib.py
@@ -7,11 +7,13 @@ from pathlib import Path
 
 
 def run_script(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Execute *script* using ``uv run --script`` and return the process."""
     cmd = ["uv", "run", "--script", str(script), *args]
-    return subprocess.run(cmd, capture_output=True, text=True)
+    return subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
 
 
 def test_copy_success(tmp_path: Path) -> None:
+    """Copying succeeds and preserves file contents."""
     artifact = tmp_path / "build" / "artifacts"
     artifact.mkdir(parents=True)
     (artifact / "foo.txt").write_text("hi")
@@ -27,6 +29,7 @@ def test_copy_success(tmp_path: Path) -> None:
 
 
 def test_copy_overwrite(tmp_path: Path) -> None:
+    """Existing destination files are overwritten."""
     artifact = tmp_path / "build" / "artifacts"
     artifact.mkdir(parents=True)
     (artifact / "new.txt").write_text("new")
@@ -45,6 +48,7 @@ def test_copy_overwrite(tmp_path: Path) -> None:
 
 
 def test_copy_missing(tmp_path: Path) -> None:
+    """Missing source directory exits with an error."""
     artifact = tmp_path / "missing"
     sysroot = tmp_path / "sysroot"
 

--- a/.github/actions/setup-rust/tests/test_copy_stdlib.py
+++ b/.github/actions/setup-rust/tests/test_copy_stdlib.py
@@ -26,6 +26,24 @@ def test_copy_success(tmp_path: Path) -> None:
     assert dest.read_text() == "hi"
 
 
+def test_copy_overwrite(tmp_path: Path) -> None:
+    artifact = tmp_path / "build" / "artifacts"
+    artifact.mkdir(parents=True)
+    (artifact / "new.txt").write_text("new")
+
+    sysroot = tmp_path / "sysroot"
+    dest = sysroot / "lib" / "rustlib" / "x86_64-unknown-openbsd"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "old.txt").write_text("old")
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "copy_openbsd_stdlib.py"
+    res = run_script(script, str(artifact), str(sysroot))
+
+    assert res.returncode == 0
+    assert not (dest / "old.txt").exists()
+    assert (dest / "new.txt").read_text() == "new"
+
+
 def test_copy_missing(tmp_path: Path) -> None:
     artifact = tmp_path / "missing"
     sysroot = tmp_path / "sysroot"


### PR DESCRIPTION
## Summary
- remove undocumented BUILD_PROFILE input from README
- document pinned nightly toolchain for OpenBSD
- dynamically resolve nightly toolchain path
- guard OpenBSD stdlib copy with existence check
- reorder changelog entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b2efff9883228658e1a7a2016234

## Summary by Sourcery

Improve OpenBSD cross-compilation support in the setup-rust action by pinning and dynamically resolving the nightly toolchain, adding error checks for stdlib copying, cleaning up undocumented inputs, and reordering changelog entries.

Enhancements:
- Pin the OpenBSD nightly toolchain to a specific date and expose its path via environment variables
- Dynamically set NIGHTLY_SYSROOT from the installed toolchain for caching
- Add a directory existence check before copying OpenBSD stdlib build artifacts

Documentation:
- Remove the undocumented BUILD_PROFILE input from README
- Document the pinned nightly toolchain (`nightly-2025-07-20`) for OpenBSD in README

Chores:
- Reorder entries in the setup-rust CHANGELOG