### PR TITLE
Add nightly availability check

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -49,6 +49,8 @@ runs:
         run: |
           set -euo pipefail
           OPENBSD_NIGHTLY='${{ inputs.openbsd-nightly }}'
+          NIGHTLY_DATE="${OPENBSD_NIGHTLY#nightly-}"
+          curl -fsI "https://static.rust-lang.org/dist/${NIGHTLY_DATE}/channel-rust-nightly.toml" >/dev/null
           rustup toolchain install --profile minimal "$OPENBSD_NIGHTLY"
           echo "OPENBSD_NIGHTLY=$OPENBSD_NIGHTLY" >> "$GITHUB_ENV"
           echo "NIGHTLY_SYSROOT=$(rustc +$OPENBSD_NIGHTLY --print sysroot)" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- verify nightly toolchain existence before installing it in setup-rust

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e82578d48322b5870b8e1587ce9f

## Summary by Sourcery

Enhancements:
- Use curl to verify the existence of the nightly channel file (channel-rust-nightly.toml) before proceeding with toolchain installation