### PR TITLE
Add coverage artifact archive step

### DIFF
--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -138,3 +138,10 @@ runs:
       env:
         DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
       shell: bash
+    - name: Archive coverage
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.out.outputs.format }}
+        path: ${{ steps.out.outputs.file }}
+        retention-days: 14


### PR DESCRIPTION
## Summary
- archive generated coverage in `generate-coverage` action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f30a979c832283c9490a177d8d21