### PR TITLE
Fix setup-rust sccache step

### DIFF
--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+## v1.0.10 - 2025-07-26
+
+- Remove `sccache-action-version` input and pin the sccache step to commit
+  `7d986dd989559c6ecdb630a3fd2557667be217ad` for reproducibility.
+
 ## v1.0.9 - 2025-07-26
 
 - Install `uv` for running helper scripts.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -27,7 +27,6 @@
 - Build OpenBSD standard library and add target via `with-openbsd`.
 - Integrate `sccache` on non-release runs to speed up compilation.
 - New `use-sccache` input controls this behaviour and caches `~/.cache/sccache`.
-- Pin sccache setup via `sccache-action-version` input (default `v0.0.10`).
 
 ## v1.0.4 - 2025-06-21
 

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -11,7 +11,6 @@ them, and set up macOS or OpenBSD cross-compilers.
 | install-postgres-deps | Install PostgreSQL system dependencies | no | `false` |
 | install-sqlite-deps | Install SQLite development libraries (Windows) | no | `false` |
 | use-sccache | Enable sccache for non-release runs | no | `true` |
-| sccache-action-version | Version tag for mozilla-actions/sccache-action | no | `v0.0.10` |
 | with-darwin | Install macOS cross build toolchain | no | `false` |
 | darwin-sdk-version | macOS SDK version for osxcross | no | `12.3` |
 | with-openbsd | Build OpenBSD std library for cross-compilation | no | `false` |
@@ -94,7 +93,10 @@ cache compiler output. It sets `SCCACHE_GHA_ENABLED=true` and
 `RUSTC_WRAPPER=sccache` so subsequent build steps benefit from the cache. The
 compiled objects are stored in `~/.cache/sccache` and cached with a **separate
 cache key** from the directories above. This directory holds the sccache cache
-space and does not share data with the standard `actions/cache` entry.
+space and does not share data with the standard `actions/cache` entry. The
+sccache step itself uses
+`mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad`,
+pinned to a specific commit for reproducibility.
 
 ### Requirements
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -13,10 +13,6 @@ inputs:
     description: Enable sccache for non-release runs
     required: false
     default: "true"
-  sccache-action-version:
-    description: Version tag for mozilla-actions/sccache-action
-    required: false
-    default: "v0.0.10"
   with-darwin:
     description: Install macOS cross build toolchain
     required: false
@@ -65,9 +61,9 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
-    - name: Run sccache only on non-release runs
-      if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' }}
-      uses: mozilla-actions/sccache-action@${{ inputs.sccache-action-version }}
+      - name: Run sccache only on non-release runs
+        if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' }}
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad
     - name: Install system dependencies
       if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Linux' }}
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev


### PR DESCRIPTION
## Summary
- remove dynamic input `sccache-action-version`
- pin the sccache action to a commit
- document pinned commit in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f38bbe28832296c2b97828b9ac7b

## Summary by Sourcery

Pin the sccache GitHub Action to a fixed commit for reproducibility, remove the dynamic version input, and update documentation and changelog accordingly.

Enhancements:
- Remove the dynamic sccache-action-version input
- Pin mozilla-actions/sccache-action to a specific commit in the setup-rust action

Documentation:
- Document the pinned sccache-action commit in the README

Chores:
- Remove the sccache-action-version entry from the README and CHANGELOG