### PR TITLE
Fix YAML indentation in setup-rust action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -61,9 +61,9 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
-      - name: Run sccache only on non-release runs
-        if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' }}
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad
+    - name: Run sccache only on non-release runs
+      if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' }}
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad
     - name: Install system dependencies
       if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Linux' }}
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev


### PR DESCRIPTION
## Summary
- fix indentation for the sccache step in `setup-rust`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ff451fa48322969c46845f18f474

## Summary by Sourcery

Bug Fixes:
- Fix YAML indentation of the sccache step in setup-rust action.yml