### PR TITLE
Fix coverage action missing cargo-llvm-cov

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.3 (2025-07-27)
+
+- Install `cargo-llvm-cov` automatically when running Rust coverage and cache the
+  binary along with Cargo artifacts.
+
 ## v1.3.2 (2025-07-26)
 
 - Pin `setup-uv` step to v6.4.3.

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -3,7 +3,8 @@
 Run code coverage for Rust projects, Python projects, and mixed Rust + Python projects. The action uses
 `cargo llvm-cov` when a `Cargo.toml` is present and `slipcover` with
 `pytest` when a `pyproject.toml` is present. It installs `slipcover` and
-`pytest` automatically via `uv` before running the tests. If both
+`pytest` automatically via `uv` before running the tests. When Rust coverage is
+required, `cargo-llvm-cov` is installed automatically as well. If both
 configuration files are present, coverage is run for each language and
 the Cobertura reports are merged using `uvx merge-cobertura`.
 

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -68,6 +68,22 @@ runs:
           echo 0 > "${{ inputs.baseline-python-file }}"
         fi
       shell: bash
+    - name: Cache cargo artifacts
+      if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/cargo-llvm-cov
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-llvmcov-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-llvmcov-
+    - name: Install cargo-llvm-cov
+      if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
+      run: uv run --script "${{ github.action_path }}/scripts/install_cargo_llvm_cov.py"
+      shell: bash
     - id: rust
       if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
       run: uv run --script "${{ github.action_path }}/scripts/run_rust.py"

--- a/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["plumbum", "typer"]
+# ///
+"""Install the cargo-llvm-cov tool via ``cargo install``."""
+
+import typer
+from plumbum.cmd import cargo
+from plumbum.commands.processes import ProcessExecutionError
+
+
+def main() -> None:
+    """Install cargo-llvm-cov via cargo install command."""
+    try:
+        cargo["install", "cargo-llvm-cov"]()
+        typer.echo("cargo-llvm-cov installed successfully")
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"cargo install failed with code {exc.retcode}: {exc.stderr}", err=True
+        )
+        raise typer.Exit(code=exc.retcode or 1) from exc
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## Summary
- install `cargo-llvm-cov` automatically in generate-coverage action
- cache cargo artifacts
- document new behaviour in README
- note change in CHANGELOG

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6885678c5bc88322a5b9224599bf287d

## Summary by Sourcery

Automate Rust coverage setup by installing cargo-llvm-cov and caching Cargo artifacts in the generate-coverage action, and update documentation accordingly.

New Features:
- Automatically install cargo-llvm-cov when running Rust coverage
- Cache Cargo artifacts (cargo-llvm-cov binary, registry, git and target directories) to speed up coverage runs

Documentation:
- Update README to document automatic cargo-llvm-cov installation
- Add v1.3.3 entry in CHANGELOG for the new Rust coverage enhancements