### PR TITLE
Fix artifact path handling

### DIFF
--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -44,3 +44,7 @@
 ## v1.5.2
 - Remove unsupported `env` block from the `runs` section.
 - Export `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` via a setup step.
+
+## v1.5.3
+- Treat empty `path` input the same as `__auto__` to avoid artifact upload
+  failures.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -6,7 +6,7 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 
 | Name             | Description                                  | Required | Default |
 | ---------------- | -------------------------------------------- | -------- | ------- |
-| path             | Coverage file path; leave blank or use `__auto__` to infer | no       | `__auto__` |
+| path             | Coverage file path; blank or `__auto__` infers automatically | no       | `__auto__` |
 | format           | Coverage format (`cobertura` or `lcov`)       | no       | `cobertura` |
 | access-token     | CodeScene project access token                | yes      |         |
 | installer-checksum | SHA-256 checksum of the installer script    | no       |         |

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -6,13 +6,13 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 
 | Name             | Description                                  | Required | Default |
 | ---------------- | -------------------------------------------- | -------- | ------- |
-| path             | Coverage file path; use `__auto__` to infer   | no       | `__auto__` |
+| path             | Coverage file path; leave blank or use `__auto__` to infer | no       | `__auto__` |
 | format           | Coverage format (`cobertura` or `lcov`)       | no       | `cobertura` |
 | access-token     | CodeScene project access token                | yes      |         |
 | installer-checksum | SHA-256 checksum of the installer script    | no       |         |
 
-If `path` is left as `__auto__`, the action will look for `lcov.info` when
-`format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.
+If `path` is empty or `__auto__`, the action looks for `lcov.info` when
+  `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`.
 The CodeScene CLI is cached using its release version extracted from the
 installer script. If the optional `installer-checksum` input is set,
 the installer is validated before execution. Any other value for

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -39,7 +39,7 @@ runs:
       id: cov-file
       run: |
         file="${{ inputs.path }}"
-        if [ "$file" = "__auto__" ]; then
+        if [ -z "$file" ] || [ "$file" = "__auto__" ]; then
           if [ "${{ inputs.format }}" = "lcov" ]; then
             file="lcov.info"
           else


### PR DESCRIPTION
## Summary
- avoid artifact upload errors when path input is blank
- document empty path behaviour
- note change in CHANGELOG

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68857387712483229779e31f41af68b9

## Summary by Sourcery

Treat empty artifact path input as '__auto__' to avoid upload failures and update docs and changelog accordingly

Bug Fixes:
- Treat empty 'path' input the same as '__auto__' to prevent artifact upload errors

Documentation:
- Clarify empty path behavior in README
- Add v1.5.3 entry to CHANGELOG documenting the change