### PR TITLE
Fix artifact path for coverage upload

### DIFF
--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -161,5 +161,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.out.outputs.format }}
-        path: ${{ steps.out.outputs.file }}
+        # Fallback to the configured output path when the step that sets
+        # outputs didn't run successfully and the file output is empty.
+        path: ${{ steps.out.outputs.file || inputs.output-path }}
         retention-days: 14


### PR DESCRIPTION
## Summary
- ensure `generate-coverage` passes a fallback path when archiving coverage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688578102fa88322a63337ae49602c03