### PR TITLE
Improve lcov coverage parsing

### DIFF
--- a/.github/actions/generate-coverage/scripts/coverage_parsers.py
+++ b/.github/actions/generate-coverage/scripts/coverage_parsers.py
@@ -1,0 +1,58 @@
+"""Coverage parsing helpers."""
+
+from __future__ import annotations
+
+import typing as t
+from decimal import ROUND_HALF_UP, Decimal
+
+import typer
+from lxml import etree
+
+if t.TYPE_CHECKING:  # pragma: no cover - import for type hints only
+    from pathlib import Path
+
+
+def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
+    """Return the overall line coverage percentage from a Cobertura XML file.
+
+    Parameters
+    ----------
+    xml_file : Path
+        Path to the coverage file to read.
+
+    Returns
+    -------
+    str
+        The coverage percentage with two decimal places. ``"0.00"`` is returned
+        if the file cannot be read or parsed.
+    """
+    try:
+        root = etree.parse(str(xml_file)).getroot()
+    except OSError as exc:
+        typer.echo(f"Could not read {xml_file}: {exc}", err=True)
+        return "0.00"
+    except etree.LxmlError as exc:  # XMLSyntaxError plus related issues
+        typer.echo(f"Failed to parse coverage XML {xml_file}: {exc}", err=True)
+        return "0.00"
+
+    def num_or_zero(expr: str) -> int:
+        n = root.xpath(f"number({expr})")
+        return 0 if n != n else int(n)
+
+    def lines_from_detail() -> tuple[int, int]:
+        total = int(root.xpath("count(//class/lines/line)"))
+        covered = int(root.xpath("count(//class/lines/line[number(@hits) > 0])"))
+        return covered, total
+
+    covered, total = lines_from_detail()
+    if total == 0:
+        covered = num_or_zero("/coverage/@lines-covered")
+        total = num_or_zero("/coverage/@lines-valid")
+
+    if total == 0:
+        return "0.00"
+
+    percent = (Decimal(covered) / Decimal(total) * 100).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    return f"{percent}"

--- a/.github/actions/generate-coverage/scripts/coverage_parsers.py
+++ b/.github/actions/generate-coverage/scripts/coverage_parsers.py
@@ -87,6 +87,7 @@ def get_line_coverage_percent_from_lcov(lcov_file: Path) -> str:
             "No lines found in lcov data. This may indicate an empty or "
             "misconfigured lcov file."
         )
-        return "0.00"
 
-    return f"{lines_hit / lines_found * 100:.2f}"
+    return (
+        "0.00" if lines_found == 0 else f"{lines_hit / lines_found * 100:.2f}"
+    )

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -13,6 +13,7 @@ import typing as t
 from pathlib import Path
 
 import typer
+from coverage_parsers import get_line_coverage_percent_from_cobertura
 from plumbum import FG
 from plumbum.cmd import python
 from plumbum.commands.processes import ProcessExecutionError
@@ -40,50 +41,6 @@ def coverage_cmd_for_fmt(fmt: str, out: Path) -> BoundCommand:
             "-v",
         ]
     return python["-m", "slipcover", "--branch", "-m", "pytest", "-v"]
-
-
-def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
-    """Return the overall line coverage percentage from a Cobertura XML file.
-
-    Parameters
-    ----------
-    xml_file : Path
-        Path to the coverage file to read.
-
-    Returns
-    -------
-    str
-        The coverage percentage with two decimal places.
-    """
-    from decimal import ROUND_HALF_UP, Decimal
-
-    from lxml import etree
-
-    root = etree.parse(str(xml_file)).getroot()
-
-    def num_or_zero(expr: str) -> int:
-        n = root.xpath(f"number({expr})")
-        return 0 if n != n else int(n)
-
-    def lines_from_detail() -> tuple[int, int]:
-        total = int(root.xpath("count(//class/lines/line)"))
-        covered = int(root.xpath("count(//class/lines/line[number(@hits) > 0])"))
-        return covered, total
-
-    covered, total = lines_from_detail()
-    if total == 0:
-        covered = num_or_zero("/coverage/@lines-covered")
-        total = num_or_zero("/coverage/@lines-valid")
-
-    if total == 0:
-        return "0.00"
-
-    percent = (Decimal(covered) / Decimal(total) * 100).quantize(
-        Decimal("0.01"), rounding=ROUND_HALF_UP
-    )
-    return f"{percent}"
-
-
 @contextlib.contextmanager
 def tmp_coveragepy_xml(out: Path) -> cabc.Generator[Path]:
     """Generate a cobertura XML from coverage.py and clean up afterwards."""

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -42,7 +42,6 @@ def coverage_cmd_for_fmt(fmt: str, out: Path) -> BoundCommand:
     return python["-m", "slipcover", "--branch", "-m", "pytest", "-v"]
 
 
-
 def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
     """Return the overall line coverage percentage from a Cobertura XML file.
 
@@ -79,9 +78,9 @@ def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
     if total == 0:
         return "0.00"
 
-    percent = (
-        Decimal(covered) / Decimal(total) * 100
-    ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    percent = (Decimal(covered) / Decimal(total) * 100).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
     return f"{percent}"
 
 

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -11,6 +11,7 @@ import re
 from pathlib import Path  # noqa: TC003 - used at runtime
 
 import typer
+from coverage_parsers import get_line_coverage_percent_from_cobertura
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
@@ -44,7 +45,7 @@ def extract_percent(output: str) -> str:
     )
     if not match:
         typer.echo("Could not parse coverage percent", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(1)
     return match[1]
 
 
@@ -59,14 +60,18 @@ def get_line_coverage_percent_from_lcov(lcov_file: Path) -> str:
     Returns
     -------
     str
-        The coverage percentage with two decimal places. "0.00" is returned if
-        the file cannot be read or parsed.
+        The coverage percentage with two decimal places.
+
+    Raises
+    ------
+    typer.Exit
+        If ``lcov_file`` cannot be read.
     """
     try:
         text = lcov_file.read_text(encoding="utf-8")
     except OSError as exc:
         typer.echo(f"Could not read {lcov_file}: {exc}", err=True)
-        return "0.00"
+        raise typer.Exit(1) from exc
 
     def total(tag: str) -> int:
         values = re.findall(rf"^{tag}:(\d+)$", text, flags=re.MULTILINE)
@@ -87,46 +92,6 @@ def get_line_coverage_percent_from_lcov(lcov_file: Path) -> str:
     return f"{lines_hit / lines_found * 100:.2f}"
 
 
-def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
-    """Return the overall line coverage percentage from a Cobertura XML file.
-
-    Parameters
-    ----------
-    xml_file : Path
-        Path to the coverage file to read.
-
-    Returns
-    -------
-    str
-        The coverage percentage with two decimal places.
-    """
-    from decimal import ROUND_HALF_UP, Decimal
-
-    from lxml import etree
-
-    root = etree.parse(str(xml_file)).getroot()
-
-    def num_or_zero(expr: str) -> int:
-        n = root.xpath(f"number({expr})")
-        return 0 if n != n else int(n)
-
-    def lines_from_detail() -> tuple[int, int]:
-        total = int(root.xpath("count(//class/lines/line)"))
-        covered = int(root.xpath("count(//class/lines/line[number(@hits) > 0])"))
-        return covered, total
-
-    covered, total = lines_from_detail()
-    if total == 0:
-        covered = num_or_zero("/coverage/@lines-covered")
-        total = num_or_zero("/coverage/@lines-valid")
-
-    if total == 0:
-        return "0.00"
-
-    percent = (Decimal(covered) / Decimal(total) * 100).quantize(
-        Decimal("0.01"), rounding=ROUND_HALF_UP
-    )
-    return f"{percent}"
 
 
 def main(

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -48,8 +48,19 @@ def extract_percent(output: str) -> str:
     return match[1]
 
 
-def percent_from_lcov(lcov_file: Path) -> str:
-    """Return the overall line coverage from an ``lcov.info`` file."""
+def get_line_coverage_percent_from_lcov(lcov_file: Path) -> str:
+    """Return the overall line coverage percentage from an ``lcov.info`` file.
+
+    Parameters
+    ----------
+    lcov_file : Path
+        Path to the coverage file to read.
+
+    Returns
+    -------
+    str
+        The coverage percentage with two decimal places.
+    """
     text = lcov_file.read_text(encoding="utf-8")
 
     def total(tag: str) -> int:
@@ -87,7 +98,11 @@ def main(
         typer.echo(f"cargo llvm-cov failed with code {retcode}: {stderr}", err=True)
         raise typer.Exit(code=retcode or 1)
     typer.echo(stdout)
-    percent = percent_from_lcov(out) if fmt == "lcov" else extract_percent(stdout)
+    percent = (
+        get_line_coverage_percent_from_lcov(out)
+        if fmt == "lcov"
+        else extract_percent(stdout)
+    )
 
     with github_output.open("a") as fh:
         fh.write(f"file={out}\n")

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -180,6 +180,12 @@ def test_lcov_malformed_file(tmp_path: Path, run_rust_module: types.ModuleType) 
     assert run_rust_module.get_line_coverage_percent_from_lcov(lcov) == "0.00"
 
 
+def test_lcov_file_missing(tmp_path: Path, run_rust_module: types.ModuleType) -> None:
+    """Missing ``lcov.info`` file yields 0.00 without raising."""
+    lcov = tmp_path / "nope.lcov"
+    assert run_rust_module.get_line_coverage_percent_from_lcov(lcov) == "0.00"
+
+
 @pytest.fixture
 def run_python_module(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     """Return the ``run_python`` module with dependencies stubbed."""
@@ -201,6 +207,48 @@ def run_python_module(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     monkeypatch.setitem(sys.modules, "plumbum.cmd", fake_plumbum.cmd)
     monkeypatch.setitem(sys.modules, "plumbum.commands.processes", fake_proc)
     monkeypatch.setitem(sys.modules, "plumbum.FG", None)
+
+    import defusedxml.ElementTree as ETree
+
+    class FakeRoot:
+        def __init__(self, elem: ETree.Element) -> None:
+            self._elem = elem
+
+        def xpath(self, expr: str) -> float:
+            if expr.startswith("number(") and expr.endswith(")"):
+                attr = expr[len("number(") : -1]
+                if attr.startswith("/coverage/@"):
+                    return float(self._elem.get(attr.split("@")[1]) or float("nan"))
+            if expr.startswith("count(") and expr.endswith(")"):
+                inner = expr[len("count(") : -1]
+                if inner == "//class/lines/line":
+                    return float(len(self._elem.findall(".//class/lines/line")))
+                if inner == "//class/lines/line[number(@hits) > 0]":
+                    total = 0
+                    for line in self._elem.findall(".//class/lines/line"):
+                        try:
+                            hits = float(line.get("hits", "0"))
+                        except ValueError:
+                            hits = 0
+                        if hits > 0:
+                            total += 1
+                    return float(total)
+            raise NotImplementedError(expr)
+
+    class FakeTree:
+        def __init__(self, elem: ETree.Element) -> None:
+            self._elem = elem
+
+        def getroot(self) -> FakeRoot:
+            return FakeRoot(self._elem)
+
+    def fake_parse(path: str) -> FakeTree:
+        return FakeTree(ETree.parse(path).getroot())
+
+    fake_etree = types.SimpleNamespace(parse=fake_parse)
+    fake_lxml = types.SimpleNamespace(etree=fake_etree)
+    monkeypatch.setitem(sys.modules, "lxml", fake_lxml)
+    monkeypatch.setitem(sys.modules, "lxml.etree", fake_etree)
 
     fake_typer = types.SimpleNamespace(
         Option=lambda default=None, **_: default,

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -23,6 +23,7 @@ def test_run_rust_success(tmp_path: Path, shell_stubs: StubManager) -> None:
     out = tmp_path / "cov.lcov"
     gh = tmp_path / "gh.txt"
 
+    out.write_text("LF:200\nLH:163\n")
     shell_stubs.register(
         "cargo",
         stdout="Coverage: 81.5%\n",
@@ -60,7 +61,7 @@ def test_run_rust_success(tmp_path: Path, shell_stubs: StubManager) -> None:
 
     data = gh.read_text().splitlines()
     assert f"file={out}" in data
-    assert "percent=81.5" in data
+    assert "percent=81.50" in data
 
 
 def test_run_rust_failure(tmp_path: Path, shell_stubs: StubManager) -> None:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -160,21 +160,21 @@ def test_merge_cobertura(tmp_path: Path, shell_stubs: StubManager) -> None:
 def test_lcov_zero_lines_found(
     tmp_path: Path, run_rust_module: types.ModuleType
 ) -> None:
-    """``percent_from_lcov`` returns 0.00 when no lines are found."""
+    """``get_line_coverage_percent_from_lcov`` returns 0.00 when no lines are found."""
     lcov = tmp_path / "zero.lcov"
     lcov.write_text("LF:0\nLH:0\n")
-    assert run_rust_module.percent_from_lcov(lcov) == "0.00"
+    assert run_rust_module.get_line_coverage_percent_from_lcov(lcov) == "0.00"
 
 
 def test_lcov_missing_lh_tag(tmp_path: Path, run_rust_module: types.ModuleType) -> None:
-    """``percent_from_lcov`` handles files missing ``LH`` tags."""
+    """``get_line_coverage_percent_from_lcov`` handles files missing ``LH`` tags."""
     lcov = tmp_path / "missing.lcov"
     lcov.write_text("LF:100\n")
-    assert run_rust_module.percent_from_lcov(lcov) == "0.00"
+    assert run_rust_module.get_line_coverage_percent_from_lcov(lcov) == "0.00"
 
 
 def test_lcov_malformed_file(tmp_path: Path, run_rust_module: types.ModuleType) -> None:
-    """``percent_from_lcov`` treats malformed files as zero coverage."""
+    """``get_line_coverage_percent_from_lcov`` returns 0.00 for malformed files."""
     lcov = tmp_path / "bad.lcov"
     lcov.write_text("LF:abc\nLH:xyz\n")
-    assert run_rust_module.percent_from_lcov(lcov) == "0.00"
+    assert run_rust_module.get_line_coverage_percent_from_lcov(lcov) == "0.00"


### PR DESCRIPTION
## Summary
- extract line coverage percent from lcov files
- use the new parsing logic when running Rust coverage
- update tests for lcov coverage parsing

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688588977888832283e0264c1eb19b1e

## Summary by Sourcery

Improve coverage parsing by extracting line coverage from lcov and Cobertura outputs via new helper functions, integrating them into the Rust and Python coverage scripts, and bolstering error handling and test coverage.

New Features:
- Add get_line_coverage_percent_from_lcov to extract line coverage from lcov.info files
- Introduce coverage_parsers module with get_line_coverage_percent_from_cobertura for Cobertura XML

Enhancements:
- Update run_rust and run_python scripts to use the new parsers for lcov and Cobertura formats
- Include lxml dependency and improve error handling with proper exit codes and two-decimal formatting

Tests:
- Add unit tests for lcov parser covering zero lines, missing tags, malformed data, and file errors
- Add unit tests for Cobertura parser covering per-line detail, root totals fallback, and zero coverage cases