### PR TITLE
Fix LCOV precision for coverage parser

### DIFF
--- a/.github/actions/generate-coverage/scripts/coverage_parsers.py
+++ b/.github/actions/generate-coverage/scripts/coverage_parsers.py
@@ -21,6 +21,10 @@ except ImportError as exc:  # pragma: no cover - fail fast if dependency missing
 
 logger = logging.getLogger(__name__)
 
+# Match coverage.py's CLI output which rounds half up to two decimal places.
+# ROUND_HALF_UP ensures we report the same values as the tool's summary.
+QUANT = Decimal("0.01")
+
 if t.TYPE_CHECKING:  # pragma: no cover - import for type hints only
     from pathlib import Path
 
@@ -80,7 +84,7 @@ def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
         return "0.00"
 
     percent = (Decimal(covered) / Decimal(total) * 100).quantize(
-        Decimal("0.01"), rounding=ROUND_HALF_UP
+        QUANT, rounding=ROUND_HALF_UP
     )
     return f"{percent}"
 
@@ -114,6 +118,6 @@ def get_line_coverage_percent_from_lcov(lcov_file: Path) -> str:
         return "0.00"
 
     percent = (Decimal(lines_hit) / Decimal(lines_found) * 100).quantize(
-        Decimal("0.01"), rounding=ROUND_HALF_UP
+        QUANT, rounding=ROUND_HALF_UP
     )
     return f"{percent}"


### PR DESCRIPTION
## Summary
- use `Decimal` arithmetic to round LCOV coverage the same as Cobertura

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68871f92b37483229aa60be1403beb45

## Summary by Sourcery

Replace float-based LCOV coverage percentage calculation with Decimal arithmetic and explicit ROUND_HALF_UP quantization to match Cobertura's rounding and ensure consistent two-decimal formatting.

Bug Fixes:
- Fix LCOV coverage rounding precision by using Decimal.quantize with ROUND_HALF_UP

Enhancements:
- Simplify zero-coverage case to explicitly return "0.00" when no lines are found