### PR TITLE
Add CI workflow for Python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup uv
+        # v6.4.3
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        with:
+          python-version: '3.12'
+      - name: Run tests
+        run: make test
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,13 @@ on:
 
 jobs:
   python-tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup uv
         # v6.4.3
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ MDLINT ?= markdownlint
 NIXIE ?= nixie
 
 test: ## Run tests
+	uv venv
+	uv sync
 	uv run pytest
 
 lint: ## Check test scripts and actions

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ NIXIE ?= nixie
 
 test: ## Run tests
 	uv venv
-	uv sync
+	uv sync --group dev
 	uv run pytest
 
 lint: ## Check test scripts and actions

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ BUILD_JOBS ?=
 MDLINT ?= markdownlint
 NIXIE ?= nixie
 
-test: ## Run tests
-	uv venv
+test: .venv ## Run tests
 	uv sync --group dev
 	uv run pytest
+
+.venv:
+	uv venv
 
 lint: ## Check test scripts and actions
 	uvx ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
+
+[dependency-groups]
+dev = ["pytest"]
+
 [tool.ruff]
 line-length = 88
 
@@ -89,12 +93,6 @@ convention = "numpy"
 asyncio_default_fixture_loop_scope = "function"
 # Tests automatically killed after seconds elapsed
 timeout = 30
-
-[project.optional-dependencies]
-dev = ["pytest"]
-
-[tool.uv.dependency-groups]
-dev = ["default", "dev"]
 
 [tool.uv]
 package = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ authors = [
 ]
 keywords = ["github-actions", "coverage", "testing"]
 dependencies = [
-    "plumbum",
-    "typer",
-    "lxml",
+    "plumbum>=1.8,<2.0",
+    "typer>=0.9,<1.0",
+    "lxml>=5.2,<6.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ authors = [
     {name = "Payton McIntosh", email = "pmcintosh@df12.net"},
 ]
 keywords = ["github-actions", "coverage", "testing"]
+dependencies = [
+    "plumbum",
+    "typer",
+    "lxml",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -84,6 +89,12 @@ convention = "numpy"
 asyncio_default_fixture_loop_scope = "function"
 # Tests automatically killed after seconds elapsed
 timeout = 30
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.uv.dependency-groups]
+dev = ["default", "dev"]
 
 [tool.uv]
 package = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ classifiers = [
 ]
 
 
-[dependency-groups]
-dev = ["pytest"]
-
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9.0",
+]
 [tool.ruff]
 line-length = 88
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ classifiers = [
 ]
 
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=8.0,<9.0",
 ]
+
 [tool.ruff]
 line-length = 88
 


### PR DESCRIPTION
## Summary
- run Python unit tests in CI via `make test`
- setup uv to manage the Python environment

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68871fcd0b608322b33c19af816fd420

## Summary by Sourcery

CI:
- Introduce .github/workflows/ci.yml to execute Python tests via make test with uv setup on pull requests and a nightly cron