### PR TITLE
Fix cargo install failure

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.4
+
+- Force reinstall of `cargo-llvm-cov` so cached binaries don't cause the
+  installation step to fail.
+
 ## v1.3.3 (2025-07-27)
 
 - Install `cargo-llvm-cov` automatically when running Rust coverage and cache the

--- a/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
@@ -13,7 +13,7 @@ from plumbum.commands.processes import ProcessExecutionError
 def main() -> None:
     """Install cargo-llvm-cov via cargo install command."""
     try:
-        cargo["install", "cargo-llvm-cov"]()
+        cargo["install", "cargo-llvm-cov", "--force"]()
         typer.echo("cargo-llvm-cov installed successfully")
     except ProcessExecutionError as exc:
         typer.echo(

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.6
+
+- Overwrite existing `cargo-llvm-cov` installation using `--force` to avoid
+  failures when the binary is restored from cache.
+
 ## v1.0.5
 
 - Round coverage values to two decimals before comparison to avoid failures from

--- a/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
@@ -13,7 +13,7 @@ from plumbum.commands.processes import ProcessExecutionError
 def main() -> None:
     """Install cargo-llvm-cov via cargo install command."""
     try:
-        cargo["install", "cargo-llvm-cov"]()
+        cargo["install", "cargo-llvm-cov", "--force"]()
         typer.echo("cargo-llvm-cov installed successfully")
     except ProcessExecutionError as exc:
         typer.echo(


### PR DESCRIPTION
## Summary
- force reinstall of `cargo-llvm-cov` to avoid cache conflicts
- document the fix in each action's changelog

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68888f7742f4832286da6823feab22da

## Summary by Sourcery

Force reinstall cargo-llvm-cov in GitHub coverage actions to avoid cache conflicts and update action changelogs

Bug Fixes:
- Add --force flag to cargo install in both generate-coverage and ratchet-coverage actions to prevent installation failures due to cached binaries.

Documentation:
- Bump versions and document the force reinstall fix in the CHANGELOG.md for both actions.