### PR TITLE
Add cucumber-rs support to generate-coverage

### DIFF
--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -40,6 +40,9 @@ flowchart TD
 | with-ratchet | Fail if coverage decreases compared to the stored baseline | no | `false` |
 | baseline-rust-file | Path used to persist the Rust coverage baseline | no | `.coverage-baseline.rust` |
 | baseline-python-file | Path used to persist the Python coverage baseline | no | `.coverage-baseline.python` |
+| with-cucumber-rs | Run cucumber-rs scenarios under coverage | no | `false` |
+| cucumber-rs-features | Path to cucumber feature files | no | |
+| cucumber-rs-args | Extra arguments for cucumber | no | |
 
 \* `lcov` is only supported for Rust projects, while `coveragepy` is only supported for Python projects. Mixed projects must use `cobertura`.
 
@@ -95,6 +98,17 @@ Enable ratcheting:
   with:
     output-path: coverage.xml
     with-ratchet: true
+```
+
+Enable cucumber-rs:
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    with-cucumber-rs: true
+    cucumber-rs-features: tests/features
+    cucumber-rs-args: "--tag @ui"
 ```
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -27,6 +27,16 @@ inputs:
     description: Path to store the Python coverage baseline
     required: false
     default: .coverage-baseline.python
+  with-cucumber-rs:
+    description: Run cucumber-rs scenarios under coverage
+    required: false
+    default: "false"
+  cucumber-rs-features:
+    description: Path to cucumber feature files
+    required: false
+  cucumber-rs-args:
+    description: Extra arguments for cucumber
+    required: false
 outputs:
   file:
     description: Path to the generated coverage file
@@ -84,6 +94,10 @@ runs:
       if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
       run: uv run --script "${{ github.action_path }}/scripts/install_cargo_llvm_cov.py"
       shell: bash
+    - name: Install cargo-cucumber
+      if: inputs.with-cucumber-rs == 'true' && (steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed')
+      run: cargo install cargo-cucumber --force
+      shell: bash
     - id: rust
       if: steps.detect.outputs.lang == 'rust' || steps.detect.outputs.lang == 'mixed'
       run: uv run --script "${{ github.action_path }}/scripts/run_rust.py"
@@ -93,6 +107,9 @@ runs:
         INPUT_OUTPUT_PATH: ${{ inputs.output-path }}
         INPUT_FEATURES: ${{ inputs.features }}
         INPUT_WITH_DEFAULT_FEATURES: ${{ inputs.with-default-features }}
+        INPUT_WITH_CUCUMBER_RS: ${{ inputs.with-cucumber-rs }}
+        INPUT_CUCUMBER_RS_FEATURES: ${{ inputs.cucumber-rs-features }}
+        INPUT_CUCUMBER_RS_ARGS: ${{ inputs.cucumber-rs-args }}
       shell: bash
     - name: Ratchet coverage
       if: inputs.with-ratchet == 'true'

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path  # noqa: TC003 - used at runtime
 
@@ -163,7 +164,7 @@ def run_cucumber_rs_coverage(
         cucumber_rs_features,
     ]
     if cucumber_rs_args:
-        c_args += cucumber_rs_args.split()
+        c_args += shlex.split(cucumber_rs_args)
 
     _run_cargo(c_args)
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -165,8 +165,8 @@ def test_run_rust_with_cucumber(tmp_path: Path, shell_stubs: StubManager) -> Non
     gh = tmp_path / "gh.txt"
 
     cuc_file = out.with_name(f"{out.stem}.cucumber{out.suffix}")
-    out.write_text("LF:1\nLH:1\n")
-    cuc_file.write_text("LF:1\nLH:1\n")
+    out.write_text("TN:test\nend_of_record\n")
+    cuc_file.write_text("TN:cuke\nend_of_record\n")
 
     shell_stubs.register("cargo", stdout="Coverage: 100%\n")
 
@@ -208,6 +208,93 @@ def test_run_rust_with_cucumber(tmp_path: Path, shell_stubs: StubManager) -> Non
         "fast",
     ]
     assert calls[1].argv == expected_second
+    assert out.read_text() == "TN:test\nend_of_record\nTN:cuke\nend_of_record\n"
+    assert not cuc_file.exists()
+
+
+def test_run_rust_with_cucumber_cobertura(
+    tmp_path: Path, shell_stubs: StubManager
+) -> None:
+    """Cobertura format merges cucumber coverage using ``merge-cobertura``."""
+    out = tmp_path / "cov.xml"
+    gh = tmp_path / "gh.txt"
+
+    cuc_file = out.with_name(f"{out.stem}.cucumber{out.suffix}")
+    out.write_text("<cov/>")
+    cuc_file.write_text("<cuke/>")
+
+    shell_stubs.register("cargo", stdout="Coverage: 100%\n")
+    shell_stubs.register(
+        "uvx",
+        variants=[{
+            "match": ["merge-cobertura", str(out), str(cuc_file)],
+            "stdout": "<coverage lines-covered='1' lines-valid='1'/>",
+        }],
+    )
+
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(out),
+        "DETECTED_LANG": "rust",
+        "DETECTED_FMT": "cobertura",
+        "INPUT_FEATURES": "",
+        "INPUT_WITH_DEFAULT_FEATURES": "true",
+        "INPUT_WITH_CUCUMBER_RS": "true",
+        "INPUT_CUCUMBER_RS_FEATURES": "tests/features",
+        "INPUT_CUCUMBER_RS_ARGS": "",
+        "GITHUB_OUTPUT": str(gh),
+    }
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_rust.py"
+    res = run_script(script, env)
+    assert res.returncode == 0
+
+    uvx_calls = shell_stubs.calls_of("uvx")
+    assert uvx_calls
+    assert uvx_calls[0].argv == ["merge-cobertura", str(out), str(cuc_file)]
+    assert out.read_text() == "<coverage lines-covered='1' lines-valid='1'/>"
+    assert not cuc_file.exists()
+
+
+def test_run_rust_with_cucumber_cobertura_merge_failure(
+    tmp_path: Path, shell_stubs: StubManager
+) -> None:
+    """Failures from ``merge-cobertura`` exit with its code."""
+    out = tmp_path / "cov.xml"
+    gh = tmp_path / "gh.txt"
+
+    cuc_file = out.with_name(f"{out.stem}.cucumber{out.suffix}")
+    out.write_text("<cov/>")
+    cuc_file.write_text("<cuke/>")
+
+    shell_stubs.register("cargo", stdout="Coverage: 100%\n")
+    shell_stubs.register(
+        "uvx",
+        variants=[{
+            "match": ["merge-cobertura", str(out), str(cuc_file)],
+            "stderr": "oops",
+            "exit_code": 3,
+        }],
+    )
+
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(out),
+        "DETECTED_LANG": "rust",
+        "DETECTED_FMT": "cobertura",
+        "INPUT_FEATURES": "",
+        "INPUT_WITH_DEFAULT_FEATURES": "true",
+        "INPUT_WITH_CUCUMBER_RS": "true",
+        "INPUT_CUCUMBER_RS_FEATURES": "tests/features",
+        "INPUT_CUCUMBER_RS_ARGS": "",
+        "GITHUB_OUTPUT": str(gh),
+    }
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_rust.py"
+    res = run_script(script, env)
+    assert res.returncode == 3
+    assert "merge-cobertura failed" in res.stderr
+    assert cuc_file.exists()
 
 
 def test_run_rust_failure(tmp_path: Path, shell_stubs: StubManager) -> None:


### PR DESCRIPTION
## Summary
- extend `generate-coverage` action to optionally run cucumber-rs scenarios
- install `cargo-cucumber` when requested
- merge cucumber coverage with standard output
- document new inputs and example usage
- test new cucumber options in `run_rust.py`

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6888c262e78c83228f0d5b60d867a5a4

## Summary by Sourcery

Enable cucumber-rs coverage in the generate-coverage action and merge its results with standard Rust coverage

New Features:
- Add flags to trigger cucumber-rs scenarios under coverage and pass feature paths and extra args
- Run a second cargo llvm-cov invocation for cucumber tests and merge its output with the main report
- Install cargo-cucumber when cucumber-rs coverage is enabled

Build:
- Add a CI step to install cargo-cucumber if cucumber-rs coverage is requested

Documentation:
- Document new cucumber-rs inputs in action.yml and README with an example usage

Tests:
- Add a test to verify cucumber-rs coverage is executed and merged in run_rust.py