### PR TITLE
Fix ratchet step order in generate-coverage action

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.5
+
+- Fix ratchet step ordering so coverage is checked after Python results are available.
+
 ## v1.3.4
 
 - Force reinstall of `cargo-llvm-cov` so cached binaries don't cause the

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -94,32 +94,6 @@ runs:
         INPUT_FEATURES: ${{ inputs.features }}
         INPUT_WITH_DEFAULT_FEATURES: ${{ inputs.with-default-features }}
       shell: bash
-    - name: Ratchet coverage
-      if: inputs.with-ratchet == 'true'
-      run: |
-        ratchet() {
-          uv run --script "${{ github.action_path }}/scripts/ratchet_coverage.py" \
-            --baseline-file "$1" \
-            --current "$2"
-        }
-
-        lang="${{ steps.detect.outputs.lang }}"
-        if [[ "$lang" == "rust" || "$lang" == "mixed" ]]; then
-          ratchet "${{ inputs.baseline-rust-file }}" "${{ steps.rust.outputs.percent }}"
-        fi
-        if [[ "$lang" == "python" || "$lang" == "mixed" ]]; then
-          ratchet "${{ inputs.baseline-python-file }}" "${{ steps.python.outputs.percent }}"
-        fi
-      shell: bash
-    - name: Save baselines
-      if: success() && inputs.with-ratchet == 'true'
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ inputs.baseline-rust-file }}
-          ${{ inputs.baseline-python-file }}
-        key: ratchet-baseline-${{ runner.os }}-${{ github.run_id }}
-        restore-keys: ratchet-baseline-${{ runner.os }}-
 
     - name: Cache Python deps
       if: steps.detect.outputs.lang == 'python' || steps.detect.outputs.lang == 'mixed'
@@ -150,6 +124,33 @@ runs:
         PYTHON_FILE: ${{ steps.python.outputs.file }}
         OUTPUT_PATH: ${{ inputs.output-path }}
       shell: bash
+    - name: Ratchet coverage
+      if: inputs.with-ratchet == 'true'
+      run: |
+        ratchet() {
+          uv run --script "${{ github.action_path }}/scripts/ratchet_coverage.py" \
+            --baseline-file "$1" \
+            --current "$2"
+        }
+
+        lang="${{ steps.detect.outputs.lang }}"
+        if [[ "$lang" == "rust" || "$lang" == "mixed" ]]; then
+          ratchet "${{ inputs.baseline-rust-file }}" "${{ steps.rust.outputs.percent }}"
+        fi
+        if [[ "$lang" == "python" || "$lang" == "mixed" ]]; then
+          ratchet "${{ inputs.baseline-python-file }}" "${{ steps.python.outputs.percent }}"
+        fi
+      shell: bash
+    - name: Save baselines
+      if: success() && inputs.with-ratchet == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ inputs.baseline-rust-file }}
+          ${{ inputs.baseline-python-file }}
+        key: ratchet-baseline-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: ratchet-baseline-${{ runner.os }}-
+
     - id: out
       run: uv run --script "${{ github.action_path }}/scripts/set_outputs.py"
       env:

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -49,13 +49,15 @@ runs:
         INPUT_FORMAT: ${{ inputs.format }}
       shell: bash
     - name: Restore baselines
+      id: restore-baselines
       if: inputs.with-ratchet == 'true'
       uses: actions/cache@v4
       with:
         path: |
           ${{ inputs.baseline-rust-file }}
           ${{ inputs.baseline-python-file }}
-        key: ratchet-baseline-${{ runner.os }}
+        key: ratchet-baseline-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: ratchet-baseline-${{ runner.os }}-
     - name: Ensure baseline files
       if: inputs.with-ratchet == 'true'
       run: |
@@ -127,6 +129,7 @@ runs:
     - name: Ratchet coverage
       if: inputs.with-ratchet == 'true'
       run: |
+        set -euo pipefail
         ratchet() {
           uv run --script "${{ github.action_path }}/scripts/ratchet_coverage.py" \
             --baseline-file "$1" \
@@ -142,14 +145,13 @@ runs:
         fi
       shell: bash
     - name: Save baselines
-      if: success() && inputs.with-ratchet == 'true'
+      if: success() && inputs.with-ratchet == 'true' && steps.restore-baselines.outputs.cache-hit != 'true'
       uses: actions/cache@v4
       with:
         path: |
           ${{ inputs.baseline-rust-file }}
           ${{ inputs.baseline-python-file }}
-        key: ratchet-baseline-${{ runner.os }}-${{ github.run_id }}
-        restore-keys: ratchet-baseline-${{ runner.os }}-
+        key: ratchet-baseline-${{ runner.os }}
 
     - id: out
       run: uv run --script "${{ github.action_path }}/scripts/set_outputs.py"


### PR DESCRIPTION
## Summary
- move ratcheting steps after Python coverage so both languages are accounted
- document the fix in the action changelog

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6888c22f31388322b885900b2ee99a9d

## Summary by Sourcery

Fix the ratchet coverage sequence in the generate-coverage GitHub Action to ensure both Rust and Python coverage are ratcheted after results are generated and update the action changelog to v1.3.5.

Bug Fixes:
- Relocate the ratchet and save baselines steps to execute after Python coverage generation

Documentation:
- Add v1.3.5 changelog entry describing the ratchet step ordering fix