### PR TITLE
Fix generate-coverage logging

### DIFF
--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -314,7 +314,8 @@ def test_run_rust_failure(tmp_path: Path, shell_stubs: StubManager) -> None:
     script = Path(__file__).resolve().parents[1] / "scripts" / "run_rust.py"
     res = run_script(script, env)
     assert res.returncode == 2
-    assert "cargo llvm-cov failed" in res.stderr
+    assert "cargo llvm-cov" in res.stderr
+    assert "failed with code 2" in res.stderr
 
 
 def test_merge_cobertura(tmp_path: Path, shell_stubs: StubManager) -> None:


### PR DESCRIPTION
## Summary
- ensure cargo test output streams to the log so failures are visible

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a840188f4832298900083d57b03cd

## Summary by Sourcery

Stream cargo output in the coverage script for real-time visibility and fail logging

Bug Fixes:
- Ensure cargo test output is streamed to the log so failures are visible

Enhancements:
- Switch _run_cargo to use subprocess.Popen and typer.echo for live output
- Remove plumbum-based cargo invocation and ProcessExecutionError import
- Apply minor whitespace and formatting cleanups in generate-coverage script