### PR TITLE
Configure UV cache for repo scripts

### DIFF
--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -53,6 +53,11 @@ runs:
     - name: Setup uv
       # v6.4.3
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      with:
+        cache-dependency-glob: |
+          **/pyproject.toml
+          **/uv.lock
+          **/scripts/*.py
     - id: detect
       run: uv run --script "${{ github.action_path }}/scripts/detect.py"
       env:

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -20,6 +20,10 @@ runs:
       uses: astral-sh/setup-uv@v5
       with:
         uv-version: ">=0.7.19,<0.8.0"
+        cache-dependency-glob: |
+          **/pyproject.toml
+          **/uv.lock
+          **/scripts/*.py
     - name: Restore baseline
       uses: actions/cache@v4
       with:

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -40,6 +40,11 @@ runs:
     - name: Install uv
       # v6.4.3
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      with:
+        cache-dependency-glob: |
+          **/pyproject.toml
+          **/uv.lock
+          **/scripts/*.py
     - name: Install nightly toolchain (needed for OpenBSD cross-compilation)
       if: ${{ inputs.with-openbsd == 'true' && runner.os == 'Linux' }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
         with:
           python-version: '3.12'
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            **/scripts/*.py
       - name: Run tests
         run: make test
         shell: bash


### PR DESCRIPTION
## Summary
- configure `setup-uv` cache key to include repo scripts

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a85035b648322a6301e6f746afe7a

## Summary by Sourcery

Configure the UV setup actions to include repository scripts and lock files in their caching dependencies

Enhancements:
- Add cache-dependency-glob input to include **/pyproject.toml, **/uv.lock, and **/scripts/*.py in the UV cache key for generate-coverage action
- Apply the same cache-dependency-glob changes to setup-rust and ratchet-coverage actions
- Update the CI workflow’s UV setup step to use cache-dependency-glob for scripts and lock file invalidation during caching

CI:
- Enable cache-dependency-glob in .github/workflows/ci.yml for the setup-uv step to include repository scripts and lock files in cache invalidation