### PR TITLE
Fix rust coverage exit handling

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -18,7 +18,6 @@ import typer
 from coverage_parsers import get_line_coverage_percent_from_lcov
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
-
 from shared_utils import read_previous_coverage
 
 try:  # runtime import for graceful fallback
@@ -127,16 +126,6 @@ def _run_cargo(args: list[str]) -> str:
             else:
                 typer.echo(line, err=True, nl=False)
 
-def read_previous(baseline: Path | None) -> str | None:
-    """Return the previously stored coverage percentage if available."""
-    if baseline and baseline.is_file():
-        try:
-            return f"{float(baseline.read_text().strip()):.2f}"
-        except ValueError:
-            return None
-    return None
-
-
     retcode = proc.wait()
     if retcode != 0:
         typer.echo(
@@ -145,6 +134,16 @@ def read_previous(baseline: Path | None) -> str | None:
         )
         raise typer.Exit(code=retcode or 1)
     return "\n".join(stdout_lines)
+
+
+def read_previous(baseline: Path | None) -> str | None:
+    """Return the previously stored coverage percentage if available."""
+    if baseline and baseline.is_file():
+        try:
+            return f"{float(baseline.read_text().strip()):.2f}"
+        except ValueError:
+            return None
+    return None
 
 
 def _merge_lcov(base: Path, extra: Path) -> None:


### PR DESCRIPTION
## Summary
- fix cargo invocation to propagate error codes

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688b5319574c8322a11b30739b5d4b31

## Summary by Sourcery

Fix Rust coverage script to correctly propagate Cargo exit codes by extracting the read_previous helper out of the _run_cargo function.

Bug Fixes:
- Ensure _run_cargo returns Cargo's error code instead of swallowing failures

Enhancements:
- Relocate the read_previous helper to avoid being nested inside _run_cargo