### PR TITLE
Refactor coverage scripts

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -136,16 +136,6 @@ def _run_cargo(args: list[str]) -> str:
     return "\n".join(stdout_lines)
 
 
-def read_previous(baseline: Path | None) -> str | None:
-    """Return the previously stored coverage percentage if available."""
-    if baseline and baseline.is_file():
-        try:
-            return f"{float(baseline.read_text().strip()):.2f}"
-        except ValueError:
-            return None
-    return None
-
-
 def _merge_lcov(base: Path, extra: Path) -> None:
     """Merge two lcov files ensuring they end with ``end_of_record``."""
     try:


### PR DESCRIPTION
## Summary
- remove unused `read_previous` function
- rely on `read_previous_coverage` helper in `shared_utils`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688b5de0590483229b4bcbcd6120a8f8

## Summary by Sourcery

Remove unused read_previous function from coverage scripts and delegate coverage reading to the shared_utils helper.

Enhancements:
- Remove dead read_previous function from run_rust.py
- Rely on read_previous_coverage helper in shared_utils for previous coverage data