### PR TITLE
feat: echo commands in action scripts

### DIFF
--- a/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
@@ -5,6 +5,8 @@
 # ///
 """Install the cargo-llvm-cov tool via ``cargo install``."""
 
+import shlex
+
 import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
@@ -13,7 +15,9 @@ from plumbum.commands.processes import ProcessExecutionError
 def main() -> None:
     """Install cargo-llvm-cov via cargo install command."""
     try:
-        cargo["install", "cargo-llvm-cov", "--force"]()
+        cmd = cargo["install", "cargo-llvm-cov", "--force"]
+        typer.echo(f"$ {shlex.join(cmd.formulate())}")
+        cmd()
         typer.echo("cargo-llvm-cov installed successfully")
     except ProcessExecutionError as exc:
         typer.echo(

--- a/.github/actions/generate-coverage/scripts/merge_cobertura.py
+++ b/.github/actions/generate-coverage/scripts/merge_cobertura.py
@@ -5,6 +5,7 @@
 # ///
 """Merge Cobertura XML files from Rust and Python coverage runs."""
 
+import shlex
 from pathlib import Path
 
 import typer
@@ -35,7 +36,9 @@ def main(
 ) -> None:
     """Merge two cobertura XML files and delete the inputs."""
     try:
-        output = uvx["merge-cobertura", str(rust_file), str(python_file)]()
+        cmd = uvx["merge-cobertura", str(rust_file), str(python_file)]
+        typer.echo(f"$ {shlex.join(cmd.formulate())}")
+        output = cmd()
     except ProcessExecutionError as exc:
         typer.echo(
             f"merge-cobertura failed with code {exc.retcode}: {exc.stderr}",

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import collections.abc as cabc  # noqa: TC003 - used at runtime
 import contextlib
+import shlex
 import typing as t
 from pathlib import Path
 
@@ -50,7 +51,9 @@ def tmp_coveragepy_xml(out: Path) -> cabc.Generator[Path]:
     """Generate a cobertura XML from coverage.py and clean up afterwards."""
     xml_tmp = out.with_suffix(".xml")
     try:
-        python["-m", "coverage", "xml", "-o", str(xml_tmp)]()
+        cmd = python["-m", "coverage", "xml", "-o", str(xml_tmp)]
+        typer.echo(f"$ {shlex.join(cmd.formulate())}")
+        cmd()
     except ProcessExecutionError as exc:
         typer.echo(
             f"coverage xml failed with code {exc.retcode}: {exc.stderr}",
@@ -78,6 +81,7 @@ def main(
 
     cmd = coverage_cmd_for_fmt(fmt, out)
     try:
+        typer.echo(f"$ {shlex.join(cmd.formulate())}")
         cmd & FG
     except ProcessExecutionError as exc:
         raise typer.Exit(code=exc.retcode or 1) from exc

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -106,6 +106,7 @@ def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
 
 def _run_cargo(args: list[str]) -> str:
     """Run ``cargo`` with ``args`` streaming output and return ``stdout``."""
+    typer.echo(f"$ cargo {shlex.join(args)}")
     proc = cargo[args].popen(stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     stdout_lines: list[str] = []
     sel = selectors.DefaultSelector()
@@ -195,7 +196,9 @@ def run_cucumber_rs_coverage(
         from plumbum.cmd import uvx
 
         try:
-            merged = uvx["merge-cobertura", str(out), str(cucumber_file)]()
+            cmd = uvx["merge-cobertura", str(out), str(cucumber_file)]
+            typer.echo(f"$ {shlex.join(cmd.formulate())}")
+            merged = cmd()
         except ProcessExecutionError as exc:
             typer.echo(
                 f"merge-cobertura failed with code {exc.retcode}: {exc.stderr}",

--- a/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
@@ -5,6 +5,8 @@
 # ///
 """Install the cargo-llvm-cov tool via ``cargo install``."""
 
+import shlex
+
 import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
@@ -13,7 +15,9 @@ from plumbum.commands.processes import ProcessExecutionError
 def main() -> None:
     """Install cargo-llvm-cov via cargo install command."""
     try:
-        cargo["install", "cargo-llvm-cov", "--force"]()
+        cmd = cargo["install", "cargo-llvm-cov", "--force"]
+        typer.echo(f"$ {shlex.join(cmd.formulate())}")
+        cmd()
         typer.echo("cargo-llvm-cov installed successfully")
     except ProcessExecutionError as exc:
         typer.echo(

--- a/.github/actions/ratchet-coverage/scripts/run_coverage.py
+++ b/.github/actions/ratchet-coverage/scripts/run_coverage.py
@@ -38,6 +38,7 @@ def main(
     cmd = cargo["llvm-cov", "--summary-only"]
     if args:
         cmd = cmd[shlex.split(args)]
+    typer.echo(f"$ {shlex.join(cmd.formulate())}")
     try:
         retcode, output, err = cmd.run(retcode=None)
     except ProcessExecutionError as exc:  # Should not happen but guard anyway

--- a/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
+++ b/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
@@ -11,6 +11,7 @@ renamed into place so consumers never see a partially copied stdlib.
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 from pathlib import Path  # noqa: TC003
@@ -33,6 +34,7 @@ def main(artifact_dir: Path, nightly_sysroot: Path) -> None:
 
     tmp.mkdir(parents=True, exist_ok=True)
     cmd = ["rsync", "-a", "--delete", f"{artifact_dir}/", str(tmp)]
+    typer.echo(f"$ {shlex.join(cmd)}")
     subprocess.check_call(cmd)  # noqa: S603
 
     if dest.exists():

--- a/docs/python-action-scripts.md
+++ b/docs/python-action-scripts.md
@@ -16,4 +16,6 @@ special comment header understood by uv.
 The [Typer](https://typer.tiangolo.com/) library is used for argument parsing and
 error handling, while [plumbum](https://plumbum.readthedocs.io/) provides simple
 command execution.  By isolating logic in Python, the composite action YAML
-remains minimal and benefits from better readability and testability.
+remains minimal and benefits from better readability and testability. All
+external commands are echoed before execution to aid debugging and
+transparency.


### PR DESCRIPTION
## Summary
- ensure Python helper scripts echo external commands before running them
- document that scripts log the commands they execute

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891112b81508322b4f73eec4169f68c