### PR TITLE
feat: add Windows support to run_rust

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -175,6 +175,7 @@ def _run_cargo(args: list[str]) -> str:
                     stdout_lines.append(line.rstrip("\r\n"))
                 else:
                     typer.echo(line, err=True, nl=False)
+        sel.close()
 
     retcode = proc.wait()
     if retcode != 0:

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -136,16 +136,27 @@ def _run_cargo(args: list[str]) -> str:
 
         threads = [
             threading.Thread(
-                target=pump, args=(proc.stdout,), kwargs={"to_stdout": True}
+                name="cargo-stdout",
+                target=pump,
+                args=(proc.stdout,),
+                kwargs={"to_stdout": True},
+                daemon=True,
             ),
             threading.Thread(
-                target=pump, args=(proc.stderr,), kwargs={"to_stdout": False}
+                name="cargo-stderr",
+                target=pump,
+                args=(proc.stderr,),
+                kwargs={"to_stdout": False},
+                daemon=True,
             ),
         ]
         for thread in threads:
             thread.start()
         for thread in threads:
             thread.join()
+        # Streams are guaranteed non-None by earlier guard.
+        proc.stdout.close()
+        proc.stderr.close()
         if thread_exceptions:
             raise thread_exceptions[0]
     else:

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -126,7 +126,7 @@ def _run_cargo(args: list[str]) -> str:
                 for line in iter(src.readline, ""):
                     if to_stdout:
                         typer.echo(line, nl=False)
-                        stdout_lines.append(line.rstrip("\n"))
+                        stdout_lines.append(line.rstrip("\r\n"))
                     else:
                         typer.echo(line, err=True, nl=False)
             except Exception as exc:  # noqa: BLE001
@@ -161,7 +161,7 @@ def _run_cargo(args: list[str]) -> str:
                     continue
                 if key.data == "stdout":
                     typer.echo(line, nl=False)
-                    stdout_lines.append(line.rstrip("\n"))
+                    stdout_lines.append(line.rstrip("\r\n"))
                 else:
                     typer.echo(line, err=True, nl=False)
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -180,7 +180,7 @@ def test_run_cargo_windows(
 
     class FakeProc:
         def __init__(self) -> None:
-            self.stdout = io.StringIO("out-line\n")
+            self.stdout = io.StringIO("out-line\r\n")
             self.stderr = io.StringIO("err-line\n")
 
         def wait(self) -> int:
@@ -197,7 +197,7 @@ def test_run_cargo_windows(
     monkeypatch.setattr(mod, "cargo", FakeCargo())
     res = mod._run_cargo([])
     captured = capsys.readouterr()
-    assert "out-line\n" in captured.out
+    assert "out-line\r\n" in captured.out
     assert "err-line\n" in captured.err
     assert res == "out-line"
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -237,23 +237,11 @@ def test_run_cargo_windows_nonzero_exit(
 
 
 def test_run_cargo_windows_none_stdout(
-    shell_stubs: StubManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_run_cargo`` fails when stdout is missing on Windows."""
-    script_dir = Path(__file__).resolve().parents[1] / "scripts"
-    monkeypatch.setenv("PATH", shell_stubs.env["PATH"])
-    shell_stubs.register("cargo")
-    monkeypatch.syspath_prepend(script_dir)
-    spec = importlib.util.spec_from_file_location(
-        "run_rust_win", script_dir / "run_rust.py"
-    )
-    mod = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, "run_rust_win", mod)
-    monkeypatch.delitem(sys.modules, "typer", raising=False)
-    monkeypatch.setattr(os, "name", "nt")
-    assert spec.loader is not None
-    spec.loader.exec_module(mod)
+    mod = _load_module(monkeypatch, "run_rust", {"cargo": None})
+    monkeypatch.setattr(mod.os, "name", "nt")
     monkeypatch.setattr(mod.typer, "echo", lambda *a, **k: None)
 
     class FakeProc:
@@ -275,23 +263,11 @@ def test_run_cargo_windows_none_stdout(
 
 
 def test_run_cargo_windows_none_stderr(
-    shell_stubs: StubManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_run_cargo`` fails when stderr is missing on Windows."""
-    script_dir = Path(__file__).resolve().parents[1] / "scripts"
-    monkeypatch.setenv("PATH", shell_stubs.env["PATH"])
-    shell_stubs.register("cargo")
-    monkeypatch.syspath_prepend(script_dir)
-    spec = importlib.util.spec_from_file_location(
-        "run_rust_win", script_dir / "run_rust.py"
-    )
-    mod = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, "run_rust_win", mod)
-    monkeypatch.delitem(sys.modules, "typer", raising=False)
-    monkeypatch.setattr(os, "name", "nt")
-    assert spec.loader is not None
-    spec.loader.exec_module(mod)
+    mod = _load_module(monkeypatch, "run_rust", {"cargo": None})
+    monkeypatch.setattr(mod.os, "name", "nt")
     monkeypatch.setattr(mod.typer, "echo", lambda *a, **k: None)
 
     class FakeProc:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -185,7 +185,7 @@ def test_run_cargo_windows(
     spec.loader.exec_module(mod)
 
     def fake_echo(line: str, *, err: bool = False, nl: bool = True) -> None:
-        print(line, end="" if not nl else "\n", file=sys.stderr if err else sys.stdout)
+        print(line, end="\n" if nl else "", file=sys.stderr if err else sys.stdout)
 
     monkeypatch.setattr(mod.typer, "echo", fake_echo)
     res = mod._run_cargo([])


### PR DESCRIPTION
## Summary
- add threaded Windows handling to run_rust
- cover Windows cargo streaming with tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aba5eb8ac08322a55189f5f875ed32

## Summary by Sourcery

Implement Windows-specific handling in run_rust._run_cargo to stream cargo stdout and stderr via threads, include a pre-check for missing streams, and maintain the selector-based approach for non-Windows platforms; update test setup and add Windows-focused tests for streaming success, non-zero exit codes, and missing stream scenarios.

New Features:
- Enable streaming of cargo stdout and stderr on Windows using threading in run_rust._run_cargo

Enhancements:
- Add a pre-check in run_rust._run_cargo to raise an error if stdout or stderr streams are not captured

Tests:
- Add tests for Windows cargo streaming success, non-zero exit code handling, and missing stdout/stderr errors
- Clear cached coverage_parsers module in test setup to avoid import issues