### PR TITLE
Use shlex.join for cargo error quoting

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -212,7 +212,7 @@ def _run_cargo(args: list[str]) -> str:
     retcode = proc.wait()
     if retcode != 0:
         typer.echo(
-            f"cargo {' '.join(args)} failed with code {retcode}",
+            f"cargo {shlex.join(args)} failed with code {retcode}",
             err=True,
         )
         raise typer.Exit(code=retcode or 1)


### PR DESCRIPTION
## Summary
- use `shlex.join` to quote cargo args in error message

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f0fdfac8322b06492b9f6a9c0db

## Summary by Sourcery

Enhancements:
- Replace manual argument joining with shlex.join to properly quote Cargo command arguments in error messages