### PR TITLE
Fix module path for coverage install script

### DIFF
--- a/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
@@ -5,10 +5,14 @@
 # ///
 """Install the cargo-llvm-cov tool via ``cargo install``."""
 
+import sys
+from pathlib import Path
+
 import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
+sys.path.append(str(Path(__file__).resolve().parents[4]))
 from cmd_utils import run_cmd
 
 


### PR DESCRIPTION
## Summary
- fix cargo llvm cov installation script to import shared `cmd_utils`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68acacce7d4c8322ac550781e3da32eb

## Summary by Sourcery

Bug Fixes:
- Correct the import path in install_cargo_llvm_cov.py to use the shared cmd_utils module.