### PR TITLE
refactor: robust cmd_utils import path

### DIFF
--- a/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
@@ -12,8 +12,24 @@ import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
-sys.path.append(str(Path(__file__).resolve().parents[4]))
-from cmd_utils import run_cmd
+ERROR_REPO_ROOT_NOT_FOUND = "Could not find repository root containing cmd_utils.py"
+ERROR_IMPORT_FAILED = "Failed to import cmd_utils from repository root"
+
+
+def _find_repo_root() -> Path:
+    """Locate the repository root containing ``cmd_utils.py``."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "cmd_utils.py").exists():
+            return parent
+    raise RuntimeError(ERROR_REPO_ROOT_NOT_FOUND)
+
+
+REPO_ROOT = _find_repo_root()
+sys.path.insert(0, str(REPO_ROOT))
+try:
+    from cmd_utils import run_cmd  # noqa: E402,RUF100
+except ModuleNotFoundError as exc:  # pragma: no cover - import-time failure
+    raise RuntimeError(ERROR_IMPORT_FAILED) from exc
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- search for repo root containing cmd_utils.py instead of hard-coded path
- guard cmd_utils import with error handling
- encapsulate repository root discovery in helper function

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68acb58e1158832282067c632558eb96

## Summary by Sourcery

Make cmd_utils import more robust by dynamically locating the repository root and handling import errors

Enhancements:
- Search for the repository root containing cmd_utils.py instead of using a hard-coded path
- Encapsulate repository root discovery in the helper function _find_repo_root
- Prepend the discovered repository root to sys.path before importing cmd_utils
- Guard the import of run_cmd with descriptive error handling on failure