### PR TITLE
refactor: harden cmd utils loader

### DIFF
--- a/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
+++ b/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
@@ -43,7 +43,7 @@ def find_repo_root() -> Path:
     parents = list(Path(__file__).resolve().parents)
     for parent in parents:
         candidate = parent / CMD_UTILS_FILENAME
-        if candidate.is_file():
+        if candidate.is_file() and not candidate.is_symlink():
             return parent
     searched = " -> ".join(str(parent / CMD_UTILS_FILENAME) for parent in parents)
     raise RepoRootNotFoundError(searched)

--- a/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
+++ b/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
@@ -34,18 +34,26 @@ class CmdUtilsImportError(RuntimeError):
         original_exception: Exception | None = None,
     ) -> None:
         detail = f"'{symbol}' not found in {path}" if symbol is not None else str(path)
+        cause = (
+            f" (cause: {type(original_exception).__name__}: {original_exception})"
+            if original_exception
+            else ""
+        )
         self.original_exception = original_exception
-        super().__init__(f"{ERROR_IMPORT_FAILED}: {detail}")
+        super().__init__(f"{ERROR_IMPORT_FAILED}: {detail}{cause}")
 
 
 def find_repo_root() -> Path:
     """Locate the repository root containing ``CMD_UTILS_FILENAME``."""
-    parents = list(Path(__file__).resolve().parents)
+    parents = Path(__file__).resolve().parents
     for parent in parents:
         candidate = parent / CMD_UTILS_FILENAME
         if candidate.is_file() and not candidate.is_symlink():
             return parent
-    searched = " -> ".join(str(parent / CMD_UTILS_FILENAME) for parent in parents)
+    searched = (
+        " -> ".join(str(parent / CMD_UTILS_FILENAME) for parent in parents)
+        + " (symlinks ignored)"
+    )
     raise RepoRootNotFoundError(searched)
 
 

--- a/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
+++ b/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
@@ -20,6 +20,7 @@ class RepoRootNotFoundError(RuntimeError):
     """Repository root not found."""
 
     def __init__(self, searched: str) -> None:
+        self.searched = searched
         super().__init__(f"{ERROR_REPO_ROOT_NOT_FOUND}; searched: {searched}")
 
 
@@ -45,15 +46,13 @@ class CmdUtilsImportError(RuntimeError):
 
 def find_repo_root() -> Path:
     """Locate the repository root containing ``CMD_UTILS_FILENAME``."""
-    parents = Path(__file__).resolve().parents
-    for parent in parents:
+    candidates: list[Path] = []
+    for parent in Path(__file__).resolve().parents:
         candidate = parent / CMD_UTILS_FILENAME
+        candidates.append(candidate)
         if candidate.is_file() and not candidate.is_symlink():
             return parent
-    searched = (
-        " -> ".join(str(parent / CMD_UTILS_FILENAME) for parent in parents)
-        + " (symlinks ignored)"
-    )
+    searched = " -> ".join(str(path) for path in candidates) + " (symlinks ignored)"
     raise RepoRootNotFoundError(searched)
 
 

--- a/.github/actions/generate-coverage/tests/test_cmd_utils_loader.py
+++ b/.github/actions/generate-coverage/tests/test_cmd_utils_loader.py
@@ -44,24 +44,26 @@ def test_find_repo_root_reports_candidates(
     mod = _load_loader(tmp_path, monkeypatch)
     with pytest.raises(mod.RepoRootNotFoundError) as excinfo:
         mod.find_repo_root()
-    msg = str(excinfo.value)
     loader_file = tmp_path / "cmd_utils_loader.py"
     expected = [
         (parent / mod.CMD_UTILS_FILENAME).resolve()
         for parent in loader_file.resolve().parents
     ]
-    chain = " -> ".join(str(path) for path in expected)
-    assert f"searched: {chain} (symlinks ignored)" in msg
+    chain = " -> ".join(str(path) for path in expected) + " (symlinks ignored)"
+    assert excinfo.value.searched == chain
 
 
-def test_find_repo_root_ignores_symlink(
+def test_find_repo_root_ignores_symlink_in_parent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Symlinked ``cmd_utils.py`` files are ignored."""
-    real = tmp_path / "real_cmd_utils.py"
+    """Symlinked ``cmd_utils.py`` files in parent dirs are ignored."""
+    parent = tmp_path
+    child = tmp_path / "child"
+    child.mkdir()
+    real = parent / "real_cmd_utils.py"
     real.write_text("pass")
-    (tmp_path / "cmd_utils.py").symlink_to(real)
-    mod = _load_loader(tmp_path, monkeypatch)
+    (parent / "cmd_utils.py").symlink_to(real)
+    mod = _load_loader(child, monkeypatch)
     with pytest.raises(mod.RepoRootNotFoundError):
         mod.find_repo_root()
 


### PR DESCRIPTION
## Summary
- ensure repo discovery checks regular file and reports all candidates
- surface `cmd_utils` import failures with module path and original exception

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ace665b30c83229a963c699c046717

## Summary by Sourcery

Harden cmd_utils loader by improving repository root discovery and enhancing import error reporting

Enhancements:
- Improve repository root detection to check for regular cmd_utils files across all parent directories and report full candidate paths
- Surface cmd_utils import failures with the module file path and original exception details for better debugging