### PR TITLE
fix: avoid coverage artifact name collisions in matrix jobs

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.7
+
+- Include job identifier and matrix index in the coverage artifact name to
+  avoid collisions in matrix workflows.
+
 ## v1.3.6 (2025-07-28)
 
 - Log the current coverage percentage after each run. When ratcheting is enabled

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -115,4 +115,8 @@ The action prints the current coverage percentage to the log. When
 ``with-ratchet`` is enabled and a baseline file is present, the previous
 percentage is shown as well.
 
+Coverage reports are archived as workflow artifacts named
+``<format>-<job>-<index>`` by default, preventing collisions when the action
+is run in matrix jobs.
+
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -188,7 +188,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ steps.out.outputs.format }}
+        name: ${{ steps.out.outputs.format }}-${{ github.job }}-${{ strategy.job-index }}
         # Fallback to the configured output path when the step that sets
         # outputs didn't run successfully and the file output is empty.
         path: ${{ steps.out.outputs.file || inputs.output-path }}


### PR DESCRIPTION
## Summary
- make coverage artifacts include job id and matrix index to prevent naming collisions
- document artifact naming and update changelog

## Testing
- `make lint`
- `make test`
- `make markdownlint` *(fails: 166 errors, existing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8804815c8322abff9cb207d7a64e

## Summary by Sourcery

Include job and matrix index in coverage artifact names to avoid naming collisions in matrix jobs and update related documentation and changelog

Bug Fixes:
- Prevent coverage artifact naming collisions in matrix workflows by appending job identifier and matrix index to the artifact name

Documentation:
- Update README to describe the new `<format>-<job>-<index>` artifact naming scheme
- Add v1.3.7 entry to CHANGELOG detailing the artifact naming change