### PR TITLE
setup-rust: respect rust-toolchain file

### DIFF
--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,6 +1,14 @@
 
 # Changelog
 
+## v1.0.12 - 2025-07-26
+
+- Honor `.rust-toolchain.toml` when `toolchain` input is omitted, falling back to `stable` if no file exists.
+
+## v1.0.11 - 2025-07-26
+
+- Add `toolchain` input to select Rust toolchain.
+
 ## v1.0.10 - 2025-07-26
 
 - Remove `sccache-action-version` input and pin the sccache step to commit
@@ -51,4 +59,5 @@
 - Document caching requirements, limitations and clarify when caches are saved.
 
 ## v1.0.0 - 2025-06-20
+
 - Initial version.

--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -8,13 +8,14 @@ them, and set up macOS or OpenBSD cross-compilers.
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
+| toolchain | Rust toolchain to install. If omitted, uses `.rust-toolchain.toml` when present, otherwise `stable`. | no | _see description_ |
 | install-postgres-deps | Install PostgreSQL system dependencies | no | `false` |
-| install-sqlite-deps | Install SQLite development libraries (Windows) | no | `false` |
+| install-sqlite-deps | Install SQLite dev libraries (Windows) | no | `false` |
 | use-sccache | Enable sccache for non-release runs | no | `true` |
 | with-darwin | Install macOS cross build toolchain | no | `false` |
 | darwin-sdk-version | macOS SDK version for osxcross | no | `12.3` |
 | with-openbsd | Build OpenBSD std library for cross-compilation | no | `false` |
-| openbsd-nightly | Nightly toolchain version for OpenBSD build | no | `nightly-2025-07-20` |
+| openbsd-nightly | Pinned nightly Rust for OpenBSD | no | `nightly-2025-07-20` |
 
 ## Outputs
 
@@ -25,6 +26,7 @@ None
 ```yaml
 uses: ./.github/actions/setup-rust@v1
   with:
+    toolchain: 'nightly'
     install-postgres-deps: 'true'
     install-sqlite-deps: 'true'
     use-sccache: 'false'
@@ -118,6 +120,5 @@ pinned to a specific commit for reproducibility.
   cache keys.
 - Set `BUILD_PROFILE` consistently across jobs. For most CI runs, `release` is a
   good choice.
-
 
 Release history is available in [CHANGELOG](CHANGELOG.md).

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,6 +1,9 @@
 name: Setup Rust
 description: Install Rust and cache cargo registry
 inputs:
+  toolchain:
+    description: Rust toolchain to install
+    required: false
   install-postgres-deps:
     description: Install PostgreSQL system dependencies
     required: false
@@ -32,7 +35,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install rust
+    - name: Install rust (explicit toolchain)
+      if: ${{ inputs.toolchain != '' }}
+      uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
+      with:
+        override: true
+        toolchain: ${{ inputs.toolchain }}
+        components: rustfmt, clippy, llvm-tools-preview
+    - name: Install rust (auto-detect)
+      if: ${{ inputs.toolchain == '' }}
       uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
       with:
         override: true


### PR DESCRIPTION
## Summary
- allow the `setup-rust` action to honor a `.rust-toolchain.toml` file when `toolchain` input is not supplied
- document the auto-detect behavior for the `toolchain` input

## Testing
- `make lint`
- `make test`
- `make markdownlint` *(fails: line length and formatting issues in existing markdown files)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f4d1e2308322a8a9e333c82ac997