### PR TITLE
Fix markdownlint issues in action documentation

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -48,7 +48,8 @@
 
 ## v1.1.2 (2025-06-25)
 
-- Merge detection and validation into a single step to simplify the workflow, routing the `lang` output directly from the `detect` step.
+- Merge detection and validation into a single step to simplify the workflow,
+  routing the `lang` output directly from the `detect` step.
 - Enable strict mode in the detection step and explicitly use Bash.
 
 ## v1.1.1 (2025-06-24)

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -1,11 +1,11 @@
 # Generate coverage
 
-Run code coverage for Rust projects, Python projects, and mixed Rust + Python projects. The action uses
-`cargo llvm-cov` when a `Cargo.toml` is present and `slipcover` with
-`pytest` when a `pyproject.toml` is present. It installs `slipcover` and
-`pytest` automatically via `uv` before running the tests. When Rust coverage is
-required, `cargo-llvm-cov` is installed automatically as well. If both
-configuration files are present, coverage is run for each language and
+Run code coverage for Rust projects, Python projects, and mixed Rust + Python
+projects. The action uses `cargo llvm-cov` when a `Cargo.toml` is present and
+`slipcover` with `pytest` when a `pyproject.toml` is present. It installs
+`slipcover` and `pytest` automatically via `uv` before running the tests. When
+Rust coverage is required, `cargo-llvm-cov` is installed automatically as well.
+If both configuration files are present, coverage is run for each language and
 the Cobertura reports are merged using `uvx merge-cobertura`.
 
 ## Flow
@@ -33,18 +33,19 @@ flowchart TD
 
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
-| features | Cargo features to enable (Rust). Separate multiple features with spaces or commas. | no | |
+| features | Cargo features to enable; separate with spaces or commas. | no | |
 | with-default-features | Enable default Cargo features (Rust) | no | `true` |
 | output-path | Output file path | yes | |
-| format | Coverage format (`lcov`*, `cobertura` or `coveragepy`*) | no | `cobertura` |
-| with-ratchet | Fail if coverage decreases compared to the stored baseline | no | `false` |
-| baseline-rust-file | Path used to persist the Rust coverage baseline | no | `.coverage-baseline.rust` |
-| baseline-python-file | Path used to persist the Python coverage baseline | no | `.coverage-baseline.python` |
+| format | Formats: `lcov`*, `cobertura`, `coveragepy`* | no | `cobertura` |
+| with-ratchet | Fail if coverage drops below baseline | no | `false` |
+| baseline-rust-file | Rust baseline file path | no | `.coverage-baseline.rust` |
+| baseline-python-file | Py baseline path | no | `.coverage-baseline.python` |
 | with-cucumber-rs | Run cucumber-rs scenarios under coverage | no | `false` |
 | cucumber-rs-features | Path to cucumber feature files | no | |
 | cucumber-rs-args | Extra arguments for cucumber | no | |
 
-\* `lcov` is only supported for Rust projects, while `coveragepy` is only supported for Python projects. Mixed projects must use `cobertura`.
+\* `lcov` is only supported for Rust projects, while `coveragepy` is only
+supported for Python projects. Mixed projects must use `cobertura`.
 
 ## Outputs
 

--- a/.github/actions/ratchet-coverage/CHANGELOG.md
+++ b/.github/actions/ratchet-coverage/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Skip gracefully on non-Linux runners.
 
 ## v1.0.1
+
 - Add the `args` input and include it in the tarpaulin command.
 - Validate numeric coverage values before comparison.
 - Handle integer coverage values in output parsing.

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ## v1.0.10 - 2025-07-26
 
-- Remove `sccache-action-version` input and pin the sccache step to commit
-  `7d986dd989559c6ecdb630a3fd2557667be217ad` for reproducibility.
+- Remove `sccache-action-version` input and pin the sccache step to
+  commit `7d986dd989559c6ecdb630a3fd2557667be217ad` for reproducibility.
 
 ## v1.0.9 - 2025-07-26
 
@@ -51,4 +51,5 @@
 - Document caching requirements, limitations and clarify when caches are saved.
 
 ## v1.0.0 - 2025-06-20
+
 - Initial version.

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -1,50 +1,63 @@
 # Changelog
 
 ## v1.0.0
+
 - Initial version.
 
 ## v1.1.0
+
 - Add `__auto__` default for `path` input and infer file name based on format.
 
 ## v1.2.0
+
 - Cache CodeScene CLI using the version extracted from the installer script.
 
 ## v1.3.0
+
 - Validate installer checksum before execution and reuse the downloaded script
   for version detection.
 
 ## v1.4.0
+
 - Fail when `format` input is not `cobertura` or `lcov`.
 
 ## v1.4.1
+
 - Improved error message when the coverage file is missing.
 - Added restore keys to cache the CLI across minor versions.
 - Removed redundant checksum validation before executing the installer.
 - Reworded README reference to CHANGELOG.
 
 ## v1.4.2
-- Fixed action load failure by removing unsupported `secrets` and `vars` references in `action.yml`.
+
+- Fixed action load failure by removing unsupported `secrets` and `vars`
+  references in `action.yml`.
 - Documented required environment variables and caching usage in the README.
 - Wrapped README lines to 80 columns for consistency.
 
 ## v1.4.5
+
 - Shortened cache description line to avoid exceeding 80 columns.
 
 ## v1.5.0
+
 - Added `access-token` and `installer-checksum` inputs, surfacing required
   variables in the UI.
 - Documented the restore-keys caching pattern and expanded example usage in the
   README.
 
 ## v1.5.1
+
 - Ensure `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` environment variables are
   derived from the corresponding inputs. This prevents action load failures
   caused by unsupported `secrets` or `vars` expressions.
 
 ## v1.5.2
+
 - Remove unsupported `env` block from the `runs` section.
 - Export `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` via a setup step.
 
 ## v1.5.3
+
 - Treat empty `path` input the same as `__auto__` to avoid artifact upload
   failures.


### PR DESCRIPTION
## Summary
- wrap long lines in changelogs and README content
- add missing blank lines around headings and lists

## Testing
- `make markdownlint` (fails: MD041, MD013, and other rules in existing docs)
- `/root/.bun/bin/markdownlint-cli2 .github/actions/generate-coverage/CHANGELOG.md .github/actions/generate-coverage/README.md .github/actions/ratchet-coverage/CHANGELOG.md .github/actions/setup-rust/CHANGELOG.md .github/actions/upload-codescene-coverage/CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68b58082c71c8322b62313b4d9e7593f