### PR TITLE
Cache generate-coverage action script dependencies

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.8
+
+- Cache script dependencies by referencing the action path in the `setup-uv` cache glob.
+
 ## v1.3.7
 
 - Include job identifier and matrix index in the coverage artifact name to

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -57,7 +57,7 @@ runs:
         cache-dependency-glob: |
           **/pyproject.toml
           **/uv.lock
-          **/scripts/*.py
+          ${{ github.action_path }}/**/scripts/*.py
     - id: detect
       run: uv run --script "${{ github.action_path }}/scripts/detect.py"
       env:


### PR DESCRIPTION
## Summary
- ensure generate-coverage action caches scripts by referencing `github.action_path`
- document script caching in changelog

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8760ec5083229781ff187ee95ba3