### PR TITLE
Add RPM packaging coverage to rust-build-release

### DIFF
--- a/.github/actions/rust-build-release/CHANGELOG.md
+++ b/.github/actions/rust-build-release/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add RPM packaging integration test to mirror the Debian coverage.
+
 ## [0.1.0] - 2025-09-10
 
 ### Added

--- a/.github/actions/rust-build-release/CHANGELOG.md
+++ b/.github/actions/rust-build-release/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add RPM packaging integration test to mirror the Debian coverage.
+- Provide shared packaging fixtures and helpers that build the sample project once and produce `.deb` and `.rpm` artefacts for the integration tests.
 
 ## [0.1.0] - 2025-09-10
 

--- a/.github/actions/rust-build-release/scripts/__init__.py
+++ b/.github/actions/rust-build-release/scripts/__init__.py
@@ -14,6 +14,7 @@ class ScriptImportError(ImportError):
     def __init__(self, module: str, package_path: Path) -> None:
         super().__init__(f"Unable to load module {module!r} from {package_path}")
 
+
 __all__ = ["load_sibling"]
 
 _PACKAGE_NAME = __name__

--- a/.github/actions/rust-build-release/scripts/package.py
+++ b/.github/actions/rust-build-release/scripts/package.py
@@ -149,13 +149,17 @@ def ensure_gz(src: Path, dst_dir: Path) -> Path:
         return src
     ensure_directory(dst_dir)
     gz_path = dst_dir / f"{src.name}.gz"
-    with src.open("rb") as fin, gz_path.open("wb") as fout, gzip.GzipFile(
-        filename="",
-        fileobj=fout,
-        mode="wb",
-        mtime=0,
-        compresslevel=9,
-    ) as gz:
+    with (
+        src.open("rb") as fin,
+        gz_path.open("wb") as fout,
+        gzip.GzipFile(
+            filename="",
+            fileobj=fout,
+            mode="wb",
+            mtime=0,
+            compresslevel=9,
+        ) as gz,
+    ):
         gz.write(fin.read())
     return gz_path
 
@@ -216,9 +220,7 @@ def build_man_entries(
 
 
 NAME_OPTION = typer.Option(..., "--name", help="Package name.")
-BIN_NAME_OPTION = typer.Option(
-    ..., "--bin-name", help="Installed binary name."
-)
+BIN_NAME_OPTION = typer.Option(..., "--bin-name", help="Installed binary name.")
 TARGET_OPTION = typer.Option(
     "x86_64-unknown-linux-gnu",
     "--target",
@@ -236,16 +238,12 @@ FORMATS_OPTION = typer.Option(
     "--formats",
     help="Comma-separated list: deb,rpm,apk,archlinux,ipk,srpm",
 )
-OUTDIR_OPTION = typer.Option(
-    Path("dist"), "--outdir", help="Where to place packages."
-)
+OUTDIR_OPTION = typer.Option(Path("dist"), "--outdir", help="Where to place packages.")
 MAINTAINER_OPTION = typer.Option("Your Name <you@example.com>", "--maintainer")
 HOMEPAGE_OPTION = typer.Option("https://example.com", "--homepage")
 LICENSE_OPTION = typer.Option("MIT", "--license")
 SECTION_OPTION = typer.Option("utils", "--section")
-DESCRIPTION_OPTION = typer.Option(
-    "A fast toy app written in Rust.", "--description"
-)
+DESCRIPTION_OPTION = typer.Option("A fast toy app written in Rust.", "--description")
 DEB_DEPENDS_OPTION = typer.Option(
     None, "--deb-depends", help="Repeatable. Debian runtime deps."
 )

--- a/.github/actions/rust-build-release/tests/_packaging_utils.py
+++ b/.github/actions/rust-build-release/tests/_packaging_utils.py
@@ -1,0 +1,52 @@
+"""Utility helpers shared by the packaging integration tests."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from plumbum import local
+
+from cmd_utils import run_cmd
+
+
+def polythene_cmd(polythene: Path, *args: str) -> str:
+    """Execute ``polythene`` with ``uv run`` and return its output."""
+
+    return run_cmd(local["uv"]["run", polythene.as_posix(), *args])
+
+
+def polythene_exec(polythene: Path, uid: str, store: str, *cmd: str) -> str:
+    """Run a command inside the exported rootfs identified by ``uid``."""
+
+    return polythene_cmd(polythene, "exec", uid, "--store", store, "--", *cmd)
+
+
+def ensure_nfpm(project_dir: Path, version: str = "v2.39.0") -> None:
+    """Download and place ``nfpm`` on ``PATH`` if it is not already available."""
+
+    if shutil.which("nfpm") is not None:
+        return
+
+    host = run_cmd(local["uname"]["-m"]).strip()
+    arch_map = {"x86_64": "x86_64", "aarch64": "arm64"}
+    asset_arch = arch_map.get(host, "x86_64")
+    base_url = "https://github.com/goreleaser/nfpm/releases/download/"
+    url = f"{base_url}{version}/nfpm_{version[1:]}_Linux_{asset_arch}.tar.gz"
+    tools_dir = project_dir / "dist" / ".tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as td:
+        tarball = Path(td) / "nfpm.tgz"
+        run_cmd(local["curl"]["-sSL", url, "-o", tarball])
+        run_cmd(local["tar"]["-xzf", tarball, "-C", td, "nfpm"])
+        run_cmd(local["install"]["-m", "0755", Path(td) / "nfpm", tools_dir / "nfpm"])
+
+    path = os.environ.get("PATH", "")
+    prefix = f"{tools_dir.as_posix()}:"
+    if not path.startswith(prefix):
+        os.environ["PATH"] = f"{prefix}{path}"
+
+
+__all__ = ["ensure_nfpm", "polythene_cmd", "polythene_exec"]

--- a/.github/actions/rust-build-release/tests/_packaging_utils.py
+++ b/.github/actions/rust-build-release/tests/_packaging_utils.py
@@ -2,14 +2,42 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import tempfile
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 from plumbum import local
+from plumbum.commands.processes import ProcessExecutionError
 
 from cmd_utils import run_cmd
+
+
+@dataclass(slots=True)
+class PolytheneRootfs:
+    """Descriptor for an exported polythene root filesystem."""
+
+    polythene: Path
+    uid: str
+    store: Path
+
+    def exec(self, *cmd: str) -> str:
+        """Execute ``cmd`` inside the rootfs via polythene."""
+
+        return polythene_exec(self.polythene, self.uid, self.store.as_posix(), *cmd)
+
+    @property
+    def root(self) -> Path:
+        """Filesystem path to the exported root."""
+
+        return self.store / self.uid
+
+
+class IsolationUnavailableError(RuntimeError):
+    """Raised when container isolation cannot be established."""
 
 
 def polythene_cmd(polythene: Path, *args: str) -> str:
@@ -24,10 +52,30 @@ def polythene_exec(polythene: Path, uid: str, store: str, *cmd: str) -> str:
     return polythene_cmd(polythene, "exec", uid, "--store", store, "--", *cmd)
 
 
-def ensure_nfpm(project_dir: Path, version: str = "v2.39.0") -> None:
-    """Download and place ``nfpm`` on ``PATH`` if it is not already available."""
+@contextlib.contextmanager
+def polythene_rootfs(polythene: Path, image: str) -> Iterator[PolytheneRootfs]:
+    """Yield an exported rootfs for ``image`` or raise ``IsolationUnavailableError``."""
 
-    if shutil.which("nfpm") is not None:
+    with tempfile.TemporaryDirectory() as store:
+        try:
+            pull_output = polythene_cmd(polythene, "pull", image, "--store", store)
+        except ProcessExecutionError as exc:  # pragma: no cover - exercised in CI only
+            raise IsolationUnavailableError(str(exc)) from exc
+        uid = pull_output.splitlines()[-1].strip()
+        try:
+            polythene_exec(polythene, uid, store, "true")
+        except ProcessExecutionError as exc:  # pragma: no cover - exercised in CI only
+            raise IsolationUnavailableError(str(exc)) from exc
+        yield PolytheneRootfs(polythene=polythene, uid=uid, store=Path(store))
+
+
+@contextlib.contextmanager
+def ensure_nfpm(project_dir: Path, version: str = "v2.39.0") -> Iterator[Path]:
+    """Ensure ``nfpm`` is available on ``PATH`` for the duration of the context."""
+
+    existing = shutil.which("nfpm")
+    if existing is not None:
+        yield Path(existing)
         return
 
     host = run_cmd(local["uname"]["-m"]).strip()
@@ -37,16 +85,31 @@ def ensure_nfpm(project_dir: Path, version: str = "v2.39.0") -> None:
     url = f"{base_url}{version}/nfpm_{version[1:]}_Linux_{asset_arch}.tar.gz"
     tools_dir = project_dir / "dist" / ".tools"
     tools_dir.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory() as td:
-        tarball = Path(td) / "nfpm.tgz"
-        run_cmd(local["curl"]["-sSL", url, "-o", tarball])
-        run_cmd(local["tar"]["-xzf", tarball, "-C", td, "nfpm"])
-        run_cmd(local["install"]["-m", "0755", Path(td) / "nfpm", tools_dir / "nfpm"])
+    nfpm_path = tools_dir / "nfpm"
+    if not nfpm_path.exists():
+        with tempfile.TemporaryDirectory() as td:
+            tarball = Path(td) / "nfpm.tgz"
+            run_cmd(local["curl"]["-sSL", url, "-o", tarball])
+            run_cmd(local["tar"]["-xzf", tarball, "-C", td, "nfpm"])
+            run_cmd(local["install"]["-m", "0755", Path(td) / "nfpm", nfpm_path])
 
-    path = os.environ.get("PATH", "")
-    prefix = f"{tools_dir.as_posix()}:"
-    if not path.startswith(prefix):
-        os.environ["PATH"] = f"{prefix}{path}"
+    original_path = os.environ.get("PATH")
+    prefix = tools_dir.as_posix()
+    os.environ["PATH"] = f"{prefix}:{original_path}" if original_path else prefix
+    try:
+        yield nfpm_path
+    finally:
+        if original_path is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = original_path
 
 
-__all__ = ["ensure_nfpm", "polythene_cmd", "polythene_exec"]
+__all__ = [
+    "IsolationUnavailableError",
+    "PolytheneRootfs",
+    "ensure_nfpm",
+    "polythene_cmd",
+    "polythene_exec",
+    "polythene_rootfs",
+]

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -2,24 +2,25 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Iterator, Mapping
+import typing as typ
 
 import pytest
-
 from _packaging_utils import (
+    DEFAULT_CONFIG,
+    DEFAULT_TARGET,
     BuildArtifacts,
     PackagingConfig,
     PackagingProject,
-    DEFAULT_CONFIG,
-    DEFAULT_TARGET,
     build_release_artifacts,
     package_project,
     packaging_project,
 )
 
+if typ.TYPE_CHECKING:
+    from pathlib import Path
 
-IteratorNone = Iterator[None]
+
+IteratorNone = typ.Iterator[None]
 
 
 @pytest.fixture
@@ -27,7 +28,6 @@ def uncapture_if_verbose(
     request: pytest.FixtureRequest, capfd: pytest.CaptureFixture[str]
 ) -> IteratorNone:
     """Disable output capture when pytest runs with ``-v`` or higher verbosity."""
-
     if request.config.get_verbosity() > 0:
         with capfd.disabled():
             yield
@@ -38,21 +38,18 @@ def uncapture_if_verbose(
 @pytest.fixture(scope="module")
 def packaging_config() -> PackagingConfig:
     """Return the static metadata for the sample packaging project."""
-
     return DEFAULT_CONFIG
 
 
 @pytest.fixture(scope="module")
 def packaging_target() -> str:
     """Return the Rust target triple used in integration tests."""
-
     return DEFAULT_TARGET
 
 
 @pytest.fixture(scope="module")
 def packaging_project_paths() -> PackagingProject:
     """Resolve the filesystem layout for packaging integration tests."""
-
     return packaging_project()
 
 
@@ -63,7 +60,6 @@ def build_artifacts(
     packaging_config: PackagingConfig,
 ) -> BuildArtifacts:
     """Ensure the sample project is built for the requested target."""
-
     return build_release_artifacts(
         packaging_project_paths,
         packaging_target,
@@ -76,13 +72,11 @@ def packaged_artifacts(
     packaging_project_paths: PackagingProject,
     build_artifacts: BuildArtifacts,
     packaging_config: PackagingConfig,
-) -> Mapping[str, Path]:
+) -> typ.Mapping[str, Path]:
     """Package the built project as both .deb and .rpm artefacts."""
-
     return package_project(
         packaging_project_paths,
         build_artifacts,
         config=packaging_config,
         formats=("deb", "rpm"),
     )
-

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
-import typing as typ
+from pathlib import Path
+from typing import Iterator, Mapping
 
 import pytest
 
-IteratorNone = typ.Iterator[None]
+from _packaging_utils import (
+    BuildArtifacts,
+    PackagingConfig,
+    PackagingProject,
+    DEFAULT_CONFIG,
+    DEFAULT_TARGET,
+    build_release_artifacts,
+    package_project,
+    packaging_project,
+)
+
+
+IteratorNone = Iterator[None]
 
 
 @pytest.fixture
@@ -14,8 +27,62 @@ def uncapture_if_verbose(
     request: pytest.FixtureRequest, capfd: pytest.CaptureFixture[str]
 ) -> IteratorNone:
     """Disable output capture when pytest runs with ``-v`` or higher verbosity."""
+
     if request.config.get_verbosity() > 0:
         with capfd.disabled():
             yield
     else:
         yield
+
+
+@pytest.fixture(scope="module")
+def packaging_config() -> PackagingConfig:
+    """Return the static metadata for the sample packaging project."""
+
+    return DEFAULT_CONFIG
+
+
+@pytest.fixture(scope="module")
+def packaging_target() -> str:
+    """Return the Rust target triple used in integration tests."""
+
+    return DEFAULT_TARGET
+
+
+@pytest.fixture(scope="module")
+def packaging_project_paths() -> PackagingProject:
+    """Resolve the filesystem layout for packaging integration tests."""
+
+    return packaging_project()
+
+
+@pytest.fixture(scope="module")
+def build_artifacts(
+    packaging_project_paths: PackagingProject,
+    packaging_target: str,
+    packaging_config: PackagingConfig,
+) -> BuildArtifacts:
+    """Ensure the sample project is built for the requested target."""
+
+    return build_release_artifacts(
+        packaging_project_paths,
+        packaging_target,
+        config=packaging_config,
+    )
+
+
+@pytest.fixture(scope="module")
+def packaged_artifacts(
+    packaging_project_paths: PackagingProject,
+    build_artifacts: BuildArtifacts,
+    packaging_config: PackagingConfig,
+) -> Mapping[str, Path]:
+    """Package the built project as both .deb and .rpm artefacts."""
+
+    return package_project(
+        packaging_project_paths,
+        build_artifacts,
+        config=packaging_config,
+        formats=("deb", "rpm"),
+    )
+

--- a/.github/actions/rust-build-release/tests/test_deb_package.py
+++ b/.github/actions/rust-build-release/tests/test_deb_package.py
@@ -6,13 +6,10 @@ import contextlib
 import shutil
 import sys
 import tempfile
-from collections.abc import Mapping
+import typing as typ
 from pathlib import Path
 
 import pytest
-from plumbum import local
-
-from cmd_utils import run_cmd
 from _packaging_utils import (
     BuildArtifacts,
     IsolationUnavailableError,
@@ -20,6 +17,9 @@ from _packaging_utils import (
     deb_arch_for_target,
     polythene_rootfs,
 )
+from plumbum import local
+
+from cmd_utils import run_cmd
 
 
 @pytest.mark.usefixtures("uncapture_if_verbose")
@@ -33,10 +33,9 @@ from _packaging_utils import (
 def test_deb_package_installs(
     packaging_project_paths: PackagingProject,
     build_artifacts: BuildArtifacts,
-    packaged_artifacts: Mapping[str, Path],
+    packaged_artifacts: typ.Mapping[str, Path],
 ) -> None:
     """Build the .deb, install in an isolated rootfs, and verify binary and man page."""
-
     polythene = packaging_project_paths.polythene_script
     deb = packaged_artifacts.get("deb")
     assert deb is not None, "expected Debian package to be built"
@@ -53,9 +52,7 @@ def test_deb_package_installs(
             assert "Package: rust-toy-app" in control_txt
             assert f"Architecture: {deb_arch}" in control_txt
     try:
-        with polythene_rootfs(
-            polythene, "docker.io/library/debian:bookworm"
-        ) as rootfs:
+        with polythene_rootfs(polythene, "docker.io/library/debian:bookworm") as rootfs:
             shutil.copy(deb, rootfs.root / deb.name)
             rootfs.exec("dpkg", "-i", deb.name)
             try:

--- a/.github/actions/rust-build-release/tests/test_deb_package.py
+++ b/.github/actions/rust-build-release/tests/test_deb_package.py
@@ -6,6 +6,7 @@ import contextlib
 import shutil
 import sys
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -13,33 +14,12 @@ from plumbum import local
 
 from cmd_utils import run_cmd
 from _packaging_utils import (
+    BuildArtifacts,
     IsolationUnavailableError,
-    ensure_nfpm,
+    PackagingProject,
+    deb_arch_for_target,
     polythene_rootfs,
 )
-
-sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
-from script_utils import unique_match
-
-def deb_arch_for_target(target: str) -> str:
-    """Return the nfpm architecture label for *target*.
-
-    Parameters
-    ----------
-    target : str
-        Rust target triple used for the build.
-
-    Returns
-    -------
-    str
-        Architecture token recognised by nfpm.
-    """
-    lowered = target.lower()
-    if lowered.startswith(("x86_64-", "x86_64_")):
-        return "amd64"
-    if lowered.startswith(("aarch64-", "arm64-")):
-        return "arm64"
-    return "amd64"
 
 
 @pytest.mark.usefixtures("uncapture_if_verbose")
@@ -50,80 +30,44 @@ def deb_arch_for_target(target: str) -> str:
     or shutil.which("uv") is None,
     reason="dpkg-deb, podman or uv not available",
 )
-def test_deb_package_installs() -> None:
+def test_deb_package_installs(
+    packaging_project_paths: PackagingProject,
+    build_artifacts: BuildArtifacts,
+    packaged_artifacts: Mapping[str, Path],
+) -> None:
     """Build the .deb, install in an isolated rootfs, and verify binary and man page."""
-    project_dir = Path(__file__).resolve().parents[4] / "rust-toy-app"
-    build_script = Path(__file__).resolve().parents[1] / "src" / "main.py"
-    pkg_script = Path(__file__).resolve().parents[1] / "scripts" / "package.py"
-    polythene = Path(__file__).resolve().parents[1] / "scripts" / "polythene.py"
-    target = "x86_64-unknown-linux-gnu"
-    with local.cwd(project_dir):
-        run_cmd(
-            local["rustup"][
-                "toolchain",
-                "install",
-                "1.89.0",
-                "--profile",
-                "minimal",
-                "--no-self-update",
-            ]
+
+    polythene = packaging_project_paths.polythene_script
+    deb = packaged_artifacts.get("deb")
+    assert deb is not None, "expected Debian package to be built"
+    deb_arch = deb_arch_for_target(build_artifacts.target)
+    with tempfile.TemporaryDirectory() as td:
+        run_cmd(local["dpkg-deb"]["-x", str(deb), td])
+        bin_extracted = Path(td, "usr/bin/rust-toy-app")
+        man_extracted = Path(td, "usr/share/man/man1/rust-toy-app.1.gz")
+        assert bin_extracted.is_file()
+        assert man_extracted.is_file()
+        with tempfile.TemporaryDirectory() as cd:
+            run_cmd(local["dpkg-deb"]["-e", str(deb), cd])
+            control_txt = Path(cd, "control").read_text(encoding="utf-8")
+            assert "Package: rust-toy-app" in control_txt
+            assert f"Architecture: {deb_arch}" in control_txt
+    try:
+        with polythene_rootfs(
+            polythene, "docker.io/library/debian:bookworm"
+        ) as rootfs:
+            shutil.copy(deb, rootfs.root / deb.name)
+            rootfs.exec("dpkg", "-i", deb.name)
+            try:
+                rootfs.exec("test", "-x", "/usr/bin/rust-toy-app")
+                rootfs.exec("test", "-f", "/usr/share/man/man1/rust-toy-app.1.gz")
+                result = rootfs.exec("/usr/bin/rust-toy-app")
+                assert "Hello, world!" in result, f"unexpected output: {result!r}"
+            finally:
+                with contextlib.suppress(Exception):
+                    rootfs.exec("dpkg", "-r", "rust-toy-app")
+    except IsolationUnavailableError as exc:
+        pytest.skip(
+            "podman-based isolation unavailable (polythene exec failed). "
+            f"Ensure rootless Podman is installed and operational. Details: {exc}"
         )
-        with local.env(CROSS_CONTAINER_ENGINE="podman"):
-            run_cmd(local[sys.executable][build_script.as_posix(), target])
-        man_src = unique_match(
-            project_dir.glob(
-                f"target/{target}/release/build/rust-toy-app-*/out/rust-toy-app.1"
-            ),
-            description="rust-toy-app man page",
-        )
-        with ensure_nfpm(project_dir):
-            run_cmd(
-                local["uv"][
-                    "run",
-                    pkg_script.as_posix(),
-                    "--name",
-                    "rust-toy-app",
-                    "--bin-name",
-                    "rust-toy-app",
-                    "--target",
-                    target,
-                    "--version",
-                    "0.1.0",
-                    "--formats",
-                    "deb",
-                    "--man",
-                    man_src.as_posix(),
-                ]
-            )
-        deb_arch = deb_arch_for_target(target)
-        deb = project_dir / f"dist/rust-toy-app_0.1.0-1_{deb_arch}.deb"
-        with tempfile.TemporaryDirectory() as td:
-            run_cmd(local["dpkg-deb"]["-x", str(deb), td])
-            bin_extracted = Path(td, "usr/bin/rust-toy-app")
-            man_extracted = Path(td, "usr/share/man/man1/rust-toy-app.1.gz")
-            assert bin_extracted.is_file()
-            assert man_extracted.is_file()
-            with tempfile.TemporaryDirectory() as cd:
-                run_cmd(local["dpkg-deb"]["-e", str(deb), cd])
-                control_txt = Path(cd, "control").read_text(encoding="utf-8")
-                assert "Package: rust-toy-app" in control_txt
-                assert f"Architecture: {deb_arch}" in control_txt
-        try:
-            with polythene_rootfs(
-                polythene, "docker.io/library/debian:bookworm"
-            ) as rootfs:
-                shutil.copy(deb, rootfs.root / deb.name)
-                rootfs.exec("dpkg", "-i", deb.name)
-                try:
-                    rootfs.exec("test", "-x", "/usr/bin/rust-toy-app")
-                    rootfs.exec("test", "-f", "/usr/share/man/man1/rust-toy-app.1.gz")
-                    result = rootfs.exec("/usr/bin/rust-toy-app")
-                    assert "Hello, world!" in result, f"unexpected output: {result!r}"
-                finally:
-                    with contextlib.suppress(Exception):
-                        rootfs.exec("dpkg", "-r", "rust-toy-app")
-        except IsolationUnavailableError as exc:
-            pytest.skip(
-                "podman-based isolation unavailable (polythene exec failed). "
-                f"Ensure rootless Podman is installed and operational. Details: {exc}"
-            )

--- a/.github/actions/rust-build-release/tests/test_deb_package.py
+++ b/.github/actions/rust-build-release/tests/test_deb_package.py
@@ -106,7 +106,7 @@ def test_deb_package_installs() -> None:
                 run_cmd(local["dpkg-deb"]["-e", str(deb), cd])
                 control_txt = Path(cd, "control").read_text(encoding="utf-8")
                 assert "Package: rust-toy-app" in control_txt
-                assert "Architecture: amd64" in control_txt
+                assert f"Architecture: {deb_arch}" in control_txt
         try:
             with polythene_rootfs(
                 polythene, "docker.io/library/debian:bookworm"

--- a/.github/actions/rust-build-release/tests/test_deb_package.py
+++ b/.github/actions/rust-build-release/tests/test_deb_package.py
@@ -46,8 +46,9 @@ def deb_arch_for_target(target: str) -> str:
 @pytest.mark.skipif(
     sys.platform == "win32"
     or shutil.which("dpkg-deb") is None
-    or shutil.which("podman") is None,
-    reason="dpkg-deb or podman not available",
+    or shutil.which("podman") is None
+    or shutil.which("uv") is None,
+    reason="dpkg-deb, podman or uv not available",
 )
 def test_deb_package_installs() -> None:
     """Build the .deb, install in an isolated rootfs, and verify binary and man page."""

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 import re
 import shutil
 import sys
-from collections.abc import Mapping
-from pathlib import Path
+import typing as typ
 
 import pytest
-
 from _packaging_utils import (
     IsolationUnavailableError,
     PackagingProject,
     polythene_rootfs,
 )
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
 
 RPM_BASE_IMAGE = "docker.io/library/rockylinux:9"
 
@@ -38,10 +39,9 @@ def _parse_rpm_info(output: str) -> dict[str, str]:
 )
 def test_rpm_package_metadata(
     packaging_project_paths: PackagingProject,
-    packaged_artifacts: Mapping[str, Path],
+    packaged_artifacts: typ.Mapping[str, Path],
 ) -> None:
     """Build the .rpm package and inspect its metadata inside an isolated rootfs."""
-
     rpm_package_path = packaged_artifacts.get("rpm")
     assert rpm_package_path is not None, "expected RPM package to be built"
 
@@ -60,7 +60,9 @@ def test_rpm_package_metadata(
             assert arch_value in {"amd64", "x86_64", "arm64", "aarch64"}, arch_value
 
             listing_output = rootfs.exec("rpm", "-qlp", rpm_package_path.name)
-            listing = {line.strip() for line in listing_output.splitlines() if line.strip()}
+            listing = {
+                line.strip() for line in listing_output.splitlines() if line.strip()
+            }
             assert "/usr/bin/rust-toy-app" in listing
             assert "/usr/share/man/man1/rust-toy-app.1.gz" in listing
     except IsolationUnavailableError as exc:

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -145,7 +145,7 @@ def test_rpm_package_metadata(
             release_value = info.get("Release", "")
             assert release_value.startswith("1"), release_value
             arch_value = info.get("Architecture")
-            assert arch_value in {"amd64", "x86_64", "arm64", "aarch64"}, arch_value
+            assert arch_value == "x86_64", arch_value
 
             listing_output = rootfs.exec("rpm", "-qlp", rpm_package_path.name)
             listing = {line.strip() for line in listing_output.splitlines() if line.strip()}

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -1,25 +1,21 @@
+"""Integration test covering RPM packaging with polythene isolation."""
+
 from __future__ import annotations
 
+import re
 import shutil
 import sys
-import re
-from dataclasses import dataclass
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
-from plumbum import local
 
-from cmd_utils import run_cmd
 from _packaging_utils import (
     IsolationUnavailableError,
-    ensure_nfpm,
+    PackagingProject,
     polythene_rootfs,
 )
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
-from script_utils import unique_match  # noqa: E402
-
-RPM_TARGET = "x86_64-unknown-linux-gnu"
 RPM_BASE_IMAGE = "docker.io/library/rockylinux:9"
 
 
@@ -33,98 +29,6 @@ def _parse_rpm_info(output: str) -> dict[str, str]:
     return info
 
 
-@dataclass(frozen=True)
-class PackagingPaths:
-    """Resolved filesystem paths required for packaging tests."""
-
-    project_dir: Path
-    build_script: Path
-    package_script: Path
-    polythene_script: Path
-
-
-@pytest.fixture(scope="module")
-def packaging_paths() -> PackagingPaths:
-    """Return the filesystem layout for the packaging fixtures."""
-
-    test_file = Path(__file__).resolve()
-    tests_root = test_file.parents[1]
-    project_dir = test_file.parents[4] / "rust-toy-app"
-    return PackagingPaths(
-        project_dir=project_dir,
-        build_script=tests_root / "src" / "main.py",
-        package_script=tests_root / "scripts" / "package.py",
-        polythene_script=tests_root / "scripts" / "polythene.py",
-    )
-
-
-@pytest.fixture(scope="module")
-def built_artifacts(packaging_paths: PackagingPaths) -> tuple[str, Path]:
-    """Compile the Rust project and return the build target and man page path."""
-
-    target = RPM_TARGET
-    project_dir = packaging_paths.project_dir
-    with local.cwd(project_dir):
-        run_cmd(
-            local["rustup"][
-                "toolchain",
-                "install",
-                "1.89.0",
-                "--profile",
-                "minimal",
-                "--no-self-update",
-            ]
-        )
-        with local.env(CROSS_CONTAINER_ENGINE="podman"):
-            run_cmd(local[sys.executable][packaging_paths.build_script.as_posix(), target])
-        man_src = unique_match(
-            project_dir.glob(
-                f"target/{target}/release/build/rust-toy-app-*/out/rust-toy-app.1"
-            ),
-            description="rust-toy-app man page",
-        )
-    return target, man_src
-
-
-@pytest.fixture(scope="module")
-def rpm_package_path(
-    packaging_paths: PackagingPaths, built_artifacts: tuple[str, Path]
-) -> Path:
-    """Package the project as an RPM and return the artifact path."""
-
-    target, man_src = built_artifacts
-    project_dir = packaging_paths.project_dir
-    with local.cwd(project_dir):
-        dist_dir = project_dir / "dist"
-        if dist_dir.exists():
-            for existing in dist_dir.glob("rust-toy-app-0.1.0-1*.rpm"):
-                existing.unlink()
-        with ensure_nfpm(project_dir):
-            run_cmd(
-                local["uv"][
-                    "run",
-                    packaging_paths.package_script.as_posix(),
-                    "--name",
-                    "rust-toy-app",
-                    "--bin-name",
-                    "rust-toy-app",
-                    "--target",
-                    target,
-                    "--version",
-                    "0.1.0",
-                    "--formats",
-                    "rpm",
-                    "--man",
-                    man_src.as_posix(),
-                ]
-            )
-        rpm_path = unique_match(
-            project_dir.glob("dist/rust-toy-app-0.1.0-1*.rpm"),
-            description="rust-toy-app rpm",
-        )
-    return rpm_path
-
-
 @pytest.mark.usefixtures("uncapture_if_verbose")
 @pytest.mark.skipif(
     sys.platform == "win32"
@@ -133,12 +37,17 @@ def rpm_package_path(
     reason="podman or uv not available",
 )
 def test_rpm_package_metadata(
-    packaging_paths: PackagingPaths, rpm_package_path: Path
+    packaging_project_paths: PackagingProject,
+    packaged_artifacts: Mapping[str, Path],
 ) -> None:
     """Build the .rpm package and inspect its metadata inside an isolated rootfs."""
+
+    rpm_package_path = packaged_artifacts.get("rpm")
+    assert rpm_package_path is not None, "expected RPM package to be built"
+
     try:
         with polythene_rootfs(
-            packaging_paths.polythene_script, RPM_BASE_IMAGE
+            packaging_project_paths.polythene_script, RPM_BASE_IMAGE
         ) as rootfs:
             shutil.copy(rpm_package_path, rootfs.root / rpm_package_path.name)
             info_output = rootfs.exec("rpm", "-qip", rpm_package_path.name)

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import sys
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -85,7 +86,7 @@ def built_artifacts(packaging_paths: PackagingPaths) -> tuple[str, Path]:
     return target, man_src
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def rpm_package_path(
     packaging_paths: PackagingPaths, built_artifacts: tuple[str, Path]
 ) -> Path:
@@ -145,7 +146,7 @@ def test_rpm_package_metadata(
             assert info.get("Name") == "rust-toy-app"
             assert info.get("Version") == "0.1.0"
             release_value = info.get("Release", "")
-            assert release_value.startswith("1"), release_value
+            assert re.match(r"^1(\.|$)", release_value), release_value
             arch_value = info.get("Architecture")
             assert arch_value in {"amd64", "x86_64", "arm64", "aarch64"}, arch_value
 

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -2,17 +2,24 @@ from __future__ import annotations
 
 import shutil
 import sys
-import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 from plumbum import local
 
 from cmd_utils import run_cmd
-from _packaging_utils import ensure_nfpm, polythene_cmd, polythene_exec
+from _packaging_utils import (
+    IsolationUnavailableError,
+    ensure_nfpm,
+    polythene_rootfs,
+)
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
 from script_utils import unique_match  # noqa: E402
+
+RPM_TARGET = "x86_64-unknown-linux-gnu"
+RPM_BASE_IMAGE = "docker.io/library/rockylinux:9"
 
 
 def _parse_rpm_info(output: str) -> dict[str, str]:
@@ -25,19 +32,37 @@ def _parse_rpm_info(output: str) -> dict[str, str]:
     return info
 
 
-@pytest.mark.usefixtures("uncapture_if_verbose")
-@pytest.mark.skipif(
-    sys.platform == "win32" or shutil.which("podman") is None,
-    reason="podman not available",
-)
-def test_rpm_package_metadata() -> None:
-    """Build the .rpm package and inspect its metadata inside an isolated rootfs."""
-    project_dir = Path(__file__).resolve().parents[4] / "rust-toy-app"
-    build_script = Path(__file__).resolve().parents[1] / "src" / "main.py"
-    pkg_script = Path(__file__).resolve().parents[1] / "scripts" / "package.py"
-    polythene = Path(__file__).resolve().parents[1] / "scripts" / "polythene.py"
-    target = "x86_64-unknown-linux-gnu"
+@dataclass(frozen=True)
+class PackagingPaths:
+    """Resolved filesystem paths required for packaging tests."""
 
+    project_dir: Path
+    build_script: Path
+    package_script: Path
+    polythene_script: Path
+
+
+@pytest.fixture(scope="module")
+def packaging_paths() -> PackagingPaths:
+    """Return the filesystem layout for the packaging fixtures."""
+
+    test_file = Path(__file__).resolve()
+    tests_root = test_file.parents[1]
+    project_dir = test_file.parents[4] / "rust-toy-app"
+    return PackagingPaths(
+        project_dir=project_dir,
+        build_script=tests_root / "src" / "main.py",
+        package_script=tests_root / "scripts" / "package.py",
+        polythene_script=tests_root / "scripts" / "polythene.py",
+    )
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(packaging_paths: PackagingPaths) -> tuple[str, Path]:
+    """Compile the Rust project and return the build target and man page path."""
+
+    target = RPM_TARGET
+    project_dir = packaging_paths.project_dir
     with local.cwd(project_dir):
         run_cmd(
             local["rustup"][
@@ -50,80 +75,81 @@ def test_rpm_package_metadata() -> None:
             ]
         )
         with local.env(CROSS_CONTAINER_ENGINE="podman"):
-            run_cmd(local[sys.executable][build_script.as_posix(), target])
+            run_cmd(local[sys.executable][packaging_paths.build_script.as_posix(), target])
         man_src = unique_match(
             project_dir.glob(
                 f"target/{target}/release/build/rust-toy-app-*/out/rust-toy-app.1"
             ),
             description="rust-toy-app man page",
         )
-        ensure_nfpm(project_dir)
-        run_cmd(
-            local["uv"][
-                "run",
-                pkg_script.as_posix(),
-                "--name",
-                "rust-toy-app",
-                "--bin-name",
-                "rust-toy-app",
-                "--target",
-                target,
-                "--version",
-                "0.1.0",
-                "--formats",
-                "rpm",
-                "--man",
-                man_src.as_posix(),
-            ]
-        )
+    return target, man_src
+
+
+@pytest.fixture
+def rpm_package_path(
+    packaging_paths: PackagingPaths, built_artifacts: tuple[str, Path]
+) -> Path:
+    """Package the project as an RPM and return the artifact path."""
+
+    target, man_src = built_artifacts
+    project_dir = packaging_paths.project_dir
+    with local.cwd(project_dir):
+        dist_dir = project_dir / "dist"
+        if dist_dir.exists():
+            for existing in dist_dir.glob("rust-toy-app-0.1.0-1*.rpm"):
+                existing.unlink()
+        with ensure_nfpm(project_dir):
+            run_cmd(
+                local["uv"][
+                    "run",
+                    packaging_paths.package_script.as_posix(),
+                    "--name",
+                    "rust-toy-app",
+                    "--bin-name",
+                    "rust-toy-app",
+                    "--target",
+                    target,
+                    "--version",
+                    "0.1.0",
+                    "--formats",
+                    "rpm",
+                    "--man",
+                    man_src.as_posix(),
+                ]
+            )
         rpm_path = unique_match(
             project_dir.glob("dist/rust-toy-app-0.1.0-1*.rpm"),
             description="rust-toy-app rpm",
         )
+    return rpm_path
 
-        with tempfile.TemporaryDirectory() as store:
-            uid = (
-                polythene_cmd(
-                    polythene,
-                    "pull",
-                    "docker.io/library/rockylinux:9",
-                    "--store",
-                    store,
-                )
-                .splitlines()[-1]
-                .strip()
-            )
-            try:
-                polythene_exec(polythene, uid, store, "true")
-            except Exception:
-                pytest.skip("isolation unavailable")
 
-            root = Path(store) / uid
-            shutil.copy(rpm_path, root / rpm_path.name)
-            info_output = polythene_exec(
-                polythene,
-                uid,
-                store,
-                "rpm",
-                "-qip",
-                rpm_path.name,
-            )
+@pytest.mark.usefixtures("uncapture_if_verbose")
+@pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("podman") is None,
+    reason="podman not available",
+)
+def test_rpm_package_metadata(
+    packaging_paths: PackagingPaths, rpm_package_path: Path
+) -> None:
+    """Build the .rpm package and inspect its metadata inside an isolated rootfs."""
+    try:
+        with polythene_rootfs(
+            packaging_paths.polythene_script, RPM_BASE_IMAGE
+        ) as rootfs:
+            shutil.copy(rpm_package_path, rootfs.root / rpm_package_path.name)
+            info_output = rootfs.exec("rpm", "-qip", rpm_package_path.name)
             info = _parse_rpm_info(info_output)
             assert info.get("Name") == "rust-toy-app"
             assert info.get("Version") == "0.1.0"
             release_value = info.get("Release", "")
             assert release_value.startswith("1"), release_value
             arch_value = info.get("Architecture")
-            assert arch_value in {"amd64", "x86_64"}, arch_value
+            assert arch_value in {"amd64", "x86_64", "arm64", "aarch64"}, arch_value
 
-            listing_output = polythene_exec(
-                polythene,
-                uid,
-                store,
-                "rpm",
-                "-qlp",
-                rpm_path.name,
-            )
+            listing_output = rootfs.exec("rpm", "-qlp", rpm_package_path.name)
             listing = {line.strip() for line in listing_output.splitlines() if line.strip()}
             assert "/usr/bin/rust-toy-app" in listing
             assert "/usr/share/man/man1/rust-toy-app.1.gz" in listing
+    except IsolationUnavailableError as exc:
+        pytest.skip(f"isolation unavailable: {exc}")

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -126,8 +126,10 @@ def rpm_package_path(
 
 @pytest.mark.usefixtures("uncapture_if_verbose")
 @pytest.mark.skipif(
-    sys.platform == "win32" or shutil.which("podman") is None,
-    reason="podman not available",
+    sys.platform == "win32"
+    or shutil.which("podman") is None
+    or shutil.which("uv") is None,
+    reason="podman or uv not available",
 )
 def test_rpm_package_metadata(
     packaging_paths: PackagingPaths, rpm_package_path: Path
@@ -145,7 +147,7 @@ def test_rpm_package_metadata(
             release_value = info.get("Release", "")
             assert release_value.startswith("1"), release_value
             arch_value = info.get("Architecture")
-            assert arch_value == "x86_64", arch_value
+            assert arch_value in {"amd64", "x86_64", "arm64", "aarch64"}, arch_value
 
             listing_output = rootfs.exec("rpm", "-qlp", rpm_package_path.name)
             listing = {line.strip() for line in listing_output.splitlines() if line.strip()}

--- a/.github/actions/rust-build-release/tests/test_rpm_package.py
+++ b/.github/actions/rust-build-release/tests/test_rpm_package.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from plumbum import local
+
+from cmd_utils import run_cmd
+from _packaging_utils import ensure_nfpm, polythene_cmd, polythene_exec
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from script_utils import unique_match  # noqa: E402
+
+
+def _parse_rpm_info(output: str) -> dict[str, str]:
+    info: dict[str, str] = {}
+    for line in output.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        info[key.strip()] = value.strip()
+    return info
+
+
+@pytest.mark.usefixtures("uncapture_if_verbose")
+@pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("podman") is None,
+    reason="podman not available",
+)
+def test_rpm_package_metadata() -> None:
+    """Build the .rpm package and inspect its metadata inside an isolated rootfs."""
+    project_dir = Path(__file__).resolve().parents[4] / "rust-toy-app"
+    build_script = Path(__file__).resolve().parents[1] / "src" / "main.py"
+    pkg_script = Path(__file__).resolve().parents[1] / "scripts" / "package.py"
+    polythene = Path(__file__).resolve().parents[1] / "scripts" / "polythene.py"
+    target = "x86_64-unknown-linux-gnu"
+
+    with local.cwd(project_dir):
+        run_cmd(
+            local["rustup"][
+                "toolchain",
+                "install",
+                "1.89.0",
+                "--profile",
+                "minimal",
+                "--no-self-update",
+            ]
+        )
+        with local.env(CROSS_CONTAINER_ENGINE="podman"):
+            run_cmd(local[sys.executable][build_script.as_posix(), target])
+        man_src = unique_match(
+            project_dir.glob(
+                f"target/{target}/release/build/rust-toy-app-*/out/rust-toy-app.1"
+            ),
+            description="rust-toy-app man page",
+        )
+        ensure_nfpm(project_dir)
+        run_cmd(
+            local["uv"][
+                "run",
+                pkg_script.as_posix(),
+                "--name",
+                "rust-toy-app",
+                "--bin-name",
+                "rust-toy-app",
+                "--target",
+                target,
+                "--version",
+                "0.1.0",
+                "--formats",
+                "rpm",
+                "--man",
+                man_src.as_posix(),
+            ]
+        )
+        rpm_path = unique_match(
+            project_dir.glob("dist/rust-toy-app-0.1.0-1*.rpm"),
+            description="rust-toy-app rpm",
+        )
+
+        with tempfile.TemporaryDirectory() as store:
+            uid = (
+                polythene_cmd(
+                    polythene,
+                    "pull",
+                    "docker.io/library/rockylinux:9",
+                    "--store",
+                    store,
+                )
+                .splitlines()[-1]
+                .strip()
+            )
+            try:
+                polythene_exec(polythene, uid, store, "true")
+            except Exception:
+                pytest.skip("isolation unavailable")
+
+            root = Path(store) / uid
+            shutil.copy(rpm_path, root / rpm_path.name)
+            info_output = polythene_exec(
+                polythene,
+                uid,
+                store,
+                "rpm",
+                "-qip",
+                rpm_path.name,
+            )
+            info = _parse_rpm_info(info_output)
+            assert info.get("Name") == "rust-toy-app"
+            assert info.get("Version") == "0.1.0"
+            release_value = info.get("Release", "")
+            assert release_value.startswith("1"), release_value
+            arch_value = info.get("Architecture")
+            assert arch_value in {"amd64", "x86_64"}, arch_value
+
+            listing_output = polythene_exec(
+                polythene,
+                uid,
+                store,
+                "rpm",
+                "-qlp",
+                rpm_path.name,
+            )
+            listing = {line.strip() for line in listing_output.splitlines() if line.strip()}
+            assert "/usr/bin/rust-toy-app" in listing
+            assert "/usr/share/man/man1/rust-toy-app.1.gz" in listing

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean help test lint markdownlint nixie fmt typecheck
+.PHONY: all clean help test lint markdownlint nixie fmt check-fmt typecheck
 
 all: fmt lint typecheck test ## Run format, lint, typecheck, then tests
 
@@ -38,6 +38,9 @@ typecheck: .venv ## Run static type checking with Ty
 
 fmt: ## Apply formatting to Python files
 	uvx ruff format
+
+check-fmt: ## Check Python formatting without modifying files
+	uvx ruff format --check
 
 markdownlint: ## Lint Markdown files
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)


### PR DESCRIPTION
## Summary
- add shared helpers for nfpm download and polythene execution
- cover rpm packaging with a new integration test mirroring the deb path
- refactor the deb test to reuse the helpers and document the addition in the changelog

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ca1f06663083228dc3ddc39e8bef3d

## Summary by Sourcery

Add shared packaging utilities and extend integration tests to cover RPM packaging, refactoring the existing Debian test to use the new helpers and updating the changelog.

New Features:
- Introduce RPM packaging integration test mirroring the Debian packaging path.

Enhancements:
- Extract nfpm download and polythene execution logic into shared _packaging_utils helpers.
- Refactor the Debian package test to utilize the new shared helpers.

Documentation:
- Update changelog to document the addition of RPM packaging test.

Tests:
- Add tests/test_rpm_package.py for RPM packaging metadata and file listing validation.