### PR TITLE
Fix typing.cast lint in rust-build-release utils

### DIFF
--- a/.github/actions/install-nfpm/action.yml
+++ b/.github/actions/install-nfpm/action.yml
@@ -1,0 +1,40 @@
+name: Install nfpm
+description: Install the nfpm CLI into the runner environment
+runs:
+  using: composite
+  steps:
+    - name: Install nfpm
+      shell: bash
+      run: |
+        set -euo pipefail
+        ver="v2.39.0"
+        uname_s="$(uname -s)"
+        uname_m="$(uname -m)"
+        case "$uname_s" in
+          Linux) asset_os="Linux" ;;
+          Darwin) asset_os="Darwin" ;;
+          *) echo "::error:: unsupported OS: $uname_s"; exit 1 ;;
+        esac
+        case "$uname_m" in
+          x86_64) asset_arch="x86_64" ;;
+          aarch64|arm64) asset_arch="arm64" ;;
+          *) echo "::error:: unsupported arch: $uname_m"; exit 1 ;;
+        esac
+        asset="nfpm_${ver#v}_${asset_os}_${asset_arch}.tar.gz"
+        base_url="https://github.com/goreleaser/nfpm/releases/download/${ver}"
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+        curl -fsSL "${base_url}/${asset}" -o "${tmp_dir}/${asset}"
+        curl -fsSL "${base_url}/checksums.txt" -o "${tmp_dir}/checksums.txt"
+        if command -v sha256sum >/dev/null 2>&1; then
+          (
+            cd "${tmp_dir}"
+            grep "  ${asset}$" checksums.txt | sha256sum --check -
+          )
+        else
+          expected="$(grep "  ${asset}$" "${tmp_dir}/checksums.txt" | awk '{print $1}')"
+          echo "${expected}  ${tmp_dir}/${asset}" | shasum -a 256 --check -
+        fi
+        tar -xzf "${tmp_dir}/${asset}" -C "${tmp_dir}" nfpm
+        install -m 0755 "${tmp_dir}/nfpm" "${RUNNER_TEMP}/nfpm"
+        echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"

--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -52,40 +52,7 @@ runs:
         workspaces: ${{ inputs.project-dir }}
         cache-on-failure: true
     - name: Install nfpm
-      shell: bash
-      run: |
-        set -euo pipefail
-        ver="v2.39.0"
-        uname_s="$(uname -s)"
-        uname_m="$(uname -m)"
-        case "$uname_s" in
-          Linux) asset_os="Linux" ;;
-          Darwin) asset_os="Darwin" ;;
-          *) echo "::error:: unsupported OS: $uname_s"; exit 1 ;;
-        esac
-        case "$uname_m" in
-          x86_64) asset_arch="x86_64" ;;
-          aarch64|arm64) asset_arch="arm64" ;;
-          *) echo "::error:: unsupported arch: $uname_m"; exit 1 ;;
-        esac
-        asset="nfpm_${ver#v}_${asset_os}_${asset_arch}.tar.gz"
-        base_url="https://github.com/goreleaser/nfpm/releases/download/${ver}"
-        tmp_dir="$(mktemp -d)"
-        trap 'rm -rf "$tmp_dir"' EXIT
-        curl -fsSL "${base_url}/${asset}" -o "${tmp_dir}/${asset}"
-        curl -fsSL "${base_url}/checksums.txt" -o "${tmp_dir}/checksums.txt"
-        if command -v sha256sum >/dev/null 2>&1; then
-          (
-            cd "${tmp_dir}"
-            grep "  ${asset}$" checksums.txt | sha256sum --check -
-          )
-        else
-          expected="$(grep "  ${asset}$" "${tmp_dir}/checksums.txt" | awk '{print $1}')"
-          echo "${expected}  ${tmp_dir}/${asset}" | shasum -a 256 --check -
-        fi
-        tar -xzf "${tmp_dir}/${asset}" -C "${tmp_dir}" nfpm
-        install -m 0755 "${tmp_dir}/nfpm" "${RUNNER_TEMP}/nfpm"
-        echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
+      uses: ../install-nfpm
     - name: Build release
       shell: bash
       env:

--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -52,7 +52,7 @@ runs:
         workspaces: ${{ inputs.project-dir }}
         cache-on-failure: true
     - name: Install nfpm
-      uses: ../install-nfpm
+      uses: ./.github/actions/install-nfpm
     - name: Build release
       shell: bash
       env:

--- a/.github/actions/rust-build-release/src/utils.py
+++ b/.github/actions/rust-build-release/src/utils.py
@@ -44,4 +44,4 @@ def run_validated(
     ):
         subprocess_kwargs["text"] = True
     result = subprocess.run([exec_path, *args], **subprocess_kwargs)  # noqa: S603
-    return typ.cast(subprocess.CompletedProcess[str], result)
+    return typ.cast("subprocess.CompletedProcess[str]", result)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
             **/pyproject.toml
             **/uv.lock
             **/scripts/*.py
+      - name: Install nfpm
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./.github/actions/install-nfpm
       - name: Run tests
         run: |
           uv sync --group dev


### PR DESCRIPTION
## Summary
- quote the CompletedProcess typing.cast target to satisfy TC006 in `run_validated`

## Testing
- make lint


------
https://chatgpt.com/codex/tasks/task_e_68cb390851188322b6c523ed7de51f86

## Summary by Sourcery

Modularize nfpm installation into a reusable composite action and fix typing.cast lint violation in the rust-build-release utility

Bug Fixes:
- Quote the typing.cast target in `run_validated` to satisfy lint rule TC006

Enhancements:
- Extract the nfpm installation logic into a new composite GitHub Action (`install-nfpm`)
- Update the rust-build-release action to use the `install-nfpm` action instead of inline script
- Add an `Install nfpm` step in the CI workflow for ubuntu-latest jobs