### PR TITLE
Ensure nfpm action fails when checksum missing

### DIFF
--- a/.github/actions/install-nfpm/action.yml
+++ b/.github/actions/install-nfpm/action.yml
@@ -26,13 +26,18 @@ runs:
         trap 'rm -rf "$tmp_dir"' EXIT
         curl -fsSL "${base_url}/${asset}" -o "${tmp_dir}/${asset}"
         curl -fsSL "${base_url}/checksums.txt" -o "${tmp_dir}/checksums.txt"
+        checksum_line="$(grep "  ${asset}$" "${tmp_dir}/checksums.txt" || true)"
+        if [ -z "${checksum_line}" ]; then
+          echo "::error:: checksum for ${asset} not found in checksums.txt" >&2
+          exit 1
+        fi
         if command -v sha256sum >/dev/null 2>&1; then
           (
             cd "${tmp_dir}"
-            grep "  ${asset}$" checksums.txt | sha256sum --check -
+            printf '%s\n' "${checksum_line}" | sha256sum --check -
           )
         else
-          expected="$(grep "  ${asset}$" "${tmp_dir}/checksums.txt" | awk '{print $1}')"
+          expected="$(awk '{print $1}' <<< "${checksum_line}")"
           echo "${expected}  ${tmp_dir}/${asset}" | shasum -a 256 --check -
         fi
         tar -xzf "${tmp_dir}/${asset}" -C "${tmp_dir}" nfpm


### PR DESCRIPTION
## Summary
- ensure the nfpm install action fails fast when the release checksum is absent
- reuse the extracted checksum for both the sha256sum and shasum verification paths

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3de3c8d88322a36fd781f1ac676a

## Summary by Sourcery

Make the nfpm install GitHub Action fail fast when the asset checksum is missing and streamline checksum verification by reusing the extracted checksum line.

Bug Fixes:
- Fail fast with an error if no checksum entry is found for the downloaded asset.

Enhancements:
- Capture the checksum line once and reuse it for both sha256sum and shasum checks instead of grepping twice.