### PR TITLE
Fix rust host detection timeout and Windows bin path

### DIFF
--- a/.github/actions/rust-build-release/src/runtime.py
+++ b/.github/actions/rust-build-release/src/runtime.py
@@ -102,8 +102,14 @@ def detect_host_target(
             capture_output=True,
             text=True,
             check=True,
+            timeout=10,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+    ):
         return default
 
     triple = next(

--- a/.github/actions/rust-build-release/src/runtime.py
+++ b/.github/actions/rust-build-release/src/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import typing as typ
@@ -15,6 +16,7 @@ if typ.TYPE_CHECKING:
 
 CROSS_CONTAINER_ERROR_CODES = {125, 126, 127}
 DEFAULT_HOST_TARGET = "x86_64-unknown-linux-gnu"
+PROBE_TIMEOUT = int(os.environ.get("RUNTIME_PROBE_TIMEOUT", "10"))
 
 
 def runtime_available(name: str, *, cwd: str | Path | None = None) -> bool:
@@ -33,7 +35,7 @@ def runtime_available(name: str, *, cwd: str | Path | None = None) -> bool:
             allowed_names=(name, f"{name}.exe"),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            timeout=10,
+            timeout=PROBE_TIMEOUT,
             cwd=cwd,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -51,7 +53,7 @@ def runtime_available(name: str, *, cwd: str | Path | None = None) -> bool:
                 capture_output=True,
                 text=True,
                 check=True,
-                timeout=10,
+                timeout=PROBE_TIMEOUT,
                 cwd=cwd,
             )
         except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
@@ -102,7 +104,7 @@ def detect_host_target(
             capture_output=True,
             text=True,
             check=True,
-            timeout=10,
+            timeout=PROBE_TIMEOUT,
         )
     except (
         subprocess.CalledProcessError,

--- a/.github/actions/rust-build-release/src/runtime.py
+++ b/.github/actions/rust-build-release/src/runtime.py
@@ -105,7 +105,6 @@ def detect_host_target(
             timeout=10,
         )
     except (
-        FileNotFoundError,
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
         OSError,

--- a/.github/actions/rust-build-release/tests/test_runtime.py
+++ b/.github/actions/rust-build-release/tests/test_runtime.py
@@ -240,8 +240,9 @@ def test_detect_host_target_passes_timeout_to_run_validated(
         allowed_names: tuple[str, ...],
         **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
-        _ = (executable, args, allowed_names)
+        _ = (executable, args)
         call_kwargs.update(kwargs)
+        call_kwargs["allowed_names"] = allowed_names
         return subprocess.CompletedProcess(
             [executable, *args], 0, stdout="host: bounded\n"
         )
@@ -250,3 +251,7 @@ def test_detect_host_target_passes_timeout_to_run_validated(
 
     assert runtime_module.detect_host_target() == "bounded"
     assert call_kwargs.get("timeout") == runtime_module.PROBE_TIMEOUT
+    assert call_kwargs.get("capture_output") is True
+    assert call_kwargs.get("text") is True
+    assert call_kwargs.get("check") is True
+    assert call_kwargs.get("allowed_names") == ("rustc", "rustc.exe")

--- a/.github/actions/rust-build-release/tests/test_runtime.py
+++ b/.github/actions/rust-build-release/tests/test_runtime.py
@@ -52,7 +52,7 @@ def test_runtime_available_returns_false_on_timeout(
     ) -> subprocess.CompletedProcess[str]:
         _ = allowed_names
         cmd = [executable, *args]
-        raise subprocess.TimeoutExpired(cmd, 10)
+        raise subprocess.TimeoutExpired(cmd, runtime_module.PROBE_TIMEOUT)
 
     harness.monkeypatch.setattr(runtime_module, "run_validated", fake_run)
 
@@ -146,7 +146,7 @@ def test_podman_security_timeout_treated_as_unavailable(
         _ = (allowed_names, capture_output, check, text)
         cmd = [executable, *args]
         if "--format" in args:
-            raise subprocess.TimeoutExpired(cmd, 10)
+            raise subprocess.TimeoutExpired(cmd, runtime_module.PROBE_TIMEOUT)
         return subprocess.CompletedProcess(cmd, 0, stdout="")
 
     harness.monkeypatch.setattr(runtime_module, "run_validated", fake_run)
@@ -209,7 +209,9 @@ def test_detect_host_target_returns_default_on_timeout(
         **_: object,
     ) -> subprocess.CompletedProcess[str]:
         _ = (executable, args, allowed_names)
-        raise subprocess.TimeoutExpired([executable, *args], 10)
+        raise subprocess.TimeoutExpired(
+            [executable, *args], runtime_module.PROBE_TIMEOUT
+        )
 
     harness.monkeypatch.setattr(runtime_module, "run_validated", fake_run)
 
@@ -247,4 +249,4 @@ def test_detect_host_target_passes_timeout_to_run_validated(
     harness.monkeypatch.setattr(runtime_module, "run_validated", fake_run)
 
     assert runtime_module.detect_host_target() == "bounded"
-    assert call_kwargs.get("timeout") == 10
+    assert call_kwargs.get("timeout") == runtime_module.PROBE_TIMEOUT

--- a/.github/actions/setup-windows-gnu/action.yml
+++ b/.github/actions/setup-windows-gnu/action.yml
@@ -54,7 +54,8 @@ runs:
           Remove-Item $destination -Recurse -Force
         }
         Expand-Archive $archive -DestinationPath $destination -Force
-        $binPath = Join-Path $destination "llvm-mingw-$version-ucrt-x86_64\bin"
+        $toolRoot = Join-Path $destination "llvm-mingw-$version-ucrt-x86_64"
+        $binPath = Join-Path $toolRoot "bin"
         if (-not (Test-Path $binPath)) {
           throw "llvm-mingw bin directory not found at $binPath"
         }


### PR DESCRIPTION
## Summary
- add a timeout to the rustc host triple probe and treat timeouts as falling back to the default host target
- build the llvm-mingw bin path with `Join-Path` to avoid embedded backslashes in the setup-windows-gnu action

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68cc41dcc0b48322baaf86145d832bab

## Summary by Sourcery

Improve reliability of host detection by timing out stalled rustc probes and enhance Windows setup by correctly building the llvm-mingw bin path

Bug Fixes:
- Add a 10-second timeout to the rustc host triple probe and treat timeouts as falling back to the default host target

Enhancements:
- Construct the llvm-mingw bin path using Join-Path to avoid embedded backslashes in the Windows setup action