### PR TITLE
Use cmd-mox to stub rust build command tests

### DIFF
--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -90,13 +90,6 @@ class ModuleHarness:
         """Patch ``shutil.which`` for the wrapped module."""
         self.monkeypatch.setattr(self.module.shutil, "which", func)
 
-    def patch_subprocess_run(self, func: cabc.Callable[..., object]) -> None:
-        """Patch ``subprocess.run`` for the wrapped module."""
-        if hasattr(self.module, "run_validated"):
-            self.monkeypatch.setattr(self.module, "run_validated", func)
-        if hasattr(self.module, "subprocess"):
-            self.monkeypatch.setattr(self.module.subprocess, "run", func)
-
     def patch_platform(self, platform: str) -> None:
         """Force ``sys.platform`` to ``platform`` within the module."""
         self.monkeypatch.setattr(self.module.sys, "platform", platform)

--- a/.github/actions/rust-build-release/tests/test_cross_install.py
+++ b/.github/actions/rust-build-release/tests/test_cross_install.py
@@ -369,9 +369,7 @@ def test_installs_cross_without_container_runtime(
             return cross_checks.pop(0) if cross_checks else cross_path
         if name in {"docker", "podman"}:
             return None
-        if name == "rustup":
-            return rustup_path
-        return None
+        return rustup_path if name == "rustup" else None
 
     cross_env.patch_shutil_which(fake_which)
     app_env.patch_shutil_which(fake_which)
@@ -449,9 +447,7 @@ def test_falls_back_to_cargo_when_runtime_unusable(
             return docker_path
         if name == "cross":
             return cross_path
-        if name == "rustup":
-            return rustup_path
-        return None
+        return rustup_path if name == "rustup" else None
 
     cross_env.patch_shutil_which(fake_which)
     app_env.patch_shutil_which(fake_which)

--- a/.github/actions/rust-build-release/tests/test_utils.py
+++ b/.github/actions/rust-build-release/tests/test_utils.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 import typing as typ
 from pathlib import Path
 
 import pytest
 
-CMD_MOX_UNSUPPORTED = pytest.mark.skipif(
-    sys.platform == "win32", reason="cmd-mox does not support Windows"
-)
+from shared_actions_conftest import CMD_MOX_UNSUPPORTED
 
 if typ.TYPE_CHECKING:
     from types import ModuleType

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+"""Pytest configuration for shared actions tests."""
+
+pytest_plugins = ("cmd_mox.pytest_plugin",)

--- a/conftest.py
+++ b/conftest.py
@@ -2,9 +2,55 @@
 
 from __future__ import annotations
 
+import collections
+import collections.abc as cabc
 import sys
 
 import pytest
+
+
+CMD_MOX_UNSUPPORTED = pytest.mark.skipif(
+    sys.platform == "win32", reason="cmd-mox does not support Windows"
+)
+
+sys.modules.setdefault("shared_actions_conftest", sys.modules[__name__])
+
+
+def _register_cross_version_stub(
+    cmd_mox, stdout: str | cabc.Iterable[str] = "cross 0.2.5\n"
+) -> str:
+    """Register a stub for ``cross --version`` and return the shim path."""
+
+    if isinstance(stdout, str):
+        cmd_mox.stub("cross").with_args("--version").returns(stdout=stdout)
+    else:
+        outputs = collections.deque(stdout)
+        last = outputs[-1] if outputs else "cross 0.2.5\n"
+
+        def _handler(_invocation: object) -> tuple[str, str, int]:
+            data = outputs.popleft() if outputs else last
+            return data, "", 0
+
+        cmd_mox.stub("cross").with_args("--version").runs(_handler)
+    return str(cmd_mox.environment.shim_dir / "cross")
+
+
+def _register_rustup_toolchain_stub(
+    cmd_mox, stdout: str
+) -> str:  # pragma: no cover - helper
+    """Register a stub for ``rustup toolchain list`` and return the shim path."""
+
+    cmd_mox.stub("rustup").with_args("toolchain", "list").returns(stdout=stdout)
+    return str(cmd_mox.environment.shim_dir / "rustup")
+
+
+def _register_docker_info_stub(
+    cmd_mox, *, exit_code: int = 0
+) -> str:  # pragma: no cover - helper
+    """Register a stub for ``docker info`` and return the shim path."""
+
+    cmd_mox.stub("docker").with_args("info").returns(exit_code=exit_code)
+    return str(cmd_mox.environment.shim_dir / "docker")
 
 
 if sys.platform != "win32":  # pragma: win32 no cover - Windows lacks cmd-mox support

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,18 @@
 """Pytest configuration for shared actions tests."""
 
-pytest_plugins = ("cmd_mox.pytest_plugin",)
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+if sys.platform != "win32":  # pragma: win32 no cover - Windows lacks cmd-mox support
+    pytest_plugins = ("cmd_mox.pytest_plugin",)
+else:
+
+    @pytest.fixture()
+    def cmd_mox():  # pragma: win32 no cover - fixture only used on Windows
+        """Skip tests that rely on cmd-mox on Windows."""
+
+        pytest.skip("cmd-mox does not support Windows")

--- a/docs/cmd-mox-users-guide.md
+++ b/docs/cmd-mox-users-guide.md
@@ -5,7 +5,8 @@ commands in your tests. This guide shows common patterns for everyday use.
 
 ## Getting started
 
-Install the package and enable the pytest plugin:
+Install the package and enable the pytest plugin (guarded on Windows where
+cmd-mox is not currently supported):
 
 ```bash
 pip install cmd-mox
@@ -14,11 +15,16 @@ pip install cmd-mox
 In your `conftest.py`:
 
 ```python
-pytest_plugins = ("cmd_mox.pytest_plugin",)
+import sys
+
+if sys.platform != "win32":
+    pytest_plugins = ("cmd_mox.pytest_plugin",)
 ```
 
 Each test receives a `cmd_mox` fixture that provides access to the controller
-object.
+object. Because the IPC transport is Unix-specific, guard any cmd-mox-backed
+tests with `pytest.mark.skipif(sys.platform == "win32", ...)` so CI runners on
+Windows bypass them gracefully.
 
 ## Basic workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pyyaml>=6.0,<7.0",
     "ty>=0.0.1a20",
     "uuid6>=2025.0.1",
+    "cmd-mox@git+https://github.com/leynos/cmd-mox.git",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,11 @@ wheels = [
 ]
 
 [[package]]
+name = "cmd-mox"
+version = "0.1.0"
+source = { git = "https://github.com/leynos/cmd-mox.git#5bf23d0ae6055397956a3d4440063fa6a77b10d8" }
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -226,6 +231,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "cmd-mox" },
     { name = "lxml-stubs" },
     { name = "pytest" },
     { name = "pyyaml" },
@@ -242,6 +248,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cmd-mox", git = "https://github.com/leynos/cmd-mox.git" },
     { name = "lxml-stubs", specifier = ">=0.5.1" },
     { name = "pytest", specifier = ">=8.0,<9.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },


### PR DESCRIPTION
## Summary
- add cmd-mox as a dev dependency and load its pytest plugin in the global conftest
- rework rust build release target install and cross install tests to use cmd-mox stubs instead of patching subprocess
- update the run_validated unit test to rely on a cmd-mox spy

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cddf10aa54832297cc3f589642beeb

## Summary by Sourcery

Adopt cmd-mox plugin to stub and spy on external CLI invocations in rust build release tests, replacing manual subprocess patches and simplifying test setup.

Enhancements:
- Integrate cmd-mox to stub command executions and spies in cross and target install tests
- Replace custom subprocess.run and run_validated monkeypatches with cmd-mox stubs and spies
- Add helper functions for registering cross, rustup, and docker stubs across tests

Build:
- Add cmd-mox as a dev dependency in pyproject.toml

CI:
- Load cmd-mox pytest plugin via global conftest

Tests:
- Update cross install, target install, and utils tests to use cmd-mox stubs/spies
- Add skip markers for Windows in tests where cmd-mox is unsupported