### PR TITLE
Mark Windows smoke tests as xfail

### DIFF
--- a/.github/actions/rust-build-release/tests/test_smoke.py
+++ b/.github/actions/rust-build-release/tests/test_smoke.py
@@ -35,6 +35,7 @@ WINDOWS_KNOWN_FAILURE = pytest.mark.xfail(
         "Known failure on Windows; see "
         "https://github.com/leynos/shared-actions/issues/93"
     ),
+    strict=True,
 )
 
 
@@ -61,7 +62,7 @@ def _param_for_target(target: str) -> object:
     marks: list[pytest.MarkDecorator] = []
     if target != HOST_TARGET and target.endswith("-unknown-linux-gnu"):
         marks.append(LINUX_ONLY)
-    if target.endswith("-pc-windows-gnu"):
+    if target.endswith("-pc-windows-gnu") or target.endswith("-pc-windows-msvc"):
         marks.append(WINDOWS_ONLY)
     if target.endswith("-pc-windows-gnu") or target.endswith("-pc-windows-msvc"):
         marks.append(WINDOWS_KNOWN_FAILURE)

--- a/.github/actions/rust-build-release/tests/test_smoke.py
+++ b/.github/actions/rust-build-release/tests/test_smoke.py
@@ -29,6 +29,13 @@ TOOLCHAIN_VERSION = (
 
 WINDOWS_ONLY = pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
 LINUX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="requires Linux")
+WINDOWS_KNOWN_FAILURE = pytest.mark.xfail(
+    sys.platform == "win32",
+    reason=(
+        "Known failure on Windows; see "
+        "https://github.com/leynos/shared-actions/issues/93"
+    ),
+)
 
 
 HOST_TARGET = detect_host_target()
@@ -56,6 +63,8 @@ def _param_for_target(target: str) -> object:
         marks.append(LINUX_ONLY)
     if target.endswith("-pc-windows-gnu"):
         marks.append(WINDOWS_ONLY)
+    if target.endswith("-pc-windows-gnu") or target.endswith("-pc-windows-msvc"):
+        marks.append(WINDOWS_KNOWN_FAILURE)
     if marks:
         return pytest.param(target, marks=tuple(marks))
     return pytest.param(target)


### PR DESCRIPTION
## Summary
- mark the rust-build-release smoke test targets for Windows as expected failures when executed on Windows runners, linking to the tracking issue

closes #93

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ce8283db7c8322819f849b7008df6d

## Summary by Sourcery

Mark smoke tests for Windows target triples as expected failures on Windows runners

Enhancements:
- Add a pytest xfail marker for known Windows failures referencing issue #93

Tests:
- Apply the Windows known failure marker to smoke tests for GNU and MSVC targets on Windows