### PR TITLE
Address reviewer feedback for release-to-pypi-uv action

### DIFF
--- a/.github/actions/release-to-pypi-uv/README.md
+++ b/.github/actions/release-to-pypi-uv/README.md
@@ -16,6 +16,10 @@ Build and publish Python distributions via
 | fail-on-dynamic-version | Fail when a project declares a dynamic PEP 621 version instead of a literal string. | no | `false` |
 | python-version | Python version to install and use for all uv commands. | no | `3.13` |
 
+The composite action installs the interpreter requested through `python-version`
+before invoking any uv commands, ensuring builds run against the expected
+runtime.
+
 ## Outputs
 
 | Name | Description |
@@ -49,13 +53,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
-        with:
-          python-version: ${{ inputs.python-version }}
-
       - name: Build and publish
         uses: ./.github/actions/release-to-pypi-uv
         with:
+          python-version: '3.12'
           require-confirmation: true
           confirm: release ${{ github.ref_name }}
 ```

--- a/.github/actions/release-to-pypi-uv/action.yml
+++ b/.github/actions/release-to-pypi-uv/action.yml
@@ -48,6 +48,7 @@ runs:
       # v6.4.3
       uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
       with:
+        python-version: ${{ inputs.python-version }}
         cache-dependency-glob: |
           **/pyproject.toml
           **/uv.lock

--- a/.github/actions/release-to-pypi-uv/tests/test_action_python_version.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_action_python_version.py
@@ -1,0 +1,43 @@
+"""Tests covering the python-version input in action.yml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_action() -> dict[str, Any]:
+    action_path = Path(__file__).resolve().parents[1] / "action.yml"
+    return yaml.safe_load(action_path.read_text(encoding="utf-8"))
+
+
+def test_action_exposes_python_version_input() -> None:
+    """Unit test: ensure metadata defines python-version with the expected default."""
+
+    data = _load_action()
+    python_version = data["inputs"]["python-version"]
+    assert python_version["default"] == "3.13"
+    assert "Python version" in python_version["description"]
+
+
+def test_setup_step_forwards_python_version_input() -> None:
+    """Behavioral test: ensure setup-uv installs the requested interpreter."""
+
+    data = _load_action()
+    steps = data["runs"]["steps"]
+    setup_step = next(step for step in steps if step["name"] == "Setup uv")
+    assert setup_step["with"]["python-version"] == "${{ inputs.python-version }}"
+
+
+def test_install_step_uses_python_version_input() -> None:
+    """Behavioral test: ensure uv python install receives the requested version."""
+
+    data = _load_action()
+    steps = data["runs"]["steps"]
+    install_step = next(step for step in steps if step["name"] == "Install Python")
+    assert (
+        install_step["run"]
+        == 'uv python install "${{ inputs.python-version }}"'
+    )

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from shared_actions_conftest import REQUIRES_UV
+
 from .test_determine_release import base_env
+
+
+pytestmark = REQUIRES_UV
 
 
 def run_confirm(tmp_path: Path, expected: str, confirm: str) -> subprocess.CompletedProcess[str]:

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
 
 
 def run_script(script: Path, *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
-import pytest
+from shared_actions_conftest import REQUIRES_UV
 
 
-pytestmark = pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+pytestmark = REQUIRES_UV
 
 
 def run_script(script: Path, *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections
 import collections.abc as cabc
+import shutil
 import sys
 
 import pytest
@@ -12,8 +13,19 @@ import pytest
 CMD_MOX_UNSUPPORTED = pytest.mark.skipif(
     sys.platform == "win32", reason="cmd-mox does not support Windows"
 )
+HAS_UV = shutil.which("uv") is not None
+
+REQUIRES_UV = pytest.mark.usefixtures("require_uv")
 
 sys.modules.setdefault("shared_actions_conftest", sys.modules[__name__])
+
+
+@pytest.fixture()
+def require_uv() -> None:
+    """Skip tests that exercise uv when the CLI is unavailable."""
+
+    if not HAS_UV:
+        pytest.skip("uv CLI not installed")
 
 
 def _register_cross_version_stub(

--- a/docs/cmd-mox-users-guide.md
+++ b/docs/cmd-mox-users-guide.md
@@ -187,8 +187,8 @@ cmd_mox.verify()
 assert [call.command for call in cmd_mox.journal] == ["git", "curl"]
 ```
 
-When you want to intercept a command without configuring a double—for example to
-ensure it is treated as unexpected—register it explicitly:
+To intercept a command without configuring a double—for example, to ensure it is
+treated as unexpected—register it explicitly:
 
 ```python
 cmd_mox.register_command("name")
@@ -216,7 +216,7 @@ few common ones are:
   receives an `Invocation` and should return either a `(stdout, stderr,
   exit_code)` tuple or a `Response` instance.
 - `times(count)` – expect the command exactly `count` times.
-- `times_called(count)` – alias for `times` that emphasises spy call counts.
+- `times_called(count)` – alias for `times` that emphasizes spy call counts.
 - `in_order()` – enforce strict ordering with other expectations.
 - `any_order()` – allow the expectation to be satisfied in any position.
 - `passthrough()` – for spies, run the real command while recording it.

--- a/docs/cmd-mox-users-guide.md
+++ b/docs/cmd-mox-users-guide.md
@@ -3,6 +3,11 @@
 CmdMox provides a fluent API for mocking, stubbing and spying on external
 commands in your tests. This guide shows common patterns for everyday use.
 
+## Related documents
+
+- [Python Native Command Mocking Design](./python-native-command-mocking-design.md)
+  – Architectural decisions, lifecycle sequencing and IPC design details.
+
 ## Getting started
 
 Install the package and enable the pytest plugin (guarded on Windows where
@@ -35,7 +40,7 @@ interactions matched what was recorded.
 The three phases are defined in the design document:
 
 1. **Record** – describe each expected command call, including its arguments
-   and behaviour.
+   and behavior.
 2. **Replay** – run the code under test while CmdMox intercepts command
    executions.
 3. **Verify** – ensure every expectation was met and nothing unexpected
@@ -68,7 +73,7 @@ cmd_mox.spy("curl")
 - **Spies** record every call for later inspection and can behave like stubs.
 
 Each call returns a `CommandDouble` that offers a fluent DSL to configure
-behaviour.
+behavior.
 
 ## Defining expectations
 

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1,0 +1,111 @@
+# Python Native Command Mocking Design
+
+CmdMox underpins our Python-based command doubling strategy. The library offers
+an ergonomic façade for writing tests while keeping the execution model explicit
+and deterministic. This document captures the architectural decisions and the
+contracts relied upon by the higher-level usage guide.
+
+## Objectives
+
+- Provide a transport-agnostic façade that lets tests intercept subprocess
+  invocations without patching the Python standard library.
+- Support mocks, stubs and spies with a consistent fluent DSL that emphasizes
+  readability.
+- Capture interactions for later inspection through a replay journal so tests
+  remain debuggable.
+- Remain portable across Unix platforms while documenting the Windows
+  limitations of the IPC transport.
+
+## Architecture Overview
+
+CmdMox consists of three cooperating subsystems:
+
+1. **Controller** – The public entry point used by tests. It configures
+   expectations, manages lifecycle transitions and coordinates verification.
+2. **Environment** – Provisions temporary shim binaries (or scripts) and binds
+   them to the controller via Unix domain sockets. Environment configuration is
+   exposed through attributes such as `environment.shim_dir`.
+3. **IPC Server** – Handles requests from shims, dispatching them to the
+   recorded doubles. The server enforces strict sequencing to maintain
+   deterministic behaviour.
+
+The pytest plugin creates a controller per test function. When used as a context
+manager (`with CmdMox() as mox:`) the same controller lifecycle is available for
+non-pytest clients.
+
+## Lifecycle: Record → Replay → Verify
+
+CmdMox enforces a three-stage lifecycle:
+
+1. **Record** – Tests describe expectations using the fluent API. Each
+   expectation registers a command double with information about argument
+   matching, environment and the response strategy.
+2. **Replay** – The controller activates the IPC server and replaces the target
+   commands with shims. During this phase, invocations flow through the doubles.
+3. **Verify** – Finally, the controller checks that every expectation was
+   satisfied, including call counts and ordering rules.
+
+Exiting a `with CmdMox()` block triggers `verify()` automatically when
+`verify_on_exit=True` (the default). Failing verification suppresses the error
+if an exception already bubbled out of the context, keeping the original
+exception visible to the test runner.
+
+## Command Doubles and Responses
+
+`CommandDouble` instances configure behaviour with a fluent DSL:
+
+- `with_args(*args)` asserts exact argument sequences.
+- `with_matching_args(*matchers)` allows per-position comparator functions such
+  as `Regex`, `Contains`, `StartsWith`, `Any`, `IsA` or custom predicates.
+- `with_stdin(...)` and `with_env({...})` match stdin content and environment
+  fragments.
+- `returns(stdout="", stderr="", exit_code=0)` provides deterministic
+  responses; the API operates exclusively on `str` payloads.
+- `runs(handler)` executes dynamic hooks that receive an `Invocation` object.
+- `times(count)` and `times_called(count)` enforce call counts, with the latter
+  acting as a spy-specific alias.
+- `passthrough()` forwards execution to the real command while continuing to
+  record invocations.
+- `assert_called*` helpers are available on spies after verification to ease
+  assertions in tests.
+
+## Journal and Diagnostics
+
+Every invocation processed during replay is appended to `cmd_mox.journal`, a
+bounded `collections.deque`. The capacity is controlled by
+`max_journal_entries`; exceeding the limit evicts the oldest entries. The
+journal is the primary diagnostic surface for understanding unexpected
+interactions and is frequently asserted against in tests.
+
+## Environment Variables
+
+Two environment variables tie the controller and shims together:
+
+- `CMOX_IPC_SOCKET` – Path to the Unix domain socket exposed by the server. Shims
+  exit early if this variable is missing.
+- `CMOX_IPC_TIMEOUT` – Seconds to wait for IPC operations before raising a
+  timeout error. The default is `5.0` seconds and can be tuned per test via the
+  controller API.
+
+These variables are injected automatically when the pytest fixture or context
+manager initialises the controller.
+
+## Platform Notes
+
+The IPC transport relies on Unix domain sockets, so the pytest plugin guards
+against activation on Windows (`sys.platform == "win32"`). Tests should guard
+Windows-specific code paths accordingly. Future work may explore TCP loopback or
+named-pipe transports for full parity.
+
+## Error Handling and Validation
+
+- The controller refuses to enter replay without recorded expectations when
+  strict verification is required, ensuring unexpected commands fail fast.
+- Each shim invocation is validated against its matching strategy; mismatches are
+  surfaced immediately with descriptive error messages.
+- Journal eviction and verification are both deterministic so repeated runs yield
+  identical behaviour given the same expectations and inputs.
+
+CmdMox is designed to remain implementation-agnostic at the call site, allowing
+us to evolve the underlying IPC layer or shim mechanism without breaking tests
+that depend on the documented contracts above.

--- a/docs/python-native-command-mocking-design.md
+++ b/docs/python-native-command-mocking-design.md
@@ -1,6 +1,6 @@
 # Python Native Command Mocking Design
 
-CmdMox underpins our Python-based command doubling strategy. The library offers
+CmdMox underpins the Python-based command doubling strategy. The library offers
 an ergonomic façade for writing tests while keeping the execution model explicit
 and deterministic. This document captures the architectural decisions and the
 contracts relied upon by the higher-level usage guide.
@@ -27,7 +27,7 @@ CmdMox consists of three cooperating subsystems:
    exposed through attributes such as `environment.shim_dir`.
 3. **IPC Server** – Handles requests from shims, dispatching them to the
    recorded doubles. The server enforces strict sequencing to maintain
-   deterministic behaviour.
+   deterministic behavior.
 
 The pytest plugin creates a controller per test function. When used as a context
 manager (`with CmdMox() as mox:`) the same controller lifecycle is available for
@@ -52,7 +52,7 @@ exception visible to the test runner.
 
 ## Command Doubles and Responses
 
-`CommandDouble` instances configure behaviour with a fluent DSL:
+`CommandDouble` instances configure behavior with a fluent DSL:
 
 - `with_args(*args)` asserts exact argument sequences.
 - `with_matching_args(*matchers)` allows per-position comparator functions such
@@ -104,8 +104,8 @@ named-pipe transports for full parity.
 - Each shim invocation is validated against its matching strategy; mismatches are
   surfaced immediately with descriptive error messages.
 - Journal eviction and verification are both deterministic so repeated runs yield
-  identical behaviour given the same expectations and inputs.
+  identical behavior given the same expectations and inputs.
 
 CmdMox is designed to remain implementation-agnostic at the call site, allowing
-us to evolve the underlying IPC layer or shim mechanism without breaking tests
-that depend on the documented contracts above.
+maintainers to evolve the underlying IPC layer or shim mechanism without
+breaking tests that depend on the documented contracts above.


### PR DESCRIPTION
## Summary
- pass the `python-version` input through the composite action's setup-uv step so the requested interpreter is installed
- skip the release determination tests when `uv` is unavailable to avoid spurious failures in constrained environments
- polish the CmdMox guide wording and add the missing design document referenced by the guide

## Testing
- make test


------
https://chatgpt.com/codex/tasks/task_e_68ce885d30408322beb94e220fa09b27

## Summary by Sourcery

Address reviewer feedback for the release-to-pypi-uv action by passing the requested Python version to the UV setup step, avoiding spurious test failures when UV is missing, and updating user documentation.

Enhancements:
- Propagate the python-version input through the composite action’s setup-uv step to ensure the requested interpreter is installed

Documentation:
- Polish wording in the CmdMox user guide
- Add the missing Python Native Command Mocking design document

Tests:
- Skip release determination tests when UV isn’t installed to prevent failures in constrained environments