### PR TITLE
Skip Windows container probe when building Windows targets

### DIFF
--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -110,8 +110,14 @@ def main(
     configure_windows_linkers(toolchain_name, target, rustup_exec)
 
     cross_path, cross_version = ensure_cross("0.2.5")
-    docker_present = runtime_available("docker")
-    podman_present = runtime_available("podman")
+    docker_present = False
+    podman_present = False
+    host_is_windows = sys.platform == "win32"
+    target_is_windows = "windows" in target
+    probe_container = not (host_is_windows and target_is_windows)
+    if probe_container:
+        docker_present = runtime_available("docker")
+        podman_present = runtime_available("podman")
     has_container = docker_present or podman_present
 
     use_cross = cross_path is not None and has_container

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -218,6 +218,7 @@ def test_windows_host_skips_container_probe_for_windows_targets(
         return subprocess.CompletedProcess(cmd, 0, stdout="")
 
     harness.patch_subprocess_run(fake_run)
+    harness.patch_run_cmd(lambda _: None)
 
     def fake_which(name: str) -> str | None:
         return "/usr/bin/rustup" if name == "rustup" else None
@@ -269,6 +270,7 @@ def test_windows_host_probes_container_for_non_windows_targets(
         return subprocess.CompletedProcess(cmd, 0, stdout="")
 
     harness.patch_subprocess_run(fake_run)
+    harness.patch_run_cmd(lambda _: None)
 
     def fake_which(name: str) -> str | None:
         return "/usr/bin/rustup" if name == "rustup" else None
@@ -286,7 +288,7 @@ def test_windows_host_probes_container_for_non_windows_targets(
 
     main_module.main("x86_64-unknown-linux-gnu", default_toolchain)
 
-    assert runtime_calls == ["docker", "podman"]
+    assert set(runtime_calls) == {"docker", "podman"}
 
 
 @pytest.mark.parametrize(

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -178,6 +178,108 @@ def test_falls_back_to_cargo_when_cross_container_fails(
     assert build_cmd[1] == f"+{default_toolchain}-x86_64-unknown-linux-gnu"
 
 
+def test_windows_host_skips_container_probe_for_windows_targets(
+    main_module: ModuleType,
+    module_harness: HarnessFactory,
+) -> None:
+    """Does not probe container runtimes for Windows targets on Windows hosts."""
+
+    harness = module_harness(main_module)
+    harness.patch_platform("win32")
+
+    default_toolchain = main_module.DEFAULT_TOOLCHAIN
+
+    def fake_run(
+        executable: str,
+        args: list[str],
+        *,
+        allowed_names: tuple[str, ...],
+        capture_output: bool = False,
+        check: bool = False,
+        text: bool = False,
+        **_: object,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = allowed_names
+        cmd = [executable, *args]
+        if executable == "/usr/bin/rustup" and args[:2] == ["toolchain", "list"]:
+            stdout = f"{default_toolchain}-x86_64-pc-windows-msvc\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout)
+        if executable == "/usr/bin/rustup" and args[:2] == ["which", "rustc"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="/fake/rustc")
+        return subprocess.CompletedProcess(cmd, 0, stdout="")
+
+    harness.patch_subprocess_run(fake_run)
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/bin/rustup" if name == "rustup" else None
+
+    harness.patch_shutil_which(fake_which)
+    runtime_calls: list[str] = []
+
+    def fake_runtime(name: str, *, cwd: object | None = None) -> bool:
+        runtime_calls.append(name)
+        _ = cwd
+        return False
+
+    harness.patch_attr("runtime_available", fake_runtime)
+    harness.patch_attr("ensure_cross", lambda *_: (None, None))
+
+    main_module.main("x86_64-pc-windows-msvc", default_toolchain)
+
+    assert runtime_calls == []
+
+
+def test_windows_host_probes_container_for_non_windows_targets(
+    main_module: ModuleType,
+    module_harness: HarnessFactory,
+) -> None:
+    """Still probes container runtimes for non-Windows targets."""
+
+    harness = module_harness(main_module)
+    harness.patch_platform("win32")
+
+    default_toolchain = main_module.DEFAULT_TOOLCHAIN
+
+    def fake_run(
+        executable: str,
+        args: list[str],
+        *,
+        allowed_names: tuple[str, ...],
+        capture_output: bool = False,
+        check: bool = False,
+        text: bool = False,
+        **_: object,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = allowed_names
+        cmd = [executable, *args]
+        if executable == "/usr/bin/rustup" and args[:2] == ["toolchain", "list"]:
+            stdout = f"{default_toolchain}-x86_64-pc-windows-msvc\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout)
+        if executable == "/usr/bin/rustup" and args[:2] == ["which", "rustc"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="/fake/rustc")
+        return subprocess.CompletedProcess(cmd, 0, stdout="")
+
+    harness.patch_subprocess_run(fake_run)
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/bin/rustup" if name == "rustup" else None
+
+    harness.patch_shutil_which(fake_which)
+    runtime_calls: list[str] = []
+
+    def fake_runtime(name: str, *, cwd: object | None = None) -> bool:
+        runtime_calls.append(name)
+        _ = cwd
+        return False
+
+    harness.patch_attr("runtime_available", fake_runtime)
+    harness.patch_attr("ensure_cross", lambda *_: (None, None))
+
+    main_module.main("x86_64-unknown-linux-gnu", default_toolchain)
+
+    assert runtime_calls == ["docker", "podman"]
+
+
 def test_configure_windows_linkers_prefers_toolchain_gcc(
     main_module: ModuleType,
     module_harness: HarnessFactory,

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -184,6 +184,7 @@ def test_falls_back_to_cargo_when_cross_container_fails(
         "x86_64-pc-windows-msvc",
         "aarch64-pc-windows-gnu",
     ],
+    ids=("x86_64-pc-windows-msvc", "aarch64-pc-windows-gnu"),
 )
 def test_windows_host_skips_container_probe_for_windows_targets(
     main_module: ModuleType,


### PR DESCRIPTION
## Summary
- Skip probing docker/podman when building Windows targets on Windows hosts to avoid docker.exe timeouts; closes #93.
- Add tests to confirm Windows hosts skip container probes for Windows targets but still probe for non-Windows builds.

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ce87d18ff48322b61f6b94cce8b7c4

## Summary by Sourcery

Skip container runtime checks when building Windows targets on Windows hosts and add tests verifying container probe behavior for Windows and non-Windows targets

Enhancements:
- Skip probing docker and podman when running on a Windows host building a Windows target

Tests:
- Add test to confirm that no container runtimes are probed for Windows targets on Windows hosts
- Add test to confirm that container runtimes are still probed for non-Windows targets on Windows hosts