### PR TITLE
Fix cmd_mox fixture usage and expose dev extra

### DIFF
--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -18,11 +18,13 @@ if typ.TYPE_CHECKING:
     from types import ModuleType
 
     from .conftest import HarnessFactory
+
 @CMD_MOX_UNSUPPORTED
 def test_skips_target_install_when_cross_available(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
+    cmd_mox,
 ) -> None:
     """Continues when target addition fails but cross is available."""
     cross_env = module_harness(cross_module)
@@ -65,6 +67,7 @@ def test_errors_when_target_unsupported_without_cross(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
+    cmd_mox,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Emits an error when the toolchain lacks the requested target."""
@@ -103,6 +106,7 @@ def test_falls_back_to_cargo_when_cross_container_fails(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
+    cmd_mox,
 ) -> None:
     """Falls back to cargo when cross exits with a container error."""
     cross_env = module_harness(cross_module)

--- a/docs/cmd-mox-users-guide.md
+++ b/docs/cmd-mox-users-guide.md
@@ -1,7 +1,7 @@
 # CmdMox Usage Guide
 
 CmdMox provides a fluent API for mocking, stubbing and spying on external
-commands in your tests. This guide shows common patterns for everyday use.
+commands in tests. This guide shows common patterns for everyday use.
 
 ## Related documents
 
@@ -17,7 +17,7 @@ cmd-mox is not currently supported):
 pip install cmd-mox
 ```
 
-In your `conftest.py`:
+In a project's `conftest.py`:
 
 ```python
 import sys
@@ -34,7 +34,7 @@ Windows bypass them gracefully.
 ## Basic workflow
 
 CmdMox follows a strict record → replay → verify lifecycle. First declare
-expectations, then run your code with the shims active, finally verify that
+expectations, then run the code with the shims active, finally verify that
 interactions matched what was recorded.
 
 The three phases are defined in the design document:
@@ -85,7 +85,7 @@ cmd_mox.mock("git") \
     .returns(exit_code=0)
 ```
 
-You can match arguments more flexibly using comparators:
+Arguments can be matched more flexibly using comparators:
 
 ```python
 from cmd_mox import Regex, Contains
@@ -175,8 +175,8 @@ restricted to spy doubles.
 the context-manager API:
 
 - `verify_on_exit` (default `True`) automatically calls `verify()` when a replay
-  phase ends inside a `with CmdMox()` block. Disable it when you need to manage
-  verification manually. Verification still runs if the body raises; when both
+  phase ends inside a `with CmdMox()` block. Disable it when manual verification
+  management is required. Verification still runs if the body raises; when both
   verification and the body fail, the verification error is suppressed so the
   original exception surfaces.
 - `max_journal_entries` bounds the number of stored invocations (oldest entries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-
-
-[project.optional-dependencies]
-dev = [
-    "lxml-stubs>=0.5.1",
-    "pytest>=8.0,<9.0",
-    "pyyaml>=6.0,<7.0",
-    "ty>=0.0.1a20",
-    "uuid6>=2025.0.1",
-    "cmd-mox@git+https://github.com/leynos/cmd-mox.git@5bf23d0ae6055397956a3d4440063fa6a77b10d8",
-]
-
 [dependency-groups]
 dev = [
     "lxml-stubs>=0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,16 @@ classifiers = [
 ]
 
 
+[project.optional-dependencies]
+dev = [
+    "lxml-stubs>=0.5.1",
+    "pytest>=8.0,<9.0",
+    "pyyaml>=6.0,<7.0",
+    "ty>=0.0.1a20",
+    "uuid6>=2025.0.1",
+    "cmd-mox@git+https://github.com/leynos/cmd-mox.git@5bf23d0ae6055397956a3d4440063fa6a77b10d8",
+]
+
 [dependency-groups]
 dev = [
     "lxml-stubs>=0.5.1",
@@ -113,7 +123,7 @@ typeCheckingMode = "strict"
 reportUnknownVariableType = "error"
 reportUnknownParameterType = "error"
 reportUnknownMemberType = "error"
-reportMissingTypeStubs = "warning"
+reportMissingTypeStubs = "error"
 pythonVersion = "3.12"
 venvPath = "."
 venv = ".venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,12 +106,3 @@ timeout = 30
 [tool.uv]
 package = false
 
-[tool.pyright]
-typeCheckingMode = "strict"
-reportUnknownVariableType = "error"
-reportUnknownParameterType = "error"
-reportUnknownMemberType = "error"
-reportMissingTypeStubs = "error"
-pythonVersion = "3.12"
-venvPath = "."
-venv = ".venv"

--- a/uv.lock
+++ b/uv.lock
@@ -229,6 +229,16 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "cmd-mox" },
+    { name = "lxml-stubs" },
+    { name = "pytest" },
+    { name = "pyyaml" },
+    { name = "ty" },
+    { name = "uuid6" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "cmd-mox" },
@@ -241,10 +251,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cmd-mox", marker = "extra == 'dev'", git = "https://github.com/leynos/cmd-mox.git?rev=5bf23d0ae6055397956a3d4440063fa6a77b10d8" },
     { name = "lxml", specifier = ">=5.2,<6.0" },
+    { name = "lxml-stubs", marker = "extra == 'dev'", specifier = ">=0.5.1" },
     { name = "plumbum", specifier = ">=1.8,<2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<9.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0,<7.0" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a20" },
     { name = "typer", specifier = ">=0.9,<1.0" },
+    { name = "uuid6", marker = "extra == 'dev'", specifier = ">=2025.0.1" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -229,16 +229,6 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "cmd-mox" },
-    { name = "lxml-stubs" },
-    { name = "pytest" },
-    { name = "pyyaml" },
-    { name = "ty" },
-    { name = "uuid6" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "cmd-mox" },
@@ -251,17 +241,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cmd-mox", marker = "extra == 'dev'", git = "https://github.com/leynos/cmd-mox.git?rev=5bf23d0ae6055397956a3d4440063fa6a77b10d8" },
     { name = "lxml", specifier = ">=5.2,<6.0" },
-    { name = "lxml-stubs", marker = "extra == 'dev'", specifier = ">=0.5.1" },
     { name = "plumbum", specifier = ">=1.8,<2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<9.0" },
-    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0,<7.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a20" },
     { name = "typer", specifier = ">=0.9,<1.0" },
-    { name = "uuid6", marker = "extra == 'dev'", specifier = ">=2025.0.1" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- request the `cmd_mox` fixture in the rust-build-release target installation tests to avoid NameError at runtime
- update the CmdMox user guide to remove second-person phrasing per documentation style guidance
- add a `dev` optional dependency extra alongside stricter Pyright configuration and refresh the lockfile metadata

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68cf479350d48322a7bc0f1ab7f64882

## Summary by Sourcery

Fix missing cmd_mox fixture in tests, refine user guide phrasing, expose a new dev extra in pyproject.toml, tighten type checking settings, and update the lockfile.

New Features:
- Add a `dev` optional dependency extra to pyproject.toml for developer tools

Enhancements:
- Enforce stricter Pyright configuration by treating missing type stubs as errors

Documentation:
- Revise the CmdMox user guide to remove second-person phrasing for style consistency

Tests:
- Request the `cmd_mox` fixture in rust-build-release target installation tests to prevent NameError

Chores:
- Refresh lockfile metadata after dependency changes