### PR TITLE
Fix Windows invocation of rust-build-release

### DIFF
--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -61,7 +61,9 @@ runs:
         RBR_TARGET: ${{ inputs.target }}
         RBR_TOOLCHAIN: ${{ env.RBR_TOOLCHAIN }}
       working-directory: ${{ inputs.project-dir }}
-      run: ${{ github.action_path }}/src/main.py
+      run: |
+        set -euo pipefail
+        uv run --script "$GITHUB_ACTION_PATH/src/main.py"
     - name: Stage artifacts
       if: contains(inputs.target, 'unknown-linux-gnu')
       shell: bash


### PR DESCRIPTION
## Summary
- invoke the Build release step via `uv run --script` so Windows runners resolve the script path correctly

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68cf436db9748322a98de40dd68859dd

## Summary by Sourcery

Fix Windows invocation of the rust-build-release GitHub Action by using `uv run --script` and adding shell safety options

Bug Fixes:
- Invoke release build script with `uv run --script` to resolve script path correctly on Windows runners

Enhancements:
- Add `set -euo pipefail` to the run step for stricter error handling