### PR TITLE
Narrow module fixtures to ModuleType

### DIFF
--- a/.github/actions/release-to-pypi-uv/tests/_helpers.py
+++ b/.github/actions/release-to-pypi-uv/tests/_helpers.py
@@ -6,6 +6,7 @@ import importlib.util
 import os
 import typing as typ
 from pathlib import Path
+from types import ModuleType
 
 _ACTION_PATH = os.environ.get("GITHUB_ACTION_PATH")
 
@@ -18,7 +19,7 @@ else:
     REPO_ROOT = SCRIPTS_DIR.parents[3]
 
 
-def load_script_module(name: str) -> typ.Any:
+def load_script_module(name: str) -> ModuleType:
     """Load a script module by *name* from the action's scripts directory."""
     script_path = SCRIPTS_DIR / f"{name}.py"
     spec = importlib.util.spec_from_file_location(

--- a/.github/actions/release-to-pypi-uv/tests/test_check_github_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_check_github_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import typing as typ
+from types import ModuleType
 
 import pytest
 
@@ -31,14 +32,14 @@ class DummyResponse:
 
 
 @pytest.fixture(name="module")
-def fixture_module() -> typ.Any:
+def fixture_module() -> ModuleType:
     return load_script_module("check_github_release")
 
 
 def test_success(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    module: typ.Any,
+    module: ModuleType,
 ) -> None:
     def fake_urlopen(request: typ.Any, timeout: float = 30) -> DummyResponse:  # noqa: ANN401
         return DummyResponse({"draft": False, "prerelease": False, "name": "1.2.3"})
@@ -53,7 +54,7 @@ def test_success(
 
 def test_draft_release(
     monkeypatch: pytest.MonkeyPatch,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     def fake_urlopen(request: typ.Any, timeout: float = 30) -> DummyResponse:  # noqa: ANN401
@@ -70,7 +71,7 @@ def test_draft_release(
 
 def test_prerelease(
     monkeypatch: pytest.MonkeyPatch,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     def fake_urlopen(request: typ.Any, timeout: float = 30) -> DummyResponse:  # noqa: ANN401
@@ -87,7 +88,7 @@ def test_prerelease(
 
 def test_missing_release(
     monkeypatch: pytest.MonkeyPatch,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     def fake_urlopen(request: typ.Any, timeout: float = 30) -> typ.Any:  # noqa: ANN401
@@ -110,7 +111,7 @@ def test_missing_release(
 
 def test_permission_denied(
     monkeypatch: pytest.MonkeyPatch,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     detail = b"forbidden"
@@ -136,7 +137,7 @@ def test_permission_denied(
 
 def test_retries_then_success(
     monkeypatch: pytest.MonkeyPatch,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     attempts: list[int] = []

--- a/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typing as typ
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,7 +12,7 @@ from ._helpers import REPO_ROOT, load_script_module
 
 
 @pytest.fixture(name="publish_module")
-def fixture_publish_module() -> typ.Any:
+def fixture_publish_module() -> ModuleType:
     module = load_script_module("publish_release")
     if str(REPO_ROOT) not in module.sys.path:  # type: ignore[attr-defined]
         module.sys.path.insert(0, str(REPO_ROOT))  # type: ignore[attr-defined]
@@ -19,7 +20,7 @@ def fixture_publish_module() -> typ.Any:
 
 
 def test_publish_default_index(
-    monkeypatch: pytest.MonkeyPatch, publish_module: typ.Any
+    monkeypatch: pytest.MonkeyPatch, publish_module: ModuleType
 ) -> None:
     calls: list[list[str]] = []
 
@@ -34,7 +35,7 @@ def test_publish_default_index(
 
 
 def test_publish_custom_index(
-    monkeypatch: pytest.MonkeyPatch, publish_module: typ.Any
+    monkeypatch: pytest.MonkeyPatch, publish_module: ModuleType
 ) -> None:
     calls: list[list[str]] = []
 
@@ -49,7 +50,7 @@ def test_publish_custom_index(
 
 
 def test_publish_run_cmd_error(
-    monkeypatch: pytest.MonkeyPatch, publish_module: typ.Any
+    monkeypatch: pytest.MonkeyPatch, publish_module: ModuleType
 ) -> None:
     class DummyError(Exception):
         pass

--- a/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as typ
+from types import ModuleType
 
 if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
     from pathlib import Path
@@ -13,7 +14,7 @@ from ._helpers import load_script_module
 
 
 @pytest.fixture(name="module")
-def fixture_module() -> typ.Any:
+def fixture_module() -> ModuleType:
     return load_script_module("validate_toml_versions")
 
 
@@ -42,14 +43,14 @@ def _write_pyproject(base: Path, content: str) -> None:
     (base / "pyproject.toml").write_text(content.strip())
 
 
-def _invoke_main(module: typ.Any, **kwargs: typ.Any) -> None:
+def _invoke_main(module: ModuleType, **kwargs: str) -> None:
     kwargs.setdefault("pattern", "**/pyproject.toml")
     kwargs.setdefault("fail_on_dynamic", "false")
     module.main(**kwargs)
 
 
 def test_passes_when_versions_match(
-    project_root: Path, module: typ.Any, capsys: pytest.CaptureFixture[str]
+    project_root: Path, module: ModuleType, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _write_pyproject(
         project_root / "pkg",
@@ -67,7 +68,7 @@ version = "1.0.0"
 
 
 def test_fails_on_mismatch(
-    project_root: Path, module: typ.Any, capsys: pytest.CaptureFixture[str]
+    project_root: Path, module: ModuleType, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _write_pyproject(
         project_root / "pkg",
@@ -86,7 +87,7 @@ version = "1.0.1"
 
 
 def test_dynamic_version_failure(
-    project_root: Path, module: typ.Any, capsys: pytest.CaptureFixture[str]
+    project_root: Path, module: ModuleType, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _write_pyproject(
         project_root / "pkg",
@@ -107,7 +108,7 @@ dynamic = ["version"]
 @pytest.mark.parametrize("truthy", ["true", "TRUE", "Yes", " y ", "1", "On"])
 def test_dynamic_version_failure_for_truthy_variants(
     project_root: Path,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
     truthy: str,
 ) -> None:
@@ -141,7 +142,7 @@ dynamic = ["version"]
 
 
 def test_fails_on_parse_error(
-    project_root: Path, module: typ.Any, capsys: pytest.CaptureFixture[str]
+    project_root: Path, module: ModuleType, capsys: pytest.CaptureFixture[str]
 ) -> None:
     target = project_root / "pkg"
     target.mkdir()
@@ -156,7 +157,7 @@ def test_fails_on_parse_error(
 
 def test_dynamic_version_allowed_when_flag_false(
     project_root: Path,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Allow dynamic versions when the flag explicitly disables failures.
@@ -188,7 +189,7 @@ dynamic = ["version"]
 @pytest.mark.parametrize("falsey", ["false", "", "no", "0", "off", "n", "False"])
 def test_dynamic_version_allowed_for_falsey_variants(
     project_root: Path,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
     falsey: str,
 ) -> None:
@@ -222,7 +223,7 @@ dynamic = ["version"]
 
 def test_dynamic_version_allowed_when_flag_unset(
     project_root: Path,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Allow dynamic versions when the flag is omitted entirely.
@@ -253,7 +254,7 @@ dynamic = ["version"]
 
 def test_missing_project_section_is_ignored(
     project_root: Path,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Ignore files lacking a ``[project]`` table when validating versions.
@@ -284,7 +285,7 @@ version = "1.0.0"
 
 def test_multiple_toml_files_mixed_validity(
     project_root: Path,
-    module: typ.Any,
+    module: ModuleType,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Fail when any discovered TOML file contains a mismatched version.
@@ -323,10 +324,10 @@ version = "2.0.0"
 
 
 @pytest.mark.parametrize("value", ["true", "TRUE", "Yes", "1", "on"])
-def test_parse_bool_truthy_values(module: typ.Any, value: str) -> None:
+def test_parse_bool_truthy_values(module: ModuleType, value: str) -> None:
     assert module._parse_bool(value) is True
 
 
 @pytest.mark.parametrize("value", [None, "", "false", "no", "0", "off", "n"])
-def test_parse_bool_falsey_values(module: typ.Any, value: str | None) -> None:
+def test_parse_bool_falsey_values(module: ModuleType, value: str | None) -> None:
     assert module._parse_bool(value) is False

--- a/.github/actions/release-to-pypi-uv/tests/test_write_summary.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_write_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typing as typ
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,11 +12,11 @@ from ._helpers import load_script_module
 
 
 @pytest.fixture(name="write_module")
-def fixture_write_module() -> typ.Any:
+def fixture_write_module() -> ModuleType:
     return load_script_module("write_summary")
 
 
-def test_write_summary_appends_markdown(tmp_path: Path, write_module: typ.Any) -> None:
+def test_write_summary_appends_markdown(tmp_path: Path, write_module: ModuleType) -> None:
     summary_path = tmp_path / "summary.md"
 
     write_module.main(
@@ -32,7 +33,7 @@ def test_write_summary_appends_markdown(tmp_path: Path, write_module: typ.Any) -
 
 
 def test_write_summary_handles_existing_content(
-    tmp_path: Path, write_module: typ.Any
+    tmp_path: Path, write_module: ModuleType
 ) -> None:
     summary_path = tmp_path / "summary.md"
     summary_path.write_text("Existing\n", encoding="utf-8")
@@ -49,7 +50,7 @@ def test_write_summary_handles_existing_content(
     assert content.count("## Release summary") == 1
 
 
-def test_write_summary_raises_on_io_error(write_module: typ.Any) -> None:
+def test_write_summary_raises_on_io_error(write_module: ModuleType) -> None:
     summary_path = Path("/nonexistent/path/summary.md")
 
     with pytest.raises(OSError):


### PR DESCRIPTION
## Summary
- replace dynamic typing with ModuleType annotations for the release-to-pypi-uv test helpers and fixtures
- ensure all tests interacting with script modules accept ModuleType instances and tighten helper kwargs to string values

## Testing
- `uvx ruff check --select ANN401`


------
https://chatgpt.com/codex/tasks/task_e_68d007fcdf30832280a26f915f34b001

## Summary by Sourcery

Narrow test fixtures and helper signatures to use ModuleType and restrict helper kwargs to strings for stricter typing

Enhancements:
- Annotate script-loading fixtures and load_script_module to return ModuleType instead of Any
- Update _invoke_main and test functions to accept ModuleType parameters and tighten **kwargs types to str
- Add ModuleType imports across tests and helper modules to support new annotations