### PR TITLE
Add docstrings for release-to-pypi-uv tests and helpers

### DIFF
--- a/.github/actions/release-to-pypi-uv/scripts/determine_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/determine_release.py
@@ -26,6 +26,21 @@ def _emit_outputs(dest: Path, tag: str, version: str) -> None:
 def main(
     tag: str | None = TAG_OPTION, github_output: Path = GITHUB_OUTPUT_OPTION
 ) -> None:
+    """Resolve the release tag for the workflow execution.
+
+    Parameters
+    ----------
+    tag : str or None
+        Optional release tag supplied via the action input or CLI argument.
+    github_output : Path
+        Destination file used to communicate outputs to GitHub Actions.
+
+    Raises
+    ------
+    typer.Exit
+        If a tag cannot be resolved or does not follow the ``vMAJOR.MINOR.PATCH``
+        semantic versioning format.
+    """
     ref_type = os.getenv("GITHUB_REF_TYPE", "")
     ref_name = os.getenv("GITHUB_REF_NAME", "")
 

--- a/.github/actions/release-to-pypi-uv/tests/__init__.py
+++ b/.github/actions/release-to-pypi-uv/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test helpers for the release-to-pypi-uv action."""
+

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -15,6 +15,23 @@ pytestmark = REQUIRES_UV
 def run_confirm(
     tmp_path: Path, expected: str, confirm: str
 ) -> subprocess.CompletedProcess[str]:
+    """Execute the ``confirm_release`` script with explicit inputs.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory that holds the generated workspace files.
+    expected : str
+        Confirmation phrase the script requires for success.
+    confirm : str
+        Value that simulates the operator-provided confirmation text.
+
+    Returns
+    -------
+    subprocess.CompletedProcess of str
+        Completed process containing stdout, stderr, and the exit status.
+    """
+
     env = base_env(tmp_path)
     env["EXPECTED"] = expected
     env["INPUT_CONFIRM"] = confirm

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -14,6 +14,21 @@ pytestmark = REQUIRES_UV
 def run_script(
     script: Path, *, env: dict[str, str]
 ) -> subprocess.CompletedProcess[str]:
+    """Execute the ``determine_release`` script with a supplied environment.
+
+    Parameters
+    ----------
+    script : Path
+        Path to the script file to execute.
+    env : dict[str, str]
+        Environment variables to provide to the spawned process.
+
+    Returns
+    -------
+    subprocess.CompletedProcess of str
+        Result containing stdout, stderr, and the exit status.
+    """
+
     cmd = ["uv", "run", "--script", str(script)]
     return subprocess.run(  # noqa: S603
         cmd,

--- a/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
@@ -13,6 +13,14 @@ from ._helpers import REPO_ROOT, load_script_module
 
 @pytest.fixture(name="publish_module")
 def fixture_publish_module() -> ModuleType:
+    """Load the ``publish_release`` script module and ensure import paths.
+
+    Returns
+    -------
+    ModuleType
+        Imported script module under test.
+    """
+
     module = load_script_module("publish_release")
     if str(REPO_ROOT) not in module.sys.path:  # type: ignore[attr-defined]
         module.sys.path.insert(0, str(REPO_ROOT))  # type: ignore[attr-defined]
@@ -22,6 +30,16 @@ def fixture_publish_module() -> ModuleType:
 def test_publish_default_index(
     monkeypatch: pytest.MonkeyPatch, publish_module: ModuleType
 ) -> None:
+    """Invoke ``uv publish`` without an index when none is provided.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to stub the ``run_cmd`` helper.
+    publish_module : ModuleType
+        Loaded ``publish_release`` script module under test.
+    """
+
     calls: list[list[str]] = []
 
     def fake_run_cmd(args: list[str], **_: object) -> None:
@@ -37,6 +55,16 @@ def test_publish_default_index(
 def test_publish_custom_index(
     monkeypatch: pytest.MonkeyPatch, publish_module: ModuleType
 ) -> None:
+    """Add the ``--index`` flag when a custom index value is supplied.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to stub the ``run_cmd`` helper.
+    publish_module : ModuleType
+        Loaded ``publish_release`` script module under test.
+    """
+
     calls: list[list[str]] = []
 
     def fake_run_cmd(args: list[str], **_: object) -> None:
@@ -52,6 +80,16 @@ def test_publish_custom_index(
 def test_publish_run_cmd_error(
     monkeypatch: pytest.MonkeyPatch, publish_module: ModuleType
 ) -> None:
+    """Propagate errors raised by ``run_cmd`` during publishing.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to stub the ``run_cmd`` helper.
+    publish_module : ModuleType
+        Loaded ``publish_release`` script module under test.
+    """
+
     class DummyError(Exception):
         pass
 

--- a/.github/actions/release-to-pypi-uv/tests/test_write_summary.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_write_summary.py
@@ -13,10 +13,28 @@ from ._helpers import load_script_module
 
 @pytest.fixture(name="write_module")
 def fixture_write_module() -> ModuleType:
+    """Load the ``write_summary`` script module for testing.
+
+    Returns
+    -------
+    ModuleType
+        Imported script module under test.
+    """
+
     return load_script_module("write_summary")
 
 
 def test_write_summary_appends_markdown(tmp_path: Path, write_module: ModuleType) -> None:
+    """Append a fresh summary block when the summary file is empty.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory that stores the generated summary file.
+    write_module : ModuleType
+        Loaded ``write_summary`` script module under test.
+    """
+
     summary_path = tmp_path / "summary.md"
 
     write_module.main(
@@ -35,6 +53,16 @@ def test_write_summary_appends_markdown(tmp_path: Path, write_module: ModuleType
 def test_write_summary_handles_existing_content(
     tmp_path: Path, write_module: ModuleType
 ) -> None:
+    """Preserve existing content while appending the release summary.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory that stores the generated summary file.
+    write_module : ModuleType
+        Loaded ``write_summary`` script module under test.
+    """
+
     summary_path = tmp_path / "summary.md"
     summary_path.write_text("Existing\n", encoding="utf-8")
 
@@ -51,6 +79,14 @@ def test_write_summary_handles_existing_content(
 
 
 def test_write_summary_raises_on_io_error(write_module: ModuleType) -> None:
+    """Surface file-system errors when the summary path is invalid.
+
+    Parameters
+    ----------
+    write_module : ModuleType
+        Loaded ``write_summary`` script module under test.
+    """
+
     summary_path = Path("/nonexistent/path/summary.md")
 
     with pytest.raises(OSError):

--- a/.github/actions/rust-build-release/tests/test_cross_install.py
+++ b/.github/actions/rust-build-release/tests/test_cross_install.py
@@ -21,13 +21,14 @@ if typ.TYPE_CHECKING:
     from types import ModuleType
 
     from .conftest import HarnessFactory
+    from shared_actions_conftest import CmdMoxFixture
 
 
 @CMD_MOX_UNSUPPORTED
 def test_installs_cross_when_missing(
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Installs cross when it is missing."""
     harness = module_harness(cross_module)
@@ -82,7 +83,7 @@ def test_cross_install_failure_non_windows(
 def test_upgrades_outdated_cross(
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Upgrades cross when an older version is installed."""
     harness = module_harness(cross_module)
@@ -114,7 +115,7 @@ def test_upgrades_outdated_cross(
 def test_uses_cached_cross(
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Uses cached cross when version is sufficient."""
     harness = module_harness(cross_module)
@@ -138,7 +139,7 @@ def test_uses_cached_cross(
 def test_installs_prebuilt_cross_on_windows(
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Uses the prebuilt cross binary on Windows hosts."""
     harness = module_harness(cross_module)
@@ -353,7 +354,7 @@ def test_installs_cross_without_container_runtime(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Installs cross even when no container runtime is available."""
     cross_env = module_harness(cross_module)
@@ -394,7 +395,7 @@ def test_installs_cross_without_container_runtime(
 def test_falls_back_to_git_when_crates_io_unavailable(
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Falls back to git install when crates.io is unavailable."""
     harness = module_harness(cross_module)
@@ -431,7 +432,7 @@ def test_falls_back_to_cargo_when_runtime_unusable(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Falls back to cargo when docker exists but is unusable."""
     cross_env = module_harness(cross_module)

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -1,3 +1,5 @@
+"""Tests for the target installation helpers in the rust-build-release action."""
+
 from __future__ import annotations
 
 import os
@@ -17,6 +19,7 @@ if typ.TYPE_CHECKING:
     from types import ModuleType
 
     from .conftest import HarnessFactory
+    from shared_actions_conftest import CmdMoxFixture
 
 
 @CMD_MOX_UNSUPPORTED
@@ -24,7 +27,7 @@ def test_skips_target_install_when_cross_available(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Continues when target addition fails but cross is available."""
     cross_env = module_harness(cross_module)
@@ -67,7 +70,7 @@ def test_errors_when_target_unsupported_without_cross(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Emits an error when the toolchain lacks the requested target."""
@@ -106,7 +109,7 @@ def test_falls_back_to_cargo_when_cross_container_fails(
     main_module: ModuleType,
     cross_module: ModuleType,
     module_harness: HarnessFactory,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """Falls back to cargo when cross exits with a container error."""
     cross_env = module_harness(cross_module)

--- a/.github/actions/rust-build-release/tests/test_utils.py
+++ b/.github/actions/rust-build-release/tests/test_utils.py
@@ -11,6 +11,7 @@ from shared_actions_conftest import CMD_MOX_UNSUPPORTED
 
 if typ.TYPE_CHECKING:
     from types import ModuleType
+    from shared_actions_conftest import CmdMoxFixture
 
 
 def test_ensure_allowed_executable_accepts_valid_name(
@@ -38,7 +39,7 @@ def test_ensure_allowed_executable_rejects_unknown(
 @CMD_MOX_UNSUPPORTED
 def test_run_validated_invokes_subprocess_with_validated_path(
     utils_module: ModuleType,
-    cmd_mox,
+    cmd_mox: CmdMoxFixture,
 ) -> None:
     """run_validated executes subprocess.run with the validated executable."""
     exe_path = cmd_mox.environment.shim_dir / "docker.exe"

--- a/conftest.py
+++ b/conftest.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import collections
 import collections.abc as cabc
+from pathlib import Path
 import shutil
 import sys
+from typing import NoReturn, Protocol
 
 import pytest
 
@@ -19,6 +21,59 @@ REQUIRES_UV = pytest.mark.usefixtures("require_uv")
 sys.modules.setdefault("shared_actions_conftest", sys.modules[__name__])
 
 
+type CommandResponse = tuple[str, str, int]
+
+
+class CommandDouble(Protocol):
+    """Contract for command doubles returned by cmd-mox helpers."""
+
+    def with_args(self, *args: str) -> CommandDouble:
+        """Configure the expected argv for the command double."""
+
+    def returns(
+        self,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        exit_code: int = 0,
+        **_: object,
+    ) -> CommandDouble:
+        """Configure the canned response for the command double."""
+
+    def runs(self, handler: cabc.Callable[[object], CommandResponse]) -> CommandDouble:
+        """Execute a handler when the command double is invoked."""
+
+
+class SpyDouble(CommandDouble, Protocol):
+    """Specialised command double returned by :meth:`CmdMoxFixture.spy`."""
+
+    call_count: int
+
+
+class CmdMoxEnvironment(Protocol):
+    """Portion of the cmd-mox fixture surface used by the tests."""
+
+    shim_dir: Path
+
+
+class CmdMoxFixture(Protocol):
+    """Typed façade for the cmd-mox pytest fixture used in tests."""
+
+    environment: CmdMoxEnvironment
+
+    def stub(self, command: str) -> CommandDouble:
+        """Register a stubbed command double."""
+
+    def spy(self, command: str) -> SpyDouble:
+        """Register a spying command double."""
+
+    def replay(self) -> None:
+        """Activate the recorded doubles."""
+
+    def verify(self) -> None:
+        """Assert that recorded expectations were satisfied."""
+
+
 @pytest.fixture()
 def require_uv() -> None:
     """Skip tests that exercise uv when the CLI is unavailable."""
@@ -27,7 +82,8 @@ def require_uv() -> None:
 
 
 def _register_cross_version_stub(
-    cmd_mox, stdout: str | cabc.Iterable[str] = "cross 0.2.5\n"
+    cmd_mox: CmdMoxFixture,
+    stdout: str | cabc.Iterable[str] = "cross 0.2.5\n",
 ) -> str:
     """Register a stub for ``cross --version`` and return the shim path."""
     if isinstance(stdout, str):
@@ -45,7 +101,8 @@ def _register_cross_version_stub(
 
 
 def _register_rustup_toolchain_stub(
-    cmd_mox, stdout: str
+    cmd_mox: CmdMoxFixture,
+    stdout: str,
 ) -> str:  # pragma: no cover - helper
     """Register a stub for ``rustup toolchain list`` and return the shim path."""
     cmd_mox.stub("rustup").with_args("toolchain", "list").returns(stdout=stdout)
@@ -53,7 +110,9 @@ def _register_rustup_toolchain_stub(
 
 
 def _register_docker_info_stub(
-    cmd_mox, *, exit_code: int = 0
+    cmd_mox: CmdMoxFixture,
+    *,
+    exit_code: int = 0,
 ) -> str:  # pragma: no cover - helper
     """Register a stub for ``docker info`` and return the shim path."""
     cmd_mox.stub("docker").with_args("info").returns(exit_code=exit_code)
@@ -65,6 +124,6 @@ if sys.platform != "win32":  # pragma: win32 no cover - Windows lacks cmd-mox su
 else:
 
     @pytest.fixture()
-    def cmd_mox():  # pragma: win32 no cover - fixture only used on Windows
+    def cmd_mox() -> NoReturn:  # pragma: win32 no cover - fixture only used on Windows
         """Skip tests that rely on cmd-mox on Windows."""
         pytest.skip("cmd-mox does not support Windows")


### PR DESCRIPTION
## Summary
- document the `determine_release.main` entrypoint with a numpy-style docstring
- add docstrings to the release-to-pypi-uv fixtures, helpers, and tests so D1 passes
- introduce module-level docstrings for the shared test package and rust target install tests

## Testing
- uvx ruff check --select D1

------
https://chatgpt.com/codex/tasks/task_e_68d00bbad2908322a2cde4ffc2153875