### PR TITLE
Add windows-package action for WiX MSI builds

### DIFF
--- a/.github/actions/windows-package/CHANGELOG.md
+++ b/.github/actions/windows-package/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## windows-package-v0.1.0
+
+- Initial release of the Windows packaging composite action.
+- Installs WiX v4, builds an MSI from a `.wxs` file and uploads the artefact.

--- a/.github/actions/windows-package/README.md
+++ b/.github/actions/windows-package/README.md
@@ -1,0 +1,88 @@
+# Windows package action
+
+Build a WiX v4 MSI from a prebuilt Windows application, licence text (RTF) and
+supporting documentation. The action codifies the workflow documented in the
+repository guidance so that any job can produce a signed installer artefact with
+one composite call.
+
+## Features
+
+- Installs the WiX v4 CLI and UI extension on the runner.
+- Resolves the MSI version from an explicit input or a tagged Git reference.
+- Builds a single-file MSI (`EmbedCab="yes"`) for the supplied WiX authoring.
+- Optionally uploads the generated MSI via `actions/upload-artifact`.
+
+> [!IMPORTANT]
+> This action **must** run on a Windows runner. The first step fails fast when
+> `RUNNER_OS` is not `Windows`.
+
+## Repository layout
+
+The action expects the following project structure (paths may be overridden via
+inputs):
+
+```
+.
+├─ installer/
+│  └─ Package.wxs              # WiX v4 authoring
+└─ assets/
+   ├─ MyApp.exe                # application binary
+   ├─ LICENSE.rtf              # licence text shown in the installer UI
+   └─ README.pdf               # documentation shipped with the installer
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ---- | -------- | ------- | ----------- |
+| `wxs-path` | no | `installer/Package.wxs` | Path to the WiX authoring file used to build the MSI. |
+| `architecture` | no | `x64` | Architecture supplied to `wix build` (`x64` or `x86`). |
+| `version` | no | _auto_ | Version embedded in the MSI. Defaults to `GITHUB_REF_NAME` with a leading `v` removed or `0.0.0`. |
+| `dotnet-version` | no | `8.0.x` | .NET SDK version installed before running WiX. |
+| `wix-tool-version` | no | _latest_ | Specific version of the `wix` .NET global tool to install. |
+| `wix-extension` | no | `WixToolset.UI.wixext` | WiX extension coordinate loaded during the build. |
+| `wix-extension-version` | no | `4` | Version suffix appended to the extension coordinate (e.g. `WixToolset.UI.wixext/4`). |
+| `output-basename` | no | `MyApp` | Base name used when creating the MSI file. |
+| `output-directory` | no | `out` | Directory where the MSI artefact is created. |
+| `upload-artifact` | no | `true` | When `true`, publishes the MSI using `actions/upload-artifact`. |
+| `artifact-name` | no | `msi` | Name of the uploaded artifact. |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| `version` | Version value resolved for the build (after tag stripping). |
+| `msi-path` | Absolute path of the generated MSI file. |
+
+## Usage
+
+```yaml
+jobs:
+  package:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build WiX MSI
+        uses: ./.github/actions/windows-package
+        with:
+          output-basename: MyApp
+          architecture: x64
+          # version: "1.2.3"               # optional override
+          # upload-artifact: 'false'       # disable artifact upload if not needed
+```
+
+When `version` is omitted the action inspects `GITHUB_REF_NAME`. If the ref
+starts with `v` (e.g. `v1.2.3`) the prefix is removed and the remainder is used
+as the MSI version. All other cases fall back to `0.0.0`.
+
+To show a licence in the installer UI you **must** supply an RTF document and
+reference it from the WiX authoring, for example:
+
+```xml
+<WixVariable Id="WixUILicenseRtf" Value="assets\LICENSE.rtf" />
+```
+
+## Release history
+
+See [CHANGELOG.md](./CHANGELOG.md).

--- a/.github/actions/windows-package/action.yml
+++ b/.github/actions/windows-package/action.yml
@@ -1,0 +1,151 @@
+name: Windows package
+description: Build a WiX v4 MSI from prebuilt application assets on Windows runners
+inputs:
+  wxs-path:
+    description: Path to the WiX authoring (.wxs) file that defines the installer.
+    required: false
+    default: installer/Package.wxs
+  architecture:
+    description: Target architecture passed to `wix build` (for example `x64` or `x86`).
+    required: false
+    default: x64
+  version:
+    description: >
+      Version string to embed in the MSI. If omitted the action strips a leading
+      `v` from `GITHUB_REF_NAME` and falls back to `0.0.0` when no tag is
+      available.
+    required: false
+  dotnet-version:
+    description: The .NET SDK version installed before invoking the WiX CLI.
+    required: false
+    default: 8.0.x
+  wix-tool-version:
+    description: Optional version constraint for the `wix` .NET global tool.
+    required: false
+  wix-extension:
+    description: WiX extension to install and load during the build.
+    required: false
+    default: WixToolset.UI.wixext
+  wix-extension-version:
+    description: Version of the WiX extension to install via `wix extension add`.
+    required: false
+    default: '4'
+  output-basename:
+    description: Base filename for the generated MSI without extension.
+    required: false
+    default: MyApp
+  output-directory:
+    description: Directory where the MSI will be written.
+    required: false
+    default: out
+  upload-artifact:
+    description: Upload the generated MSI with `actions/upload-artifact`.
+    required: false
+    default: 'true'
+  artifact-name:
+    description: Artifact name when `upload-artifact` is enabled.
+    required: false
+    default: msi
+outputs:
+  version:
+    description: Version string resolved for the MSI build.
+    value: ${{ steps.resolve-version.outputs.version }}
+  msi-path:
+    description: Absolute path to the generated MSI file.
+    value: ${{ steps.build-msi.outputs.msi-path }}
+runs:
+  using: composite
+  steps:
+    - name: Ensure Windows runner
+      shell: pwsh
+      run: |
+        if ($env:RUNNER_OS -ne 'Windows') {
+          Write-Error "windows-package action must run on a Windows runner. Current OS: $($env:RUNNER_OS)"
+          exit 1
+        }
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+    - name: Install WiX CLI and extensions
+      shell: pwsh
+      env:
+        WIX_TOOL_VERSION: ${{ inputs.wix-tool-version }}
+        WIX_EXTENSION: ${{ inputs.wix-extension }}
+        WIX_EXTENSION_VERSION: ${{ inputs.wix-extension-version }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $toolVersion = $env:WIX_TOOL_VERSION
+        if ([string]::IsNullOrWhiteSpace($toolVersion)) {
+          dotnet tool install --global wix
+        }
+        else {
+          dotnet tool install --global wix --version $toolVersion
+        }
+        if (-not [string]::IsNullOrWhiteSpace($env:WIX_EXTENSION)) {
+          $extensionCoordinate = $env:WIX_EXTENSION
+          if (-not [string]::IsNullOrWhiteSpace($env:WIX_EXTENSION_VERSION)) {
+            $extensionCoordinate = "$extensionCoordinate/$($env:WIX_EXTENSION_VERSION)"
+          }
+          wix extension add -g $extensionCoordinate
+        }
+    - id: resolve-version
+      name: Resolve package version
+      shell: pwsh
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $version = $env:INPUT_VERSION
+        if ([string]::IsNullOrWhiteSpace($version)) {
+          $refName = $env:GITHUB_REF_NAME
+          if (-not [string]::IsNullOrWhiteSpace($refName)) {
+            $version = $refName -replace '^v', ''
+          }
+        }
+        if ([string]::IsNullOrWhiteSpace($version)) {
+          $version = '0.0.0'
+        }
+        Write-Host "Resolved version: $version"
+        "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    - id: build-msi
+      name: Build MSI
+      shell: pwsh
+      env:
+        WXS_PATH: ${{ inputs.wxs-path }}
+        ARCHITECTURE: ${{ inputs.architecture }}
+        OUTPUT_BASENAME: ${{ inputs.output-basename }}
+        OUTPUT_DIRECTORY: ${{ inputs.output-directory }}
+        VERSION: ${{ steps.resolve-version.outputs.version }}
+        WIX_EXTENSION: ${{ inputs.wix-extension }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        if (-not (Test-Path -LiteralPath $env:WXS_PATH)) {
+          Write-Error "WiX source file not found: $env:WXS_PATH"
+          exit 1
+        }
+        $outDir = $env:OUTPUT_DIRECTORY
+        if (Test-Path -LiteralPath $outDir) {
+          $outDirItem = Get-Item -LiteralPath $outDir
+        }
+        else {
+          $outDirItem = New-Item -ItemType Directory -Path $outDir
+        }
+        $outputPath = Join-Path -Path $outDirItem.FullName -ChildPath ("{0}-{1}-{2}.msi" -f $env:OUTPUT_BASENAME, $env:VERSION, $env:ARCHITECTURE)
+        $arguments = @('build', $env:WXS_PATH)
+        if (-not [string]::IsNullOrWhiteSpace($env:WIX_EXTENSION)) {
+          $arguments += @('-ext', $env:WIX_EXTENSION)
+        }
+        $arguments += @('-arch', $env:ARCHITECTURE, "-dVersion=$($env:VERSION)", '-o', $outputPath)
+        wix @arguments
+        $resolved = (Resolve-Path -LiteralPath $outputPath).Path
+        "msi-path=$resolved" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    - name: Upload MSI artifact
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ steps.build-msi.outputs.msi-path }}
+branding:
+  icon: package
+  color: blue

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GitHub Actions
 | Upload CodeScene Coverage | `.github/actions/upload-codescene-coverage` | v1           |
 | Ratchet coverage          | `.github/actions/ratchet-coverage`          | v1           |
 | Rust build release        | `.github/actions/rust-build-release`        | v1           |
+| Windows package           | `.github/actions/windows-package`           | v0           |
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add the `windows-package` composite action that installs WiX v4, resolves the version and builds the MSI on Windows runners
- document usage, inputs and expected layout for the new action and start its changelog
- list the action alongside the other published actions in the repository README

## Testing
- make lint *(fails: existing ruff D202/FBT001 findings in rust-build-release code)*
- make test


------
https://chatgpt.com/codex/tasks/task_e_68d021cb4af48322a0452510a8e605d4