### PR TITLE
Scope type-checking imports

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -161,7 +161,8 @@ def _run_cargo(args: list[str]) -> str:
         errors="replace",
     )
     if proc.stdout is None or proc.stderr is None:
-        raise RuntimeError("cargo output streams not captured")  # noqa: TRY003
+        message = "cargo output streams not captured"
+        raise RuntimeError(message)
     stdout_lines: list[str] = []
 
     if os.name == "nt":

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -228,7 +228,8 @@ def test_run_cargo_windows_pump_exception(
 
     class BoomIO(io.StringIO):
         def readline(self) -> str:
-            raise RuntimeError("boom in pump")  # noqa: TRY003
+            message = "boom in pump"
+            raise RuntimeError(message)
 
     fake_cargo = _make_fake_cargo(BoomIO(), io.StringIO(""), track_lifecycle=True)
     monkeypatch.setattr(mod, "cargo", fake_cargo)
@@ -509,7 +510,8 @@ def test_lcov_permission_error(
     lcov.write_text("LF:1\nLH:1\n")
 
     def bad_read_text(*_: object, **__: object) -> str:
-        raise PermissionError("nope")
+        message = "nope"
+        raise PermissionError(message)
 
     monkeypatch.setattr(Path, "read_text", bad_read_text, raising=False)
     with pytest.raises(run_rust_module.typer.Exit) as excinfo:
@@ -677,7 +679,8 @@ def test_cobertura_permission_error(
     xml.write_text("<coverage/>")
 
     def raise_permission_error(*_: object, **__: object) -> object:
-        raise PermissionError("denied")
+        message = "denied"
+        raise PermissionError(message)
 
     import coverage_parsers
 

--- a/.github/actions/release-to-pypi-uv/scripts/validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/scripts/validate_toml_versions.py
@@ -58,17 +58,20 @@ def _load_toml(path: Path) -> dict[str, object]:
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
-        raise RuntimeError(f"{path}: failed to read: {exc}") from exc
+        message = f"{path}: failed to read: {exc}"
+        raise RuntimeError(message) from exc
 
     try:
         import tomllib
     except ModuleNotFoundError as exc:  # pragma: no cover - python < 3.11
-        raise RuntimeError("tomllib module is unavailable") from exc
+        message = "tomllib module is unavailable"
+        raise RuntimeError(message) from exc
 
     try:
         return tomllib.loads(text)
     except tomllib.TOMLDecodeError as exc:  # type: ignore[attr-defined]
-        raise RuntimeError(f"{path}: failed to parse: {exc}") from exc
+        message = f"{path}: failed to parse: {exc}"
+        raise RuntimeError(message) from exc
 
 
 def main(

--- a/.github/actions/release-to-pypi-uv/tests/_helpers.py
+++ b/.github/actions/release-to-pypi-uv/tests/_helpers.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
-from types import ModuleType
+import typing as typ
+
+if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
+    from types import ModuleType
 
 _ACTION_PATH = os.environ.get("GITHUB_ACTION_PATH")
 
@@ -25,7 +28,8 @@ def load_script_module(name: str) -> ModuleType:
         f"release_to_pypi_uv_{name}", script_path
     )
     if spec is None or spec.loader is None:  # pragma: no cover - import failure
-        raise RuntimeError(f"Unable to load script module {name} from {script_path}")
+        message = f"Unable to load script module {name} from {script_path}"
+        raise RuntimeError(message)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/.github/actions/release-to-pypi-uv/tests/test_check_github_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_check_github_release.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import io
 import json
 import typing as typ
-from types import ModuleType
+
+if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
+    from types import ModuleType
 
 import pytest
 
@@ -162,7 +164,8 @@ def test_retries_then_success(
     def fake_urlopen(request: typ.Any, timeout: float = 30) -> DummyResponse:  # noqa: ANN401
         attempts.append(1)
         if len(attempts) < 3:
-            raise module.urllib.error.URLError("temporary")
+            message = "temporary"
+            raise module.urllib.error.URLError(message)
         return DummyResponse({"draft": False, "prerelease": False, "name": "ok"})
 
     monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)

--- a/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from types import ModuleType
+import typing as typ
+
+if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
+    from types import ModuleType
 
 import pytest
 
@@ -59,7 +62,8 @@ def test_publish_run_cmd_error(
         pass
 
     def fake_run_cmd(_: list[str], **__: object) -> None:
-        raise DummyError("uv publish failed")
+        message = "uv publish failed"
+        raise DummyError(message)
 
     monkeypatch.setattr(publish_module, "run_cmd", fake_run_cmd)
 

--- a/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import typing as typ
-from types import ModuleType
 
 if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
     from pathlib import Path
+    from types import ModuleType
 
 import pytest
 

--- a/.github/actions/release-to-pypi-uv/tests/test_write_summary.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_write_summary.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import ModuleType
+import typing as typ
+
+if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
+    from types import ModuleType
 
 import pytest
 

--- a/.github/actions/rust-build-release/tests/test_utils.py
+++ b/.github/actions/rust-build-release/tests/test_utils.py
@@ -43,7 +43,9 @@ def test_run_validated_invokes_subprocess_with_validated_path(
     cmd_mox: CmdMox,
 ) -> None:
     """run_validated executes subprocess.run with the validated executable."""
-    exe_path = cmd_mox.shim_dir / "docker.exe"
+    shim_dir = cmd_mox.environment.shim_dir
+    assert shim_dir is not None
+    exe_path = shim_dir / "docker.exe"
     spy = cmd_mox.spy("docker.exe").with_args("info").returns(stdout="ok")
 
     cmd_mox.replay()

--- a/conftest.py
+++ b/conftest.py
@@ -6,8 +6,7 @@ import collections
 import collections.abc as cabc
 import shutil
 import sys
-from pathlib import Path
-from typing import NoReturn, Protocol
+import typing as t
 
 import pytest
 
@@ -21,7 +20,11 @@ REQUIRES_UV = pytest.mark.usefixtures("require_uv")
 sys.modules.setdefault("shared_actions_conftest", sys.modules[__name__])
 
 
-class CmdDouble(Protocol):
+if t.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
+    from pathlib import Path
+
+
+class CmdDouble(t.Protocol):
     """Contract for cmd-mox doubles that record expectations and behaviour."""
 
     call_count: int
@@ -43,10 +46,16 @@ class CmdDouble(Protocol):
         """Execute a handler when the double is invoked."""
 
 
-class CmdMox(Protocol):
+class CmdMoxEnvironment(t.Protocol):
+    """Subset of :class:`cmd_mox.EnvironmentManager` used in tests."""
+
+    shim_dir: Path | None
+
+
+class CmdMox(t.Protocol):
     """Typed façade for the cmd-mox pytest fixture used in tests."""
 
-    shim_dir: Path
+    environment: CmdMoxEnvironment
 
     def stub(self, command: str) -> CmdDouble:
         """Register a stubbed command double."""
@@ -59,6 +68,15 @@ class CmdMox(Protocol):
 
     def verify(self) -> None:
         """Assert that recorded expectations were satisfied."""
+
+
+def _shim_path(cmd_mox: CmdMox, command: str) -> str:
+    """Return the shim path for ``command`` ensuring the environment is ready."""
+    shim_dir = cmd_mox.environment.shim_dir
+    if shim_dir is None:  # pragma: no cover - defensive guard
+        msg = "cmd-mox shim directory is unavailable"
+        raise RuntimeError(msg)
+    return str(shim_dir / command)
 
 
 @pytest.fixture
@@ -84,7 +102,7 @@ def _register_cross_version_stub(
             return data, "", 0
 
         cmd_mox.stub("cross").with_args("--version").runs(_handler)
-    return str(cmd_mox.shim_dir / "cross")
+    return _shim_path(cmd_mox, "cross")
 
 
 def _register_rustup_toolchain_stub(
@@ -93,7 +111,7 @@ def _register_rustup_toolchain_stub(
 ) -> str:  # pragma: no cover - helper
     """Register a stub for ``rustup toolchain list`` and return the shim path."""
     cmd_mox.stub("rustup").with_args("toolchain", "list").returns(stdout=stdout)
-    return str(cmd_mox.shim_dir / "rustup")
+    return _shim_path(cmd_mox, "rustup")
 
 
 def _register_docker_info_stub(
@@ -103,7 +121,7 @@ def _register_docker_info_stub(
 ) -> str:  # pragma: no cover - helper
     """Register a stub for ``docker info`` and return the shim path."""
     cmd_mox.stub("docker").with_args("info").returns(exit_code=exit_code)
-    return str(cmd_mox.shim_dir / "docker")
+    return _shim_path(cmd_mox, "docker")
 
 
 if sys.platform != "win32":  # pragma: win32 no cover - Windows lacks cmd-mox support
@@ -111,6 +129,6 @@ if sys.platform != "win32":  # pragma: win32 no cover - Windows lacks cmd-mox su
 else:
 
     @pytest.fixture
-    def cmd_mox() -> NoReturn:  # pragma: win32 no cover - fixture only used on Windows
+    def cmd_mox() -> t.NoReturn:  # pragma: win32 no cover - fixture only used on Windows
         """Skip tests that rely on cmd-mox on Windows."""
         pytest.skip("cmd-mox does not support Windows")


### PR DESCRIPTION
## Summary
- gate cmd-mox typing dependencies behind `TYPE_CHECKING` in `conftest.py`
- move the `ModuleType` annotations for release-to-pypi tests behind type-checking blocks to satisfy TC003

## Testing
- `uvx ruff check --select ICN003,TC003`
- `uv run --with typer --with packaging --with plumbum --with pyyaml pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d026396ed4832285ef8e693f20a6fd