### PR TITLE
Test full success message for matching versions

### DIFF
--- a/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
@@ -55,7 +55,10 @@ version = "1.0.0"
     _invoke_main(module, version="1.0.0")
 
     captured = capsys.readouterr()
-    assert "all versions match 1.0.0" in captured.out
+    assert (
+        captured.out.strip()
+        == "Checked 1 PEP 621 project file(s); all versions match 1.0.0."
+    )
 
 
 def test_fails_on_mismatch(


### PR DESCRIPTION
## Summary
- update the happy-path validate_toml_versions test to assert the complete success message emitted by the CLI

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d0685c4d9883228457034fe555469b

## Summary by Sourcery

Tests:
- Modify test_passes_when_versions_match to assert the exact output: "Checked 1 PEP 621 project file(s); all versions match 1.0.0."