### PR TITLE
Address review feedback for release-to-pypi-uv and rust build tests

### DIFF
--- a/.github/actions/release-to-pypi-uv/scripts/validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/scripts/validate_toml_versions.py
@@ -35,7 +35,9 @@ TRUTHY_STRINGS = {"true", "1", "yes", "y", "on"}
 
 def _iter_files(pattern: str) -> typ.Iterable[Path]:
     root = Path()
-    for path in root.glob(pattern):
+    for path in sorted(
+        root.glob(pattern), key=lambda candidate: tuple(candidate.parts)
+    ):
         if not path.is_file():
             continue
         parts = set(path.parts)

--- a/.github/actions/release-to-pypi-uv/tests/test_action_python_version.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_action_python_version.py
@@ -34,4 +34,4 @@ def test_install_step_uses_python_version_input() -> None:
     data = _load_action()
     steps = data["runs"]["steps"]
     install_step = next(step for step in steps if step["name"] == "Install Python")
-    assert install_step["run"] == 'uv python install "${{ inputs.python-version }}"'
+    assert 'uv python install "${{ inputs.python-version }}"' in install_step["run"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         # v2.0.2
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
-      - name: Install action-validator
+      - name: Validate GitHub Actions metadata
         if: matrix.os == 'ubuntu-latest'
-        run: bun install -g @action-validator/core @action-validator/cli
+        run: |
+          set -euxo pipefail
+          find . -type f \( -name 'action.yml' -o -name 'action.yaml' \) -print0 \
+            | xargs -0 -n1 bunx -y @action-validator/cli validate
         shell: bash
       - name: Check formatting
         if: matrix.os == 'ubuntu-latest'

--- a/conftest.py
+++ b/conftest.py
@@ -124,6 +124,16 @@ def _register_docker_info_stub(
     return _shim_path(cmd_mox, "docker")
 
 
+def _register_podman_info_stub(
+    cmd_mox: CmdMox,
+    *,
+    exit_code: int = 0,
+) -> str:  # pragma: no cover - helper
+    """Register a stub for ``podman info`` and return the shim path."""
+    cmd_mox.stub("podman").with_args("info").returns(exit_code=exit_code)
+    return _shim_path(cmd_mox, "podman")
+
+
 if sys.platform != "win32":  # pragma: win32 no cover - windows lacks cmd-mox
     pytest_plugins = ("cmd_mox.pytest_plugin",)
 else:


### PR DESCRIPTION
## Summary
- enforce deterministic discovery ordering in `validate_toml_versions` and cover it with a focused test
- extend release validation tests and relax the python-version assertion for action metadata
- validate GitHub Action metadata in CI and guard rust-build-release against Podman runtime failures

## Testing
- make check-fmt
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d08d0ea9f883228436414af98488d0

## Summary by Sourcery

Enforce deterministic TOML discovery, extend release-to-pypi-uv tests, validate GitHub Actions metadata in CI, and add Podman fallback for rust-build-release

Bug Fixes:
- Fall back to cargo when Podman runtime detection fails in rust-build-release.

Enhancements:
- Enforce sorted, deterministic ordering of pyproject.toml file discovery in validate_toml_versions.
- Relax python-version assertion in action metadata tests to allow substring matching.

CI:
- Validate GitHub Actions metadata in CI workflow using @action-validator.

Tests:
- Add test for deterministic TOML file discovery ordering.
- Add test for Podman fallback in rust-build-release.
- Add test for aborting after exhausting retries in GitHub release validation.