### PR TITLE
Fix toolchain triple test for Linux architectures

### DIFF
--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -122,7 +122,17 @@ def main(
     toolchain_name = _resolve_toolchain_name(toolchain, target, installed_names)
     if not toolchain_name:
         try:
-            run_cmd([rustup_exec, "toolchain", "install", toolchain])
+            run_cmd(
+                [
+                    rustup_exec,
+                    "toolchain",
+                    "install",
+                    toolchain,
+                    "--profile",
+                    "minimal",
+                    "--no-self-update",
+                ]
+            )
         except subprocess.CalledProcessError:
             typer.echo(
                 f"::error:: failed to install toolchain '{toolchain}'",

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -182,9 +182,7 @@ def main(
     else:
         typer.echo(f"Building with cross ({cross_version})")
 
-    toolchain_spec = (
-        f"+{toolchain_name.rsplit('-', 4)[0]}" if use_cross else f"+{toolchain_name}"
-    )
+    toolchain_spec = f"+{toolchain_name}"
     build_cmd = [
         "cross" if use_cross else "cargo",
         toolchain_spec,

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -52,6 +52,10 @@ def _host_linux_triple() -> str:
         "amd64": "x86_64",
         "aarch64": "aarch64",
         "arm64": "aarch64",
+        "riscv64": "riscv64",
+        "ppc64le": "powerpc64le",
+        "ppc64": "powerpc64",
+        "s390x": "s390x",
     }
     arch = arch_map.get(machine)
     if arch is None:  # pragma: no cover - defensive skip

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -110,4 +110,4 @@ def test_accepts_toolchain_with_triple() -> None:
     manpage_glob = (
         project_dir / "target" / target_triple / "release" / "build"
     ).glob("rust-toy-app-*/out/rust-toy-app.1")
-    assert any(manpage_glob)
+    assert any(path.is_file() for path in manpage_glob)

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -85,6 +85,18 @@ def test_accepts_toolchain_with_triple() -> None:
             "--no-self-update",
         ]
     )
+    # Ensure the host-qualified toolchain name exists as well (no-op if already present).
+    run_cmd(
+        [
+            "rustup",
+            "toolchain",
+            "install",
+            toolchain_spec,
+            "--profile",
+            "minimal",
+            "--no-self-update",
+        ]
+    )
     res = run_script(
         script,
         target_triple,

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -39,9 +40,31 @@ def run_script(
         return subprocess.CompletedProcess(cmd, 1, "", str(exc))
 
 
+def _host_linux_triple() -> str:
+    """Return the host's GNU/Linux target triple."""
+
+    if sys.platform != "linux":  # pragma: no cover - defensive skip
+        pytest.skip(f"unsupported platform: {sys.platform!r}")
+
+    machine = platform.machine().lower()
+    arch_map = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+    }
+    arch = arch_map.get(machine)
+    if arch is None:  # pragma: no cover - defensive skip
+        pytest.skip(f"unsupported architecture: {machine!r}")
+    return f"{arch}-unknown-linux-gnu"
+
+
 @pytest.mark.usefixtures("uncapture_if_verbose")
 def test_accepts_toolchain_with_triple() -> None:
     """Running with a full toolchain triple succeeds."""
+
+    target_triple = _host_linux_triple()
+    toolchain_spec = f"1.89.0-{target_triple}"
     script = Path(__file__).resolve().parents[1] / "src" / "main.py"
     project_dir = Path(__file__).resolve().parents[4] / "rust-toy-app"
     run_cmd(
@@ -57,15 +80,15 @@ def test_accepts_toolchain_with_triple() -> None:
     )
     res = run_script(
         script,
-        "x86_64-unknown-linux-gnu",
+        target_triple,
         "--toolchain",
-        "1.89.0-x86_64-unknown-linux-gnu",
+        toolchain_spec,
         cwd=project_dir,
     )
     assert res.returncode == 0
-    binary = project_dir / "target/x86_64-unknown-linux-gnu/release/rust-toy-app"
+    binary = project_dir / f"target/{target_triple}/release/rust-toy-app"
     assert binary.exists()
     manpage_glob = project_dir.glob(
-        "target/x86_64-unknown-linux-gnu/release/build/rust-toy-app-*/out/rust-toy-app.1"
+        f"target/{target_triple}/release/build/rust-toy-app-*/out/rust-toy-app.1"
     )
     assert any(manpage_glob)

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -7,10 +7,26 @@ import platform
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 from cmd_utils import run_cmd
+
+
+def test_toolchain_channel_strips_host_triple(main_module: ModuleType) -> None:
+    """The action strips host triples when preparing cross CLI overrides."""
+
+    channel = main_module._toolchain_channel("1.89.0-x86_64-unknown-linux-gnu")
+    assert channel == "1.89.0"
+
+    nightly = main_module._toolchain_channel(
+        "nightly-2024-08-10-x86_64-unknown-linux-gnu"
+    )
+    assert nightly == "nightly-2024-08-10"
+
+    stable = main_module._toolchain_channel("stable")
+    assert stable == "stable"
 
 os.environ.setdefault("CROSS_CONTAINER_ENGINE", "docker")
 


### PR DESCRIPTION
## Summary
- detect the host GNU/Linux target triple for the toolchain sanitizer test
- run the test with the matching toolchain spec and adjust artifact assertions accordingly

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d10b25e46483229290d893f0b827ac

## Summary by Sourcery

Use the host’s GNU/Linux target triple in the toolchain sanitizer test to support multiple architectures and remove hardcoded x86_64 values.

Enhancements:
- Add a helper to detect and map the host’s Linux target triple and skip unsupported platforms or architectures
- Parameterize the toolchain spec and artifact paths in the test using the detected triple instead of hardcoded values

Tests:
- Update test_accepts_toolchain_with_triple to invoke the script with the dynamic host triple and adjust binary and manpage existence assertions