### PR TITLE
Handle runtime probe timeouts and expand release tests

### DIFF
--- a/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
@@ -10,15 +10,16 @@ if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
 import pytest
 from typer.testing import CliRunner
 
-from ._helpers import REPO_ROOT, load_script_module
+from ._helpers import SCRIPTS_DIR, load_script_module
 
 
 @pytest.fixture(name="publish_module")
 def fixture_publish_module() -> ModuleType:
     """Load the ``publish_release`` script module with repository paths set."""
     module = load_script_module("publish_release")
-    if str(REPO_ROOT) not in module.sys.path:  # type: ignore[attr-defined]
-        module.sys.path.insert(0, str(REPO_ROOT))  # type: ignore[attr-defined]
+    scripts_dir = str(SCRIPTS_DIR)
+    if scripts_dir not in module.sys.path:  # type: ignore[attr-defined]
+        module.sys.path.insert(0, scripts_dir)  # type: ignore[attr-defined]
     return module
 
 

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -57,10 +57,11 @@ def _probe_runtime(name: str) -> bool:
     except subprocess.TimeoutExpired as exc:
         timeout = getattr(exc, "timeout", None)
         duration = f" after {timeout}s" if timeout else ""
-        typer.echo(
-            f"::warning::{name} runtime probe timed out{duration}; treating runtime as unavailable",
-            err=True,
+        message = (
+            f"::warning::{name} runtime probe timed out{duration}; "
+            "treating runtime as unavailable"
         )
+        typer.echo(message, err=True)
         return False
 
 

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -50,6 +50,20 @@ def should_probe_container(host_platform: str, target: str) -> bool:
     return not _target_is_windows(target)
 
 
+def _probe_runtime(name: str) -> bool:
+    """Return True when *name* runtime is available, tolerating probe timeouts."""
+    try:
+        return runtime_available(name)
+    except subprocess.TimeoutExpired as exc:
+        timeout = getattr(exc, "timeout", None)
+        duration = f" after {timeout}s" if timeout else ""
+        typer.echo(
+            f"::warning::{name} runtime probe timed out{duration}; treating runtime as unavailable",
+            err=True,
+        )
+        return False
+
+
 @app.command()
 def main(
     target: str = typer.Argument("", help="Target triple to build"),
@@ -135,8 +149,8 @@ def main(
     docker_present = False
     podman_present = False
     if should_probe_container(sys.platform, target):
-        docker_present = runtime_available("docker")
-        podman_present = runtime_available("podman")
+        docker_present = _probe_runtime("docker")
+        podman_present = _probe_runtime("podman")
     has_container = docker_present or podman_present
 
     use_cross = cross_path is not None and has_container


### PR DESCRIPTION
## Summary
- ensure the publish_release tests add the scripts directory to sys.path instead of the repo root
- extend validate_toml_versions tests to cover ignored directories and missing project versions while hardening the fixture helper
- guard rust-build-release runtime probing against subprocess timeouts and add a regression test for the scenario

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68d13b7657b48322b36de0365c464f39

## Summary by Sourcery

Handle runtime probe timeouts gracefully in rust-build-release, expand validate_toml_versions and publish_release test coverage, and adjust test fixtures

Bug Fixes:
- Prevent subprocess.TimeoutExpired from crashing rust-build-release by catching timeouts and treating the runtime as unavailable

Enhancements:
- Introduce _probe_runtime wrapper around runtime_available and update main to use it for container probes
- Update publish_release test fixture to add the scripts directory to sys.path instead of the repository root

Tests:
- Harden validate_toml_versions fixture to create directories with mkdir(parents=True, exist_ok=True)
- Extend validate_toml_versions tests to cover ignored directories and missing project version scenarios
- Add a regression test to ensure runtime probe timeouts are handled gracefully
- Adjust publish_release tests to use the new SCRIPTS_DIR fixture for sys.path insertion