### PR TITLE
Fix Windows xfail marker removal for pytest 8

### DIFF
--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -286,15 +286,14 @@ def pytest_collection_modifyitems(
         nodeid = getattr(item, "nodeid", "")
         if WINDOWS_SMOKE_TEST not in nodeid or "-pc-windows-" not in nodeid:
             continue
-        filtered_markers = []
-        removed = False
-        for mark in item.own_markers:
-            if (
+        original_count = len(item.own_markers)
+        filtered_markers = [
+            mark
+            for mark in item.own_markers
+            if not (
                 mark.name == "xfail"
-                and WINDOWS_XFAIL_REASON in str(mark.kwargs.get("reason", ""))
-            ):
-                removed = True
-                continue
-            filtered_markers.append(mark)
-        if removed:
+                and mark.kwargs.get("reason") == WINDOWS_XFAIL_REASON
+            )
+        ]
+        if len(filtered_markers) != original_count:
             item.own_markers[:] = filtered_markers


### PR DESCRIPTION
## Summary
- update the rust-build-release test hook to filter Windows xfail markers without relying on pytest's removed `remove_marker`

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d13ca9b97c8322b443fccdfa789f06

## Summary by Sourcery

Fix Windows xfail marker removal in the rust-build-release pytest hook by filtering item.own_markers directly instead of using the removed remove_marker API to support pytest 8

Bug Fixes:
- Adjust pytest_collection_modifyitems hook to drop Windows xfail markers without relying on the deprecated remove_marker method

Tests:
- Update conftest.py to manipulate item.own_markers in-place for filtering xfail markers