### PR TITLE
Expand TOML skip directories for release validation

### DIFF
--- a/.github/actions/release-to-pypi-uv/scripts/validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/scripts/validate_toml_versions.py
@@ -28,6 +28,9 @@ SKIP_PARTS = {
     "build",
     ".direnv",
     ".mypy_cache",
+    ".pytest_cache",
+    ".cache",
+    "htmlcov",
 }
 
 TRUTHY_STRINGS = {"true", "1", "yes", "y", "on"}

--- a/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_validate_toml_versions.py
@@ -213,15 +213,17 @@ def test_skips_files_in_ignored_directories(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Warn and exit when only ignored directories match the pattern."""
-    ignored = project_root / ".venv" / "pkg"
-    _write_pyproject(
-        ignored,
-        """
+    skip_dirs = {".venv", ".mypy_cache", ".pytest_cache", ".cache", "htmlcov"}
+    assert skip_dirs <= module.SKIP_PARTS
+    for name in skip_dirs:
+        _write_pyproject(
+            project_root / name / "pkg",
+            """
 [project]
 name = "ignored"
 version = "9.9.9"
 """,
-    )
+        )
     _invoke_main(module, version="1.0.0")
     captured = capsys.readouterr()
     assert "::warning::No TOML files matched pattern" in captured.out


### PR DESCRIPTION
## Summary
- include additional transient directories in `validate_toml_versions` skip list
- extend the skip-directory test to cover the newly ignored paths

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d197d7cdd08322be2fb4b87d6cdeab