### PR TITLE
Centralize linux-packages script bootstrap

### DIFF
--- a/.github/actions/linux-packages/scripts/bootstrap.py
+++ b/.github/actions/linux-packages/scripts/bootstrap.py
@@ -1,0 +1,72 @@
+"""Helpers for loading sibling modules when executed as standalone scripts."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+import typing as typ
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_PACKAGE_NAME = _PACKAGE_DIR.name
+_HELPER_MODULE = "script_utils"
+_QUALIFIED_HELPER = f"{_PACKAGE_NAME}.{_HELPER_MODULE}"
+
+
+def _get_from_sys_modules() -> ModuleType | None:
+    """Return a cached helper module if it was already imported."""
+    for name in (_QUALIFIED_HELPER, _HELPER_MODULE):
+        module = sys.modules.get(name)
+        if isinstance(module, ModuleType):
+            return module
+    return None
+
+
+def _ensure_package() -> ModuleType:
+    """Ensure the package module exists in :data:`sys.modules`."""
+    package = sys.modules.get(_PACKAGE_NAME)
+    if isinstance(package, ModuleType):
+        return package
+    package_module = ModuleType(_PACKAGE_NAME)
+    package_module.__path__ = [str(_PACKAGE_DIR)]  # type: ignore[attr-defined]
+    sys.modules[_PACKAGE_NAME] = package_module
+    return package_module
+
+
+def _import_via_package() -> ModuleType | None:
+    """Attempt to import the helper module using the package name."""
+    try:
+        return importlib.import_module(_QUALIFIED_HELPER)
+    except ImportError:
+        return None
+
+
+def _import_via_path() -> ModuleType:
+    """Load the helper module directly from its file path."""
+    _ensure_package()
+    module_path = _PACKAGE_DIR / f"{_HELPER_MODULE}.py"
+    spec = importlib.util.spec_from_file_location(_QUALIFIED_HELPER, module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"Unable to load {_HELPER_MODULE!r} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    loader = typ.cast(importlib.abc.Loader, spec.loader)
+    sys.modules[_QUALIFIED_HELPER] = module
+    sys.modules[_HELPER_MODULE] = module
+    loader.exec_module(module)
+    return module
+
+
+def load_script_utils() -> ModuleType:
+    """Return the ``script_utils`` module regardless of execution context."""
+    cached = _get_from_sys_modules()
+    if cached is not None:
+        return cached
+
+    module = _import_via_package()
+    if module is not None:
+        return module
+
+    return _import_via_path()

--- a/.github/actions/linux-packages/scripts/package.py
+++ b/.github/actions/linux-packages/scripts/package.py
@@ -46,20 +46,15 @@ if typ.TYPE_CHECKING:
     )
 else:  # pragma: no cover - runtime fallback when executed as a script
     try:
-        from .script_utils import (
-            ensure_directory,
-            ensure_exists,
-            get_command,
-            run_cmd,
-        )
+        from .bootstrap import load_script_utils
     except ImportError:  # pragma: no cover - fallback for direct execution
-        scripts_dir = Path(__file__).resolve().parent
-        sys.path.insert(0, scripts_dir.as_posix())
-        helpers = typ.cast("typ.Any", __import__("script_utils"))
-        ensure_directory = helpers.ensure_directory
-        ensure_exists = helpers.ensure_exists
-        get_command = helpers.get_command
-        run_cmd = helpers.run_cmd
+        from bootstrap import load_script_utils  # type: ignore[import-not-found]
+
+    helpers = typ.cast("typ.Any", load_script_utils())
+    ensure_directory = helpers.ensure_directory
+    ensure_exists = helpers.ensure_exists
+    get_command = helpers.get_command
+    run_cmd = helpers.run_cmd
 
 
 class PackagingError(RuntimeError):

--- a/.github/actions/linux-packages/scripts/polythene.py
+++ b/.github/actions/linux-packages/scripts/polythene.py
@@ -50,14 +50,14 @@ if typ.TYPE_CHECKING:
     from .script_utils import ensure_directory, get_command, run_cmd
 else:
     try:
-        from .script_utils import ensure_directory, get_command, run_cmd
+        from .bootstrap import load_script_utils
     except ImportError:  # pragma: no cover - fallback for direct execution
-        scripts_dir = Path(__file__).resolve().parent
-        sys.path.insert(0, scripts_dir.as_posix())
-        helpers = typ.cast("typ.Any", __import__("script_utils"))
-        ensure_directory = helpers.ensure_directory
-        get_command = helpers.get_command
-        run_cmd = helpers.run_cmd
+        from bootstrap import load_script_utils  # type: ignore[import-not-found]
+
+    helpers = typ.cast("typ.Any", load_script_utils())
+    ensure_directory = helpers.ensure_directory
+    get_command = helpers.get_command
+    run_cmd = helpers.run_cmd
 
 
 # -------------------- Configuration --------------------


### PR DESCRIPTION
## Summary
- add a bootstrap helper to resolve script_utils whether the scripts run as part of the package or via runpy
- update package.py and polythene.py to call the shared loader instead of duplicating sys.path manipulation

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d1c72493f48322abb6031d7f62105f