### PR TITLE
Fix crate version extraction step indentation

### DIFF
--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -47,13 +47,20 @@ jobs:
         with:
           llvm-mingw-version: ${{ env.LLVM_MINGW_VERSION }}
           llvm-mingw-sha256: ${{ env.LLVM_MINGW_SHA256 }}
+      - name: Setup uv
+        # v6.4.3
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        with:
+          python-version: '3.12'
       - name: Extract crate version
         id: crate-version
         shell: bash
         working-directory: rust-toy-app
         run: |
           set -euo pipefail
-          version=$(python -c 'import pathlib, tomllib; data = tomllib.loads(pathlib.Path("Cargo.toml").read_text("utf-8")); print(data["package"]["version"])')
+          version=$(
+            uv run --python 3.12 python -c "from pathlib import Path; import tomllib; print(tomllib.loads(Path('Cargo.toml').read_text(encoding='utf-8'))['package']['version'])"
+          )
           echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Build
         uses: ./.github/actions/rust-build-release

--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -53,16 +53,7 @@ jobs:
         working-directory: rust-toy-app
         run: |
           set -euo pipefail
-          version=$(python - <<'PY'
-import tomllib
-from pathlib import Path
-
-with Path("Cargo.toml").open("rb") as handle:
-    data = tomllib.load(handle)
-
-print(data["package"]["version"])
-PY
-)
+          version=$(python -c 'import pathlib, tomllib; data = tomllib.loads(pathlib.Path("Cargo.toml").read_text("utf-8")); print(data["package"]["version"])')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Build
         uses: ./.github/actions/rust-build-release


### PR DESCRIPTION
## Summary
- update the crate version extraction step to use a single-line `python -c` invocation
- avoid YAML indentation issues that broke workflow parsing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cc4cf1d8832286008edd9482c922

## Summary by Sourcery

Streamline the crate version extraction step in the GitHub Actions workflow by using a single-line Python invocation to avoid YAML indentation errors

Bug Fixes:
- Fix YAML indentation issue that was breaking the workflow parsing

Enhancements:
- Replace the multi-line Python here-doc with a single-line `python -c` command for extracting the Cargo package version