### PR TITLE
tests: align linux arch mapping helper with action logic

### DIFF
--- a/.github/actions/linux-packages/tests/_packaging_utils.py
+++ b/.github/actions/linux-packages/tests/_packaging_utils.py
@@ -87,7 +87,20 @@ def deb_arch_for_target(target: str) -> str:
         return "i386"
     if lowered.startswith(("aarch64-", "arm64-")):
         return "arm64"
-    return "riscv64" if lowered.startswith("riscv64") else "amd64"
+    if lowered.startswith(
+        (
+            "armv7-",
+            "armv7_",
+            "armv6-",
+            "armv6_",
+            "arm-unknown-linux-gnueabihf",
+            "arm-unknown-linux-musleabihf",
+        )
+    ):
+        return "armhf"
+    if lowered.startswith("riscv64"):
+        return "riscv64"
+    return "amd64"
 
 
 def build_release_artifacts(

--- a/.github/actions/linux-packages/tests/test_package_cli.py
+++ b/.github/actions/linux-packages/tests/test_package_cli.py
@@ -49,6 +49,22 @@ def test_normalise_list_preserves_case_variants(
     assert result == ["Foo", "foo", "BAR", "bar", "Mixed", "MIXED"]
 
 
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("x86_64-unknown-linux-gnu", "amd64"),
+        ("i686-unknown-linux-gnu", "i386"),
+        ("aarch64-unknown-linux-gnu", "arm64"),
+        ("armv7-unknown-linux-gnueabihf", "armhf"),
+        ("riscv64gc-unknown-linux-gnu", "riscv64"),
+        ("powerpc64le-unknown-linux-gnu", "amd64"),
+    ],
+)
+def test_deb_arch_for_target_matches_action_mapping(target: str, expected: str) -> None:
+    """Helper mirrors the Debian arch logic used during staging."""
+    assert pkg_utils.deb_arch_for_target(target) == expected
+
+
 def test_coerce_optional_path_handles_none_and_blank(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docs/python-action-scripts.md
+++ b/docs/python-action-scripts.md
@@ -14,8 +14,7 @@ header so the runner can install dependencies on demand.
 #   "cyclopts>=2.9,<3.0",
 #   "plumbum>=1.8,<2.0",
 #   "pyyaml>=6.0,<7.0",
-#   "typer>=0.9,<1.0",
-#       # optional: coloured error reporting via script_utils
+#   "typer>=0.9,<1.0",  # optional: coloured error reporting via script_utils
 # ]
 # ///
 ```


### PR DESCRIPTION
## Summary
- update the Debian architecture helper to cover the same linux target patterns handled during staging, including armhf and riscv64
- add a parametrized test that locks the helper behaviour to the action mapping

## Testing
- make check-fmt
- make typecheck
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68d1cbd8573883229271389413d28a57