### PR TITLE
Improve linux-packages script helper bootstrap

### DIFF
--- a/.github/actions/linux-packages/scripts/package.py
+++ b/.github/actions/linux-packages/scripts/package.py
@@ -53,9 +53,9 @@ else:  # pragma: no cover - runtime fallback when executed as a script
             run_cmd,
         )
     except ImportError:  # pragma: no cover - fallback for direct execution
-        scripts_dir = Path(__file__).resolve().parent
-        sys.path.insert(0, scripts_dir.as_posix())
-        helpers = typ.cast("typ.Any", __import__("script_utils"))
+        from script_utils import load_script_helpers
+
+        helpers = load_script_helpers()
         ensure_directory = helpers.ensure_directory
         ensure_exists = helpers.ensure_exists
         get_command = helpers.get_command

--- a/.github/actions/linux-packages/scripts/polythene.py
+++ b/.github/actions/linux-packages/scripts/polythene.py
@@ -52,9 +52,9 @@ else:
     try:
         from .script_utils import ensure_directory, get_command, run_cmd
     except ImportError:  # pragma: no cover - fallback for direct execution
-        scripts_dir = Path(__file__).resolve().parent
-        sys.path.insert(0, scripts_dir.as_posix())
-        helpers = typ.cast("typ.Any", __import__("script_utils"))
+        from script_utils import load_script_helpers
+
+        helpers = load_script_helpers()
         ensure_directory = helpers.ensure_directory
         get_command = helpers.get_command
         run_cmd = helpers.run_cmd

--- a/.github/actions/linux-packages/scripts/script_utils.py
+++ b/.github/actions/linux-packages/scripts/script_utils.py
@@ -11,7 +11,19 @@ import typer
 from plumbum import local
 
 if typ.TYPE_CHECKING:
+    from types import ModuleType
+
     from plumbum.commands.base import BaseCommand
+
+    class _ScriptHelperModule(typ.Protocol):
+        def ensure_directory(self, path: Path, *, exist_ok: bool = True) -> Path: ...
+
+        def ensure_exists(self, path: Path, message: str) -> None: ...
+
+        def get_command(self, name: str) -> BaseCommand: ...
+
+        def run_cmd(self, *args: object, **kwargs: object) -> object: ...
+
 
 PKG_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = PKG_DIR.parent.parent.parent.parent
@@ -30,14 +42,58 @@ except ImportError:  # pragma: no cover - fallback when run as a script
 
 __all__ = [
     "PKG_DIR",
+    "ScriptHelperExports",
     "ensure_directory",
     "ensure_exists",
     "get_command",
+    "load_script_helpers",
     "run_cmd",
     "unique_match",
 ]
 
 PathIterable = typ.Iterable[Path]
+
+
+class ScriptHelperExports(typ.NamedTuple):
+    """Container for helper callables needed by standalone scripts."""
+
+    ensure_directory: typ.Callable[..., Path]
+    ensure_exists: typ.Callable[[Path, str], None]
+    get_command: typ.Callable[[str], typ.Any]
+    run_cmd: typ.Callable[..., typ.Any]
+
+
+def load_script_helpers() -> ScriptHelperExports:
+    """Return helper callables for scripts executed outside the package."""
+    module_names = {__name__}
+    if "." in __name__:
+        module_names.add(__name__.rsplit(".", 1)[-1])
+
+    module: ModuleType | None = None
+    for name in module_names:
+        module = sys.modules.get(name)
+        if module is not None:
+            break
+
+    if module is None:
+        module_path = PKG_DIR / "script_utils.py"
+        spec = importlib.util.spec_from_file_location("script_utils", module_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(name="script_utils") from None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+
+    for alias in module_names:
+        sys.modules.setdefault(alias, module)
+
+    helpers_mod = typ.cast("_ScriptHelperModule", module)
+    return ScriptHelperExports(
+        helpers_mod.ensure_directory,
+        helpers_mod.ensure_exists,
+        helpers_mod.get_command,
+        helpers_mod.run_cmd,
+    )
 
 
 def get_command(name: str) -> BaseCommand:


### PR DESCRIPTION
## Summary
- add a typed `ScriptHelperExports` container in `script_utils` and enhance `load_script_helpers` to normalise module aliases when loading outside the package
- update `package.py` and `polythene.py` fallbacks to use the typed helper without local `Any` casts when run as standalone scripts

## Testing
- make check-fmt
- make typecheck
- make lint
- make test
- ./.venv/bin/python .github/actions/linux-packages/scripts/package.py --help | head -n 2
- ./.venv/bin/python .github/actions/linux-packages/scripts/polythene.py --help | head -n 2

------
https://chatgpt.com/codex/tasks/task_e_68d1d4f20ab08322a155c9087a466d44