### PR TITLE
Fix lint issues in rust build release tests

### DIFF
--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -77,7 +77,6 @@ def should_probe_container(host_platform: str, target: str) -> bool:
 
 def _list_installed_toolchains(rustup_exec: str) -> list[str]:
     """Return installed rustup toolchain names."""
-
     result = run_validated(
         rustup_exec,
         ["toolchain", "list"],
@@ -94,7 +93,6 @@ def _resolve_toolchain_name(
     toolchain: str, target: str, installed_names: list[str]
 ) -> str:
     """Choose the best matching installed toolchain for *toolchain*."""
-
     preferred = (f"{toolchain}-{target}", toolchain)
     for name in installed_names:
         if name in preferred:
@@ -108,7 +106,6 @@ def _resolve_toolchain_name(
 
 def _looks_like_triple(candidate: str) -> bool:
     """Return ``True`` when *candidate* resembles a target triple."""
-
     components = [part for part in candidate.split("-") if part]
     if len(components) < 3:
         return False
@@ -117,7 +114,6 @@ def _looks_like_triple(candidate: str) -> bool:
 
 def _toolchain_channel(toolchain_name: str) -> str:
     """Strip any target triple suffix from *toolchain_name* for CLI overrides."""
-
     for suffix_parts in (4, 3):
         parts = toolchain_name.rsplit("-", suffix_parts)
         if len(parts) != suffix_parts + 1:

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -289,18 +289,12 @@ def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
     """Drop legacy xfail marks for Windows smoke tests now passing."""
-
     for item in items:
         nodeid = getattr(item, "nodeid", "")
-        if (
-            WINDOWS_SMOKE_TEST not in nodeid
-            or "-pc-windows-" not in nodeid
-        ):
+        if WINDOWS_SMOKE_TEST not in nodeid or "-pc-windows-" not in nodeid:
             continue
         xfail_marks = [
-            mark
-            for mark in item.iter_markers(name="xfail")
-            if mark in item.own_markers
+            mark for mark in item.iter_markers(name="xfail") if mark in item.own_markers
         ]
         if not xfail_marks:
             continue


### PR DESCRIPTION
## Summary
- remove extra blank lines after docstrings in the rust build release helper and associated tests
- tidy pytest collection hook formatting and guard `ModuleType` imports behind a `typing` gate while shortening long comments

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d25aee2c008322bd6904847178c886

## Summary by Sourcery

Fix lint issues in the rust build release helper and tests by cleaning up blank lines, adjusting imports, wrapping long lines, and tidying multi-line expressions for lint compliance.

Enhancements:
- Remove extra blank lines after docstrings and reflow long lines (comments, glob expressions) in tests and main script
- Guard ModuleType import behind typing.TYPE_CHECKING in the test module
- Simplify list comprehension and conditional formatting in the pytest_collection_modifyitems hook