### PR TITLE
Fix Windows xfail reason filtering

### DIFF
--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -341,7 +341,10 @@ def pytest_collection_modifyitems(
         drop_marks = [
             mark
             for mark in xfail_marks
-            if str(mark.kwargs.get("reason", "")).strip() == WINDOWS_XFAIL_REASON
+            if (
+                isinstance(reason := mark.kwargs.get("reason"), str)
+                and reason.strip() == WINDOWS_XFAIL_REASON
+            )
         ]
         if not drop_marks:
             continue


### PR DESCRIPTION
## Summary
- ensure Windows smoke xfail marks are only dropped when the reason is a matching string

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2cae7158c8322a48ad756d66db9c1

## Summary by Sourcery

Bug Fixes:
- Guard against non-string reasons when filtering xfail marks on Windows tests