### PR TITLE
Close cargo pipes when coverage stream missing

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -151,7 +151,6 @@ def get_line_coverage_percent_from_cobertura(xml_file: Path) -> str:
 
 def _safe_close_text_stream(stream: typ.TextIO | None) -> None:
     """Close ``stream`` while suppressing any cleanup errors."""
-
     if stream is None:
         return
     with contextlib.suppress(Exception):
@@ -182,6 +181,8 @@ def _run_cargo(args: list[str]) -> str:
                 proc.kill()
             with contextlib.suppress(Exception):
                 proc.wait(timeout=5)
+            _safe_close_text_stream(proc.stdout)
+            _safe_close_text_stream(proc.stderr)
             typer.echo(f"::error::{message}", err=True)
             raise typer.Exit(1)
         stdout_lines: list[str] = []

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -202,7 +202,6 @@ def test_run_cargo_windows_closes_streams(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_run_cargo`` closes captured streams on success."""
-
     mod = _load_module(monkeypatch, "run_rust")
     monkeypatch.setattr(mod.os, "name", "nt")
     monkeypatch.setattr(mod.typer, "echo", lambda *a, **k: None)
@@ -313,7 +312,6 @@ def test_run_cargo_stream_close_error_suppressed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Errors closing streams are suppressed during cleanup."""
-
     mod = _load_module(monkeypatch, "run_rust")
     monkeypatch.setattr(mod.os, "name", "nt")
     monkeypatch.setattr(mod.typer, "echo", lambda *a, **k: None)
@@ -326,7 +324,8 @@ def test_run_cargo_stream_close_error_suppressed(
         def close(self) -> None:
             self.close_calls += 1
             super().close()
-            raise RuntimeError("close failure")
+            message = "close failure"
+            raise RuntimeError(message)
 
     stdout = ExplodingStream("out-line\n")
     stderr = io.StringIO("err-line\n")


### PR DESCRIPTION
## Summary
- close captured cargo stdout/stderr streams when pipe creation fails to avoid leaks

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68d2d2a5e3c083228294ce3937a5ccc8

## Summary by Sourcery

Bug Fixes:
- Close captured cargo stdout and stderr streams on error to avoid pipe leaks