### PR TITLE
Fix default host triple fallback by platform

### DIFF
--- a/.github/actions/rust-build-release/src/runtime.py
+++ b/.github/actions/rust-build-release/src/runtime.py
@@ -22,35 +22,52 @@ CROSS_CONTAINER_ERROR_CODES = {125, 126, 127}
 def _normalize_arch(machine: str) -> str:
     mapping = {
         "amd64": "x86_64",
-        "x86_64": "x86_64",
         "x64": "x86_64",
+        "x86_64": "x86_64",
         "i386": "i686",
+        "i486": "i686",
+        "i586": "i686",
         "i686": "i686",
         "x86": "i686",
         "arm64": "aarch64",
         "aarch64": "aarch64",
         "armv8": "aarch64",
+        "armv8a": "aarch64",
+        "armv8l": "aarch64",
+        "armv7": "armv7",
+        "armv7a": "armv7",
+        "armv7hl": "armv7",
+        "armv7l": "armv7",
+        "armv6": "armv6",
+        "armv6l": "armv6",
+        "ppc64": "ppc64",
+        "ppc64le": "ppc64le",
+        "powerpc64": "ppc64",
+        "powerpc64le": "ppc64le",
+        "s390x": "s390x",
+        "riscv64": "riscv64",
+        "loongarch64": "loongarch64",
     }
-    normalized = mapping.get(machine.lower()) if machine else None
-    if normalized:
-        return normalized
-    if machine:
-        return machine.lower()
-    return "x86_64"
+    if not machine:
+        return "x86_64"
+    machine_lower = machine.lower()
+    return mapping.get(machine_lower, machine_lower)
 
 
 def _default_host_target_for_current_platform() -> str:
-    platform_id = sys.platform
-    arch = _normalize_arch(platform.machine())
-    if not arch:
-        arch = "x86_64"
-    if platform_id == "win32":
+    arch = _normalize_arch(platform.machine()) or "x86_64"
+    system_name = platform.system().lower()
+    platform_id = sys.platform.lower()
+    if system_name == "windows":
         return f"{arch}-pc-windows-msvc"
-    if platform_id in {"cygwin", "msys"}:
+    if system_name.startswith(("cygwin", "msys")) or platform_id in {"cygwin", "msys"}:
         return f"{arch}-pc-windows-gnu"
-    if platform_id == "darwin":
+    if system_name == "darwin":
         return f"{arch}-apple-darwin"
-    return f"{arch}-unknown-linux-gnu"
+    if system_name.startswith("linux"):
+        return f"{arch}-unknown-linux-gnu"
+    identifier = system_name or platform_id or "linux"
+    return f"{arch}-unknown-{identifier}"
 
 
 DEFAULT_HOST_TARGET = _default_host_target_for_current_platform()

--- a/.github/actions/rust-build-release/tests/test_runtime.py
+++ b/.github/actions/rust-build-release/tests/test_runtime.py
@@ -6,6 +6,8 @@ import json
 import subprocess
 import typing as typ
 
+import pytest
+
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
@@ -255,3 +257,78 @@ def test_detect_host_target_passes_timeout_to_run_validated(
     assert call_kwargs.get("text") is True
     assert call_kwargs.get("check") is True
     assert call_kwargs.get("allowed_names") == ("rustc", "rustc.exe")
+@pytest.mark.parametrize(
+    ("machine", "expected"),
+    [
+        ("AMD64", "x86_64"),
+        ("x64", "x86_64"),
+        ("i386", "i686"),
+        ("I586", "i686"),
+        ("ARM64", "aarch64"),
+        ("armv8l", "aarch64"),
+        ("ARMV7L", "armv7"),
+        ("armv6l", "armv6"),
+        ("PPC64LE", "ppc64le"),
+        ("PowerPC64", "ppc64"),
+        ("sparc64", "sparc64"),
+    ],
+)
+def test_normalize_arch_unit_mappings(
+    runtime_module: ModuleType, machine: str, expected: str
+) -> None:
+    """Unit test: known architecture identifiers normalize correctly."""
+
+    assert runtime_module._normalize_arch(machine) == expected
+
+
+def test_normalize_arch_behavioral_fallbacks(runtime_module: ModuleType) -> None:
+    """Behavioural test: unknown and missing machine names are handled."""
+
+    assert runtime_module._normalize_arch("") == "x86_64"
+    # Unknown identifiers are normalized to lowercase for stability.
+    assert runtime_module._normalize_arch("Loongson") == "loongson"
+
+
+@pytest.mark.parametrize(
+    ("system_name", "machine", "sys_platform", "expected"),
+    [
+        ("Windows", "AMD64", "win32", "x86_64-pc-windows-msvc"),
+        ("CYGWIN_NT-10.0", "x86_64", "cygwin", "x86_64-pc-windows-gnu"),
+        ("MSYS_NT-10.0", "x86_64", "msys", "x86_64-pc-windows-gnu"),
+        ("Darwin", "arm64", "darwin", "aarch64-apple-darwin"),
+        ("Linux", "ppc64le", "linux", "ppc64le-unknown-linux-gnu"),
+        ("Linux-gnu", "armv7l", "linux-gnu", "armv7-unknown-linux-gnu"),
+        ("FreeBSD", "sparc64", "freebsd13", "sparc64-unknown-freebsd"),
+    ],
+)
+def test_default_host_target_for_current_platform_unit(
+    runtime_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    system_name: str,
+    machine: str,
+    sys_platform: str,
+    expected: str,
+) -> None:
+    """Unit test: platform/architecture combinations map to expected triples."""
+
+    monkeypatch.setattr(runtime_module.platform, "system", lambda: system_name)
+    monkeypatch.setattr(runtime_module.platform, "machine", lambda: machine)
+    monkeypatch.setattr(runtime_module.sys, "platform", sys_platform)
+
+    assert runtime_module._default_host_target_for_current_platform() == expected
+
+
+def test_default_host_target_for_current_platform_behavioral_fallback(
+    runtime_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Behavioural test: fallbacks cover missing identifiers."""
+
+    monkeypatch.setattr(runtime_module.platform, "system", lambda: "")
+    monkeypatch.setattr(runtime_module.platform, "machine", lambda: "")
+    monkeypatch.setattr(runtime_module.sys, "platform", "customos")
+
+    assert (
+        runtime_module._default_host_target_for_current_platform()
+        == "x86_64-unknown-customos"
+    )
+


### PR DESCRIPTION
## Summary
- derive the runtime default host triple from the current platform instead of hard-coding the Linux target
- normalize common architecture names so the fallback produces stable triples across hosts

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2dcd6b1e08322bbb490dbc7a09bd1

## Summary by Sourcery

Derive the default Rust host target dynamically based on the current OS and normalized CPU architecture instead of using a hardcoded Linux triple

Bug Fixes:
- Fix fallback host triple for non-Linux platforms by detecting runtime platform instead of assuming Linux

Enhancements:
- Add architecture normalization mapping for stable host triples across platforms
- Implement platform-specific logic to construct the default host target triple for Windows (MSVC/GNU), macOS, and Linux