### PR TITLE
Refactor cargo output pumping logic

### DIFF
--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -301,7 +301,7 @@ def _run_cargo(args: list[str]) -> str:
             _safe_close_text_stream(proc.stdout)
             _safe_close_text_stream(proc.stderr)
             typer.echo(f"::error::{message}", err=True)
-            raise typer.Exit(1)
+            raise typer.Exit(1) from None
         stdout_lines = _pump_cargo_output(proc)
         wait_timeout = float(os.getenv("RUN_RUST_CARGO_WAIT_TIMEOUT", "600"))
         try:
@@ -315,7 +315,7 @@ def _run_cargo(args: list[str]) -> str:
                 proc.kill()
             with contextlib.suppress(Exception):
                 proc.wait(timeout=5)
-            raise typer.Exit(1)
+            raise typer.Exit(1) from None
         if retcode != 0:
             typer.echo(
                 f"cargo {shlex.join(args)} failed with code {retcode}",

--- a/.github/actions/generate-coverage/scripts/tests/test_run_rust_windows.py
+++ b/.github/actions/generate-coverage/scripts/tests/test_run_rust_windows.py
@@ -1,0 +1,107 @@
+"""Tests for the Windows cargo output pump helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import typing as typ
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "run_rust.py"
+SCRIPT_DIR = MODULE_PATH.parent
+SCRIPT_DIR_STR = str(SCRIPT_DIR)
+if SCRIPT_DIR_STR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR_STR)
+
+spec = importlib.util.spec_from_file_location("run_rust_module", MODULE_PATH)
+if spec is None or spec.loader is None:  # pragma: no cover - defensive import guard
+    load_error_message = "Unable to load run_rust module for testing"
+    raise RuntimeError(load_error_message)
+run_rust_module = importlib.util.module_from_spec(spec)
+if not isinstance(run_rust_module, ModuleType):  # pragma: no cover - importlib contract
+    type_error_message = "module_from_spec did not return a ModuleType"
+    raise TypeError(type_error_message)
+spec.loader.exec_module(run_rust_module)  # type: ignore[misc]
+run_rust = run_rust_module
+
+
+class _SupportsKillWait(typ.Protocol):
+    """Minimal protocol for processes that expose kill/wait."""
+
+    def kill(self) -> None: ...
+
+    def wait(self, timeout: float | None = ...) -> int: ...
+
+
+class _RunRustModule(typ.Protocol):
+    """Subset of the run_rust module used by the tests."""
+
+    sys: typ.Any
+
+    def _pump_cargo_output_windows(
+        self,
+        proc: _SupportsKillWait,
+        stdout_stream: typ.IO[str],
+        stderr_stream: typ.IO[str],
+    ) -> list[str]:
+        """Mirror of the helper under test."""
+
+
+run_rust_typed: _RunRustModule = typ.cast("_RunRustModule", run_rust)
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.killed = False
+        self.wait_timeouts: list[float | None] = []
+
+    def kill(self) -> None:  # pragma: no cover - exercised only on failure
+        self.killed = True
+
+    def wait(
+        self, timeout: float | None = None
+    ) -> int:  # pragma: no cover - failure path
+        self.wait_timeouts.append(timeout)
+        return 0
+
+
+@pytest.mark.parametrize(
+    ("stdout_payload", "stderr_payload", "expected"),
+    [
+        ("hello\r\nworld\r\n", "warn\r\n", ["hello", "world"]),
+        ("single line\n", "", ["single line"]),
+    ],
+)
+def test_pump_cargo_output_windows_streams(
+    stdout_payload: str,
+    stderr_payload: str,
+    expected: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stream cargo output through the Windows pump into captured buffers."""
+    dummy_proc = _DummyProc()
+
+    captured_stdout = io.StringIO()
+    captured_stderr = io.StringIO()
+    run_rust_sys = run_rust_typed.sys
+    monkeypatch.setattr(run_rust_sys, "stdout", captured_stdout)
+    monkeypatch.setattr(run_rust_sys, "stderr", captured_stderr)
+
+    stdout_stream = io.StringIO(stdout_payload)
+    stderr_stream = io.StringIO(stderr_payload)
+
+    lines = run_rust_typed._pump_cargo_output_windows(
+        dummy_proc,
+        stdout_stream,
+        stderr_stream,
+    )
+
+    assert lines == expected
+    assert captured_stdout.getvalue() == stdout_payload
+    assert captured_stderr.getvalue() == stderr_payload
+    assert not dummy_proc.killed
+    assert dummy_proc.wait_timeouts == []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13]
     steps:
       - name: Checkout repository
         # v4
@@ -47,6 +47,32 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make lint
         shell: bash
+      - name: Run tests
+        run: |
+          uv sync --group dev
+          uv run pytest
+        env:
+          PYTHONIOENCODING: utf-8
+        shell: bash
+
+  python-tests-windows:
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Setup uv
+        # v6.4.3
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        with:
+          python-version: '3.12'
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            **/scripts/*.py
       - name: Run tests
         run: |
           uv sync --group dev


### PR DESCRIPTION
## Summary
- extract the platform-specific cargo output pumping into dedicated helpers, including a Windows-specific helper
- simplify `_run_cargo` to focus on spawning, pumping, and waiting
- add a defensive guard for missing cargo output streams
- update `_pump_cargo_output_windows` to collect stdout internally and accept generic text streams

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d447c9fddc832295114d73f7f33d86

## Summary by Sourcery

Refactor cargo output pumping logic by extracting platform-specific pumping into reusable helpers and simplifying the _run_cargo function to delegate output streaming and line collection.

New Features:
- Introduce _pump_cargo_output_windows helper to stream and collect cargo output on Windows using background threads
- Add _pump_cargo_output helper to unify output pumping for all platforms

Enhancements:
- Simplify _run_cargo to call the dedicated pumping helper and focus on spawning, waiting, and error handling
- Add a defensive guard to error if cargo stdout or stderr streams are not captured