### PR TITLE
Refactor rust build release packaging flow

### DIFF
--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -12,9 +12,6 @@ inputs:
     description: Name of the binary produced by the build
     required: false
     default: rust-toy-app
-  version:
-    description: Package version (e.g. 0.1.0)
-    required: true
 runs:
   using: composite
   steps:

--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -9,13 +9,9 @@ inputs:
     required: false
     default: .
   bin-name:
-    description: Name of the binary to stage and package
+    description: Name of the binary produced by the build
     required: false
     default: rust-toy-app
-  formats:
-    description: Comma-separated package formats to produce
-    required: false
-    default: deb
   version:
     description: Package version (e.g. 0.1.0)
     required: true
@@ -135,14 +131,3 @@ runs:
         install -m 0755 "${bin_src}" "dist/${{ inputs.bin-name }}_${os}_${arch}/${{ inputs.bin-name }}"
         install -m 0644 "${man_path}" "dist/${{ inputs.bin-name }}_${os}_${arch}/${{ inputs.bin-name }}.1"
         echo "man-path=dist/${{ inputs.bin-name }}_${os}_${arch}/${{ inputs.bin-name }}.1" >> "${GITHUB_OUTPUT}"
-    - name: Package Linux artifacts
-      if: contains(inputs.target, 'unknown-linux-')
-      uses: ./.github/actions/linux-packages
-      with:
-        project-dir: ${{ inputs.project-dir }}
-        bin-name: ${{ inputs.bin-name }}
-        package-name: ${{ inputs.bin-name }}
-        target: ${{ inputs.target }}
-        version: ${{ inputs.version }}
-        formats: ${{ inputs.formats }}
-        man-paths: ${{ steps.stage-linux-artifacts.outputs.man-path }}

--- a/.github/actions/rust-build-release/tests/test_linux_package_step.py
+++ b/.github/actions/rust-build-release/tests/test_linux_package_step.py
@@ -13,6 +13,6 @@ def test_linux_packaging_not_present() -> None:
     data = yaml.safe_load(action.read_text(encoding="utf-8"))
     steps = data["runs"]["steps"]
 
-    assert all(
-        "linux-packages" not in (step.get("uses") or "") for step in steps
-    ), "linux-packages step should be removed from rust-build-release"
+    assert all("linux-packages" not in (step.get("uses") or "") for step in steps), (
+        "linux-packages step should be removed from rust-build-release"
+    )

--- a/.github/actions/rust-build-release/tests/test_linux_package_step.py
+++ b/.github/actions/rust-build-release/tests/test_linux_package_step.py
@@ -1,4 +1,4 @@
-"""Ensure the composite action delegates Linux packaging to linux-packages."""
+"""Ensure the composite action leaves Linux packaging to workflows."""
 
 from __future__ import annotations
 
@@ -7,33 +7,12 @@ from pathlib import Path
 import yaml
 
 
-def test_linux_packaging_step() -> None:
-    """Validate the linux-packages step configuration."""
+def test_linux_packaging_not_present() -> None:
+    """Validate that linux packaging is no longer invoked by the action."""
     action = Path(__file__).resolve().parents[1] / "action.yml"
     data = yaml.safe_load(action.read_text(encoding="utf-8"))
     steps = data["runs"]["steps"]
 
-    stage_step = next(
-        (step for step in steps if step.get("id") == "stage-linux-artifacts"),
-        None,
-    )
-    assert stage_step is not None, "stage-linux-artifacts step missing"
-    assert stage_step.get("if") == "contains(inputs.target, 'unknown-linux-')"
-
-    linux_step = next(
-        (step for step in steps if "linux-packages" in step.get("uses", "")),
-        None,
-    )
-    assert linux_step is not None, "linux-packages step missing"
-    assert linux_step.get("if") == "contains(inputs.target, 'unknown-linux-')"
-    with_block = linux_step.get("with") or {}
-    assert with_block.get("project-dir") == "${{ inputs.project-dir }}"
-    assert with_block.get("bin-name") == "${{ inputs.bin-name }}"
-    assert with_block.get("package-name") == "${{ inputs.bin-name }}"
-    assert with_block.get("target") == "${{ inputs.target }}"
-    assert with_block.get("version") == "${{ inputs.version }}"
-    assert with_block.get("formats") == "${{ inputs.formats }}"
-    assert (
-        with_block.get("man-paths")
-        == "${{ steps.stage-linux-artifacts.outputs.man-path }}"
-    )
+    assert all(
+        "linux-packages" not in (step.get("uses") or "") for step in steps
+    ), "linux-packages step should be removed from rust-build-release"

--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -71,9 +71,21 @@ jobs:
           manpages=(target/${{ matrix.target }}/release/build/rust-toy-app-*/out/rust-toy-app.1)
           (( "${#manpages[@]}" > 0 ))
           echo "binary=rust-toy-app/$binary_path" >> "$GITHUB_OUTPUT"
+          echo "binary-relative=${binary_path}" >> "$GITHUB_OUTPUT"
           echo "manpage=rust-toy-app/${manpages[0]}" >> "$GITHUB_OUTPUT"
+          echo "manpage-relative=${manpages[0]}" >> "$GITHUB_OUTPUT"
         working-directory: rust-toy-app
         shell: bash
+      - name: Package Linux artifacts
+        if: contains(matrix.target, 'unknown-linux-')
+        uses: ./.github/actions/linux-packages
+        with:
+          project-dir: rust-toy-app
+          bin-name: rust-toy-app
+          package-name: rust-toy-app
+          target: ${{ matrix.target }}
+          version: ${{ steps.crate-version.outputs.version }}
+          man-paths: ${{ steps.verify-artifacts.outputs.manpage-relative }}
       - name: Package macOS installer
         if: contains(matrix.target, 'apple-darwin')
         id: package-macos

--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -55,7 +55,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           project-dir: rust-toy-app
-          version: ${{ steps.crate-version.outputs.version }}
       - name: Verify artifacts
         id: verify-artifacts
         run: |


### PR DESCRIPTION
## Summary
- remove Linux packaging from the rust-build-release action and clarify documentation about dedicated OS packaging actions
- update the rust-toy-app workflow to invoke the linux-packages action directly and expose reusable artifact metadata
- adjust the rust-build-release test suite to reflect the absence of the linux packaging step

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d9c5ce0ef8832296d0ced77524dae6

## Summary by Sourcery

Remove Linux packaging from the rust-build-release action and delegate packaging to dedicated platform-specific composite actions. Update documentation, action inputs, test suite, and workflows to reflect this change by removing the formats parameter, clarifying packaging responsibilities, exposing artifact metadata, and invoking the linux-packages action directly in the rust-toy-app workflow.

New Features:
- Expose binary-relative and manpage-relative outputs in the rust-toy-app workflow and invoke the linux-packages action directly for Linux packaging

Enhancements:
- Remove the Linux packaging step and the `formats` input from the rust-build-release action and its action.yml
- Update the rust-build-release README to note separate Linux, macOS, and Windows packaging actions and adjust example usage
- Adjust the rust-build-release test to validate that the linux-packages step is no longer present