### PR TITLE
Add illumos support to rust build release action

### DIFF
--- a/.github/actions/rust-build-release/CHANGELOG.md
+++ b/.github/actions/rust-build-release/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Cross-compile and stage `x86_64-unknown-illumos` artefacts from Linux runners.
 - Provide shared packaging fixtures and helpers that build the sample project once and produce `.deb` and `.rpm` artefacts for the integration tests.
 - Support staging and packaging for `unknown-linux-musl` targets alongside GNU triples for x86_64, aarch64, i686, arm*, and riscv64 builds.
 

--- a/.github/actions/rust-build-release/README.md
+++ b/.github/actions/rust-build-release/README.md
@@ -9,6 +9,10 @@ Build Rust application release artefacts using the repository's `setup-rust` act
 > - Linux: [`linux-packages`](../linux-packages)
 > - macOS: [`macos-package`](../macos-package)
 > - Windows: [`windows-package`](../windows-package)
+>
+> When run on Linux runners the action also supports cross-compiling
+> `x86_64-unknown-illumos` targets. The staged artefacts are emitted beneath an
+> `illumos/amd64` directory alongside the Linux distributions.
 
 The `uv` Python package manager is installed automatically to execute the build
 script.
@@ -64,6 +68,26 @@ None.
     version: 1.2.3
     man-paths: ${{ steps.find-linux-manpage.outputs.path }}
 ```
+
+### Cross-compiling illumos artefacts
+
+The action can build illumos binaries from a Linux runner using `cross`:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rust-build-release
+        with:
+          target: x86_64-unknown-illumos
+          project-dir: rust-toy-app
+```
+
+The Stage artifacts step maps the resulting files into
+`dist/rust-toy-app_illumos_amd64/` so they can be uploaded or packaged by
+downstream workflows.
 
 ## Release History
 

--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -63,7 +63,7 @@ runs:
         uv run --script "$GITHUB_ACTION_PATH/src/main.py"
     - id: stage-linux-artifacts
       name: Stage artifacts
-      if: contains(inputs.target, 'unknown-linux-')
+      if: contains(inputs.target, 'unknown-linux-') || contains(inputs.target, 'unknown-illumos')
       shell: bash
       working-directory: ${{ inputs.project-dir }}
       run: |
@@ -71,6 +71,10 @@ runs:
         case "${{ inputs.target }}" in
           x86_64-unknown-linux-*)
             os=linux
+            arch=amd64
+            ;;
+          x86_64-unknown-illumos)
+            os=illumos
             arch=amd64
             ;;
           aarch64-unknown-linux-*)

--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -61,7 +61,7 @@ runs:
       run: |
         set -euo pipefail
         uv run --script "$GITHUB_ACTION_PATH/src/main.py"
-    - id: stage-linux-artifacts
+    - id: stage-artifacts
       name: Stage artifacts
       if: contains(inputs.target, 'unknown-linux-') || contains(inputs.target, 'unknown-illumos')
       shell: bash

--- a/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
+++ b/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
@@ -1,0 +1,38 @@
+"""Tests covering the Stage artifacts step mapping."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _load_stage_step() -> dict[str, object]:
+    action = Path(__file__).resolve().parents[1] / "action.yml"
+    data = yaml.safe_load(action.read_text(encoding="utf-8"))
+    steps: list[dict[str, object]] = data["runs"]["steps"]
+    for step in steps:
+        if step.get("id") == "stage-linux-artifacts":
+            return step
+    raise AssertionError("stage-linux-artifacts step missing from action")
+
+
+def test_stage_step_condition_includes_illumos() -> None:
+    """Validate illumos targets trigger the Stage artifacts step."""
+
+    step = _load_stage_step()
+    condition = step.get("if")
+    assert isinstance(condition, str)
+    assert "unknown-linux-" in condition
+    assert "unknown-illumos" in condition
+
+
+def test_stage_step_maps_illumos_to_expected_tuple() -> None:
+    """Ensure the illumos target maps to illumos/amd64 output tuple."""
+
+    step = _load_stage_step()
+    run_script = step.get("run")
+    assert isinstance(run_script, str)
+    assert "x86_64-unknown-illumos" in run_script
+    assert "os=illumos" in run_script
+    assert "arch=amd64" in run_script

--- a/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
+++ b/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
@@ -14,12 +14,12 @@ def _load_stage_step() -> dict[str, object]:
     for step in steps:
         if step.get("id") == "stage-linux-artifacts":
             return step
-    raise AssertionError("stage-linux-artifacts step missing from action")
+    message = "stage-linux-artifacts step missing from action"
+    raise AssertionError(message)
 
 
 def test_stage_step_condition_includes_illumos() -> None:
     """Validate illumos targets trigger the Stage artifacts step."""
-
     step = _load_stage_step()
     condition = step.get("if")
     assert isinstance(condition, str)
@@ -29,7 +29,6 @@ def test_stage_step_condition_includes_illumos() -> None:
 
 def test_stage_step_maps_illumos_to_expected_tuple() -> None:
     """Ensure the illumos target maps to illumos/amd64 output tuple."""
-
     step = _load_stage_step()
     run_script = step.get("run")
     assert isinstance(run_script, str)

--- a/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
+++ b/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
@@ -35,3 +35,46 @@ def test_stage_step_maps_illumos_to_expected_tuple() -> None:
     assert "x86_64-unknown-illumos" in run_script
     assert "os=illumos" in run_script
     assert "arch=amd64" in run_script
+
+
+def test_stage_step_preserves_existing_linux_mapping() -> None:
+    """Verify existing Linux target mappings remain correct."""
+    step = _load_stage_step()
+    run_script = step.get("run")
+    assert isinstance(run_script, str)
+    assert "x86_64-unknown-linux-" in run_script
+    assert "os=linux" in run_script
+    lines = run_script.split("\n")
+    in_x86_linux_case = False
+    for line in lines:
+        if "x86_64-unknown-linux-" in line:
+            in_x86_linux_case = True
+            continue
+        if in_x86_linux_case and "arch=amd64" in line:
+            break
+        if in_x86_linux_case and line.strip() == ";;":
+            message = "amd64 arch not found in x86_64 Linux case"
+            raise AssertionError(message)
+
+
+def test_stage_step_errors_for_unsupported_target() -> None:
+    """Confirm unsupported targets trigger the default error path."""
+    step = _load_stage_step()
+    run_script = step.get("run")
+    assert isinstance(run_script, str)
+    assert "::error:: unsupported target" in run_script
+    lines = run_script.split("\n")
+    default_case_lines: list[str] = []
+    in_default_case = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("*)"):
+            in_default_case = True
+            continue
+        if in_default_case and stripped == ";;":
+            break
+        if in_default_case:
+            default_case_lines.append(stripped)
+    assert default_case_lines, "default case not found in stage script"
+    assert any("::error:: unsupported target" in line for line in default_case_lines)
+    assert any(line == "exit 1" for line in default_case_lines)

--- a/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
+++ b/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
@@ -33,8 +33,22 @@ def test_stage_step_maps_illumos_to_expected_tuple() -> None:
     run_script = step.get("run")
     assert isinstance(run_script, str)
     assert "x86_64-unknown-illumos" in run_script
-    assert "os=illumos" in run_script
-    assert "arch=amd64" in run_script
+    lines = run_script.split("\n")
+    in_illumos_case = False
+    found_os = False
+    found_arch = False
+    for line in lines:
+        if "x86_64-unknown-illumos" in line:
+            in_illumos_case = True
+            continue
+        if in_illumos_case and "os=illumos" in line:
+            found_os = True
+        if in_illumos_case and "arch=amd64" in line:
+            found_arch = True
+        if in_illumos_case and line.strip() == ";;":
+            break
+    assert found_os, "os=illumos not found in illumos case block"
+    assert found_arch, "arch=amd64 not found in illumos case block"
 
 
 def test_stage_step_preserves_existing_linux_mapping() -> None:

--- a/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
+++ b/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
@@ -60,15 +60,21 @@ def test_stage_step_preserves_existing_linux_mapping() -> None:
     assert "os=linux" in run_script
     lines = run_script.split("\n")
     in_x86_linux_case = False
+    found_os = False
+    found_arch = False
     for line in lines:
         if "x86_64-unknown-linux-" in line:
             in_x86_linux_case = True
             continue
+        if in_x86_linux_case and "os=linux" in line:
+            found_os = True
         if in_x86_linux_case and "arch=amd64" in line:
-            break
+            found_arch = True
         if in_x86_linux_case and line.strip() == ";;":
-            message = "amd64 arch not found in x86_64 Linux case"
-            raise AssertionError(message)
+            message = "expected linux/amd64 mapping in x86_64 case"
+            if not (found_os and found_arch):
+                raise AssertionError(message)
+            break
 
 
 def test_stage_step_errors_for_unsupported_target() -> None:

--- a/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
+++ b/.github/actions/rust-build-release/tests/test_stage_artifacts_step.py
@@ -12,9 +12,9 @@ def _load_stage_step() -> dict[str, object]:
     data = yaml.safe_load(action.read_text(encoding="utf-8"))
     steps: list[dict[str, object]] = data["runs"]["steps"]
     for step in steps:
-        if step.get("id") == "stage-linux-artifacts":
+        if step.get("id") == "stage-artifacts":
             return step
-    message = "stage-linux-artifacts step missing from action"
+    message = "stage-artifacts step missing from action"
     raise AssertionError(message)
 
 

--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -15,6 +15,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: x86_64-unknown-illumos
           - runner: macos-latest
             target: x86_64-apple-darwin
           - runner: macos-latest


### PR DESCRIPTION
## Summary
- allow the rust-build-release action to stage x86_64-unknown-illumos artifacts alongside the existing Linux targets
- cover the illumos mapping in the action test suite
- extend the rust-toy-app workflow matrix to exercise the illumos build on Ubuntu

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dbbc5a18d083228634ba8371e775a5

## Summary by Sourcery

Add support for x86_64-unknown-illumos targets to the rust-build-release action by including illumos in the artifact staging step, update the rust-toy-app workflow matrix to test the illumos build, and add tests to verify the new mapping and condition.

New Features:
- Support x86_64-unknown-illumos artifacts in the rust-build-release action.

Enhancements:
- Include illumos targets in the Stage artifacts step script.
- Extend the rust-toy-app workflow matrix to exercise the illumos build on Ubuntu.

Tests:
- Add tests verifying the Stage artifacts step triggers for illumos and maps it to illumos/amd64.