### PR TITLE
Add crate name output to ensure-cargo-version action

### DIFF
--- a/.github/actions/ensure-cargo-version/README.md
+++ b/.github/actions/ensure-cargo-version/README.md
@@ -16,6 +16,7 @@ Validate that the Git tag triggering a release workflow matches the version in o
 | ---- | ----------- |
 | `version` | Version extracted from the tag reference after removing the configured prefix. |
 | `crate-version` | Version read from the first manifest path provided (after resolution) after resolving workspace inheritance. |
+| `crate-name` | Package name read from the first manifest path provided (after resolution). |
 
 ## Usage
 

--- a/.github/actions/ensure-cargo-version/action.yml
+++ b/.github/actions/ensure-cargo-version/action.yml
@@ -46,3 +46,6 @@ outputs:
   crate-version:
     description: Version number declared in the first Cargo manifest.
     value: ${{ steps.verify.outputs['crate-version'] }}
+  crate-name:
+    description: Package name declared in the first Cargo manifest.
+    value: ${{ steps.verify.outputs['crate-name'] }}


### PR DESCRIPTION
## Summary
- include the package name from the first manifest in ensure-cargo-version outputs
- document the new output and extend unit tests to cover it

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68de5ed578108322887f030db4d54adc