### PR TITLE
Fix plumbum command usage for polythene validation

### DIFF
--- a/.github/actions/validate-linux-packages/scripts/validate_polythene.py
+++ b/.github/actions/validate-linux-packages/scripts/validate_polythene.py
@@ -43,8 +43,7 @@ class PolytheneSession:
     def exec(self, *args: str, timeout: int | None = None) -> str:
         """Execute ``args`` inside the sandbox and return its stdout."""
         effective_timeout = timeout if timeout is not None else self.timeout
-        cmd = local[
-            "uv",
+        cmd = local["uv"][
             "run",
             self.script.as_posix(),
             "exec",
@@ -72,8 +71,7 @@ def polythene_rootfs(
 ) -> typ.ContextManager[PolytheneSession]:
     """Yield a :class:`PolytheneSession` for ``image`` using ``store``."""
     ensure_directory(store)
-    pull_cmd = local[
-        "uv",
+    pull_cmd = local["uv"][
         "run",
         polythene.as_posix(),
         "pull",
@@ -101,8 +99,7 @@ def polythene_rootfs(
         yield session
     finally:
         try:
-            local[
-                "uv",
+            local["uv"][
                 "run",
                 polythene.as_posix(),
                 "rm",

--- a/.github/actions/validate-linux-packages/tests/test_validate_polythene.py
+++ b/.github/actions/validate-linux-packages/tests/test_validate_polythene.py
@@ -38,6 +38,11 @@ class _FakeCommand:
         self.argv = argv
         self._calls = calls
 
+    def __getitem__(self, value: str | tuple[str, ...]) -> "_FakeCommand":
+        if not isinstance(value, tuple):
+            value = (value,)
+        return _FakeCommand(self.argv + value, self._calls)
+
     def __call__(self) -> str:
         self._calls.append(self.argv)
         return ""


### PR DESCRIPTION
## Summary
- construct polythene commands with `local["uv"]` to avoid runtime type errors
- extend the validate_polythene test fakes to mimic chained plumbum commands

## Testing
- `uv run pytest .github/actions/validate-linux-packages/tests/test_validate_polythene.py`


------
https://chatgpt.com/codex/tasks/task_e_68e03b7bb1088322a1c0fce4f3e538a8