### PR TITLE
Switch run_completed_process to plumbum and update tests

### DIFF
--- a/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
+++ b/.github/actions/generate-coverage/scripts/cmd_utils_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import typing as typ
 from functools import cache
 from pathlib import Path
@@ -47,7 +48,14 @@ class CmdUtilsImportError(RuntimeError):
 def find_repo_root() -> Path:
     """Locate the repository root containing ``CMD_UTILS_FILENAME``."""
     candidates: list[Path] = []
-    for parent in Path(__file__).resolve().parents:
+    env_path = os.environ.get("GITHUB_ACTION_PATH")
+    search_roots: list[Path]
+    if env_path:
+        action_path = Path(env_path).expanduser().resolve()
+        search_roots = [action_path, *action_path.parents]
+    else:  # pragma: no cover - fallback for local tooling
+        search_roots = list(Path(__file__).resolve().parents)
+    for parent in search_roots:
         candidate = parent / CMD_UTILS_FILENAME
         candidates.append(candidate)
         if candidate.is_file() and not candidate.is_symlink():

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -79,7 +79,7 @@ def main(
 
     cmd = coverage_cmd_for_fmt(fmt, out)
     try:
-        run_cmd(cmd, fg=True)
+        run_cmd(cmd, method="run_fg")
     except ProcessExecutionError as exc:
         raise typer.Exit(code=exc.retcode or 1) from exc
 

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -389,12 +389,14 @@ def run_cucumber_rs_coverage(
         try:
             cmd = uvx["merge-cobertura", str(out), str(cucumber_file)]
             merged = run_cmd(cmd)
-        except ProcessExecutionError as exc:
+        except (ProcessExecutionError, subprocess.CalledProcessError) as exc:
+            retcode = getattr(exc, "retcode", getattr(exc, "returncode", None))
+            stderr = getattr(exc, "stderr", "")
             typer.echo(
-                f"merge-cobertura failed with code {exc.retcode}: {exc.stderr}",
+                f"merge-cobertura failed with code {retcode}: {stderr}",
                 err=True,
             )
-            raise typer.Exit(code=exc.retcode or 1) from exc
+            raise typer.Exit(code=retcode or 1) from exc
         out.write_text(merged)
     else:
         _merge_lcov(out, cucumber_file)

--- a/.github/actions/generate-coverage/tests/test_cmd_utils.py
+++ b/.github/actions/generate-coverage/tests/test_cmd_utils.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 
 import pytest
 from plumbum import local
+from plumbum.commands.processes import ProcessTimedOut
 
 from cmd_utils import run_cmd
 
@@ -14,11 +14,11 @@ from cmd_utils import run_cmd
 def test_run_cmd_foreground_timeout() -> None:
     """Foreground commands honour the configured timeout."""
     sleeper = local[sys.executable]["-c", "import time; time.sleep(5)"]
-    with pytest.raises(subprocess.TimeoutExpired):
-        run_cmd(sleeper, fg=True, timeout=0.2)
+    with pytest.raises(ProcessTimedOut):
+        run_cmd(sleeper, method="run_fg", timeout=0.2)
 
 
 def test_run_cmd_foreground_success() -> None:
     """Foreground commands still succeed without a timeout."""
     cmd = local[sys.executable]["-c", "print('ok')"]
-    run_cmd(cmd, fg=True)
+    run_cmd(cmd, method="run_fg")

--- a/.github/actions/generate-coverage/tests/test_cmd_utils.py
+++ b/.github/actions/generate-coverage/tests/test_cmd_utils.py
@@ -8,7 +8,9 @@ import pytest
 from plumbum import local
 from plumbum.commands.processes import ProcessTimedOut
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 
 def test_run_cmd_foreground_timeout() -> None:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -11,6 +11,7 @@ import typing as typ
 from pathlib import Path
 
 import pytest
+from plumbum import local
 
 from cmd_utils import run_completed_process
 
@@ -33,7 +34,9 @@ def run_script(
     script: Path, env: dict[str, str], *args: str
 ) -> subprocess.CompletedProcess[str]:
     """Run ``script`` via ``uv`` with ``env`` and return the completed process."""
-    cmd = ["uv", "run", "--script", str(script), *args]
+    command = local["uv"]["run", "--script", str(script)]
+    if args:
+        command = command[list(args)]
     root = Path(__file__).resolve().parents[4]
     merged = {**os.environ, **env}
     current_pp = merged.get("PYTHONPATH", "")
@@ -42,7 +45,7 @@ def run_script(
     )
     merged["PYTHONIOENCODING"] = "utf-8"
     return run_completed_process(
-        cmd,
+        command,
         capture_output=True,
         encoding="utf-8",
         errors="replace",

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
 
 if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -20,6 +21,8 @@ if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
 
     from cmd_utils import RunResult
     from shellstub import StubManager
+else:
+    RunResult = import_cmd_utils().RunResult
 
 
 def _exit_code(exc: BaseException) -> int | None:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -6,14 +6,16 @@ import contextlib
 import importlib.util
 import io
 import os
-import subprocess
 import sys
 import typing as typ
 from pathlib import Path
 
 import pytest
 
+from cmd_utils import run_completed_process
+
 if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
+    import subprocess
     from types import ModuleType
 
     from shellstub import StubManager
@@ -39,7 +41,7 @@ def run_script(
         f"{root}{os.pathsep}{current_pp}" if current_pp else str(root)
     )
     merged["PYTHONIOENCODING"] = "utf-8"
-    return subprocess.run(  # noqa: S603
+    return run_completed_process(
         cmd,
         capture_output=True,
         encoding="utf-8",

--- a/.github/actions/linux-packages/scripts/cmd_utils.py
+++ b/.github/actions/linux-packages/scripts/cmd_utils.py
@@ -2,55 +2,8 @@
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-import typing as typ
-from pathlib import Path
+from cmd_utils_importer import import_cmd_utils
 
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
-    import types
+run_cmd = import_cmd_utils().run_cmd
 
 __all__ = ["run_cmd"]
-
-_REPO_CMD_UTILS_NAME = "cmd_utils"
-_REPO_CMD_UTILS_PATH = Path(__file__).resolve().parents[4] / "cmd_utils.py"
-
-
-class CmdUtilsLoadError(ImportError):
-    """Raised when the repository-level cmd_utils module cannot be loaded."""
-
-    def __init__(self, path: Path) -> None:
-        super().__init__(f"Cannot load cmd_utils from {path}")
-
-
-class CmdUtilsAttributeError(AttributeError):
-    """Raised when the shimmed cmd_utils module misses an expected attribute."""
-
-    def __init__(self, module_name: str, attribute: str) -> None:
-        super().__init__(f"Module {module_name} missing attribute {attribute}")
-
-
-def _load_cmd_utils_module() -> types.ModuleType:
-    module = sys.modules.get(_REPO_CMD_UTILS_NAME)
-    if module and hasattr(module, "run_cmd"):
-        return module
-    spec = importlib.util.spec_from_file_location(
-        "shared_actions.cmd_utils", _REPO_CMD_UTILS_PATH
-    )
-    if spec is None or spec.loader is None:  # pragma: no cover - defensive
-        raise CmdUtilsLoadError(_REPO_CMD_UTILS_PATH)
-    module_obj = importlib.util.module_from_spec(spec)
-    sys.modules.setdefault(spec.name, module_obj)
-    spec.loader.exec_module(module_obj)
-    sys.modules.setdefault(_REPO_CMD_UTILS_NAME, module_obj)
-    return module_obj
-
-
-def _getattr(module: types.ModuleType, attr: str) -> cabc.Callable[..., typ.Any]:
-    if not hasattr(module, attr):  # pragma: no cover - defensive
-        raise CmdUtilsAttributeError(module.__name__, attr)
-    return getattr(module, attr)
-
-
-run_cmd = _getattr(_load_cmd_utils_module(), "run_cmd")

--- a/.github/actions/linux-packages/scripts/script_utils.py
+++ b/.github/actions/linux-packages/scripts/script_utils.py
@@ -5,31 +5,23 @@ from __future__ import annotations
 import importlib
 import importlib.machinery
 import importlib.util
-import sys
 import typing as typ
 from pathlib import Path
 
 import typer
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
+
 if typ.TYPE_CHECKING:
     from plumbum.commands.base import BaseCommand
 
 
 PKG_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = PKG_DIR.parent.parent.parent.parent
-
 try:  # pragma: no cover - exercised during script execution
     from .cmd_utils import run_cmd
 except ImportError:  # pragma: no cover - fallback when run as a script
-    module_path = _REPO_ROOT / "cmd_utils.py"
-    spec = importlib.util.spec_from_file_location("cmd_utils", module_path)
-    if spec is None or spec.loader is None:
-        raise ImportError(name="cmd_utils") from None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    run_cmd = module.run_cmd  # type: ignore[assignment]
+    run_cmd = import_cmd_utils().run_cmd
 
 __all__ = [
     "PKG_DIR",

--- a/.github/actions/linux-packages/tests/_packaging_utils.py
+++ b/.github/actions/linux-packages/tests/_packaging_utils.py
@@ -17,7 +17,9 @@ import pytest
 from plumbum import local
 from plumbum.commands.processes import ProcessExecutionError
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 TESTS_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(TESTS_ROOT / "scripts"))

--- a/.github/actions/linux-packages/tests/test_deb_package.py
+++ b/.github/actions/linux-packages/tests/test_deb_package.py
@@ -19,7 +19,9 @@ from _packaging_utils import (
 )
 from plumbum import local
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 
 @pytest.mark.usefixtures("uncapture_if_verbose")

--- a/.github/actions/linux-packages/tests/test_package_cli.py
+++ b/.github/actions/linux-packages/tests/test_package_cli.py
@@ -16,6 +16,10 @@ import pytest
 import yaml
 from plumbum.commands.processes import ProcessExecutionError
 
+from cmd_utils_importer import import_cmd_utils
+
+import_cmd_utils()
+
 
 @pytest.fixture
 def packaging_module() -> types.ModuleType:

--- a/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
@@ -9,7 +9,9 @@ import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 
 def main() -> None:

--- a/.github/actions/ratchet-coverage/scripts/run_coverage.py
+++ b/.github/actions/ratchet-coverage/scripts/run_coverage.py
@@ -16,7 +16,9 @@ import typer
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
-import cmd_utils
+from cmd_utils_importer import import_cmd_utils
+
+cmd_utils = import_cmd_utils()
 
 
 def extract_percent(output: str) -> str:

--- a/.github/actions/ratchet-coverage/scripts/run_coverage.py
+++ b/.github/actions/ratchet-coverage/scripts/run_coverage.py
@@ -41,7 +41,7 @@ def main(
     if args:
         cmd = cmd[shlex.split(args)]
     try:
-        retcode, output, err = run_cmd(cmd, retcode=None)
+        retcode, output, err = run_cmd(cmd, method="run")
     except ProcessExecutionError as exc:  # Should not happen but guard anyway
         retcode, output, err = exc.retcode, exc.stdout, exc.stderr
     if retcode != 0:

--- a/.github/actions/release-to-pypi-uv/scripts/publish_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/publish_release.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 
 import typer
+from plumbum import local
 
 
 def _ensure_python_runtime() -> None:
@@ -73,10 +74,10 @@ def main(index: str = "") -> None:
     """
     if index := index.strip():
         typer.echo(f"Publishing with uv to index '{index}'")
-        run_cmd(["uv", "publish", "--index", index])
+        run_cmd(local["uv"]["publish"]["--index", index])
     else:
         typer.echo("Publishing with uv to default index (PyPI)")
-        run_cmd(["uv", "publish"])
+        run_cmd(local["uv"]["publish"])
 
 
 def cli(index: str = INDEX_OPTION) -> None:

--- a/.github/actions/release-to-pypi-uv/scripts/publish_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/publish_release.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import typer
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
+
 
 def _ensure_python_runtime() -> None:
     """Fail fast when Python 3.13+ or uv provisioning is unavailable."""
@@ -55,7 +57,7 @@ def _extend_sys_path() -> None:
 _ensure_python_runtime()
 _extend_sys_path()
 
-from cmd_utils import run_cmd  # noqa: E402
+run_cmd = import_cmd_utils().run_cmd
 
 INDEX_OPTION = typer.Option(
     "",

--- a/.github/actions/release-to-pypi-uv/scripts/publish_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/publish_release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
-# dependencies = ["typer>=0.17,<0.18"]
+# dependencies = ["plumbum", "typer>=0.17,<0.18"]
 # ///
 """Publish the built distributions using uv."""
 

--- a/.github/actions/release-to-pypi-uv/tests/_helpers.py
+++ b/.github/actions/release-to-pypi-uv/tests/_helpers.py
@@ -13,8 +13,16 @@ if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
 
 if _ACTION_PATH := os.environ.get("GITHUB_ACTION_PATH"):
     _action_root = Path(_ACTION_PATH).resolve()
-    SCRIPTS_DIR = _action_root / "scripts"
-    REPO_ROOT = _action_root.parents[2]
+    scripts_candidate = _action_root / "scripts"
+    if scripts_candidate.is_dir():
+        SCRIPTS_DIR = scripts_candidate
+        try:
+            REPO_ROOT = _action_root.parents[2]
+        except IndexError:
+            REPO_ROOT = scripts_candidate.parents[3]
+    else:
+        SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+        REPO_ROOT = SCRIPTS_DIR.parents[3]
 else:
     SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
     REPO_ROOT = SCRIPTS_DIR.parents[3]

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -6,49 +6,63 @@ import typing as typ
 from pathlib import Path
 
 from plumbum import local
+from plumbum.commands.processes import ProcessExecutionError
 from shared_actions_conftest import REQUIRES_UV
 
-from cmd_utils import run_completed_process
+from cmd_utils import run_cmd
 
 from .test_determine_release import base_env
-
-if typ.TYPE_CHECKING:  # pragma: no cover - typing only
-    import subprocess
 
 pytestmark = REQUIRES_UV
 
 
-def run_confirm(
-    tmp_path: Path, expected: str, confirm: str
-) -> subprocess.CompletedProcess[str]:
+def run_confirm(tmp_path: Path, expected: str, confirm: str) -> tuple[int, str, str]:
     """Run the ``confirm_release`` script with explicit confirmation inputs."""
     env = base_env(tmp_path)
     env["EXPECTED"] = expected
     env["INPUT_CONFIRM"] = confirm
     script = Path(__file__).resolve().parents[1] / "scripts" / "confirm_release.py"
     command = local["uv"]["run", "--script", str(script)]
-    return run_completed_process(
-        command,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-        env=env,
-        check=False,
-        cwd=env.get("PWD"),
+    try:
+        code, stdout, stderr = typ.cast(
+            "tuple[int, str | bytes, str | bytes]",
+            run_cmd(
+                command,
+                method="run",
+                env=env,
+                cwd=env.get("PWD"),
+            ),
+        )
+    except ProcessExecutionError as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        return (
+            int(exc.retcode),
+            stdout if isinstance(stdout, str) else stdout.decode("utf-8", "replace"),
+            stderr if isinstance(stderr, str) else stderr.decode("utf-8", "replace"),
+        )
+    return (
+        code,
+        stdout.decode("utf-8", "replace") if isinstance(stdout, bytes) else stdout,
+        stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else stderr,
     )
 
 
 def test_confirmation_success(tmp_path: Path) -> None:
     """Accept matching confirmation phrases."""
-    result = run_confirm(tmp_path, expected="release v1.2.3", confirm="release v1.2.3")
+    returncode, stdout, stderr = run_confirm(
+        tmp_path, expected="release v1.2.3", confirm="release v1.2.3"
+    )
 
-    assert result.returncode == 0, result.stderr
-    assert "Manual confirmation OK." in result.stdout
+    assert returncode == 0, stderr
+    assert "Manual confirmation OK." in stdout
 
 
 def test_confirmation_failure(tmp_path: Path) -> None:
     """Reject confirmation attempts with mismatched input."""
-    result = run_confirm(tmp_path, expected="release v1.2.3", confirm="nope")
+    returncode, _, stderr = run_confirm(
+        tmp_path, expected="release v1.2.3", confirm="nope"
+    )
 
-    assert result.returncode == 1
-    assert "Confirmation failed" in result.stderr
+    assert returncode == 1
+    assert "Confirmation failed" in stderr

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-import subprocess
+import typing as typ
 from pathlib import Path
 
 from shared_actions_conftest import REQUIRES_UV
 
+from cmd_utils import run_completed_process
+
 from .test_determine_release import base_env
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+    import subprocess
 
 pytestmark = REQUIRES_UV
 
@@ -21,7 +26,7 @@ def run_confirm(
     env["INPUT_CONFIRM"] = confirm
     script = Path(__file__).resolve().parents[1] / "scripts" / "confirm_release.py"
     cmd = ["uv", "run", "--script", str(script)]
-    return subprocess.run(  # noqa: S603
+    return run_completed_process(
         cmd,
         capture_output=True,
         encoding="utf-8",

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typing as typ
 from pathlib import Path
 
+from plumbum import local
 from shared_actions_conftest import REQUIRES_UV
 
 from cmd_utils import run_completed_process
@@ -25,9 +26,9 @@ def run_confirm(
     env["EXPECTED"] = expected
     env["INPUT_CONFIRM"] = confirm
     script = Path(__file__).resolve().parents[1] / "scripts" / "confirm_release.py"
-    cmd = ["uv", "run", "--script", str(script)]
+    command = local["uv"]["run", "--script", str(script)]
     return run_completed_process(
-        cmd,
+        command,
         capture_output=True,
         encoding="utf-8",
         errors="replace",

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -6,63 +6,40 @@ import typing as typ
 from pathlib import Path
 
 from plumbum import local
-from plumbum.commands.processes import ProcessExecutionError
 from shared_actions_conftest import REQUIRES_UV
 
-from cmd_utils import run_cmd
+from test_support.plumbum_helpers import run_plumbum_command
 
 from .test_determine_release import base_env
 
 pytestmark = REQUIRES_UV
 
 
-def run_confirm(tmp_path: Path, expected: str, confirm: str) -> tuple[int, str, str]:
+if typ.TYPE_CHECKING:
+    from cmd_utils import RunResult
+
+
+def run_confirm(tmp_path: Path, expected: str, confirm: str) -> RunResult:
     """Run the ``confirm_release`` script with explicit confirmation inputs."""
     env = base_env(tmp_path)
     env["EXPECTED"] = expected
     env["INPUT_CONFIRM"] = confirm
     script = Path(__file__).resolve().parents[1] / "scripts" / "confirm_release.py"
     command = local["uv"]["run", "--script", str(script)]
-    try:
-        code, stdout, stderr = typ.cast(
-            "tuple[int, str | bytes, str | bytes]",
-            run_cmd(
-                command,
-                method="run",
-                env=env,
-                cwd=env.get("PWD"),
-            ),
-        )
-    except ProcessExecutionError as exc:
-        stdout = exc.stdout or ""
-        stderr = exc.stderr or ""
-        return (
-            int(exc.retcode),
-            stdout if isinstance(stdout, str) else stdout.decode("utf-8", "replace"),
-            stderr if isinstance(stderr, str) else stderr.decode("utf-8", "replace"),
-        )
-    return (
-        code,
-        stdout.decode("utf-8", "replace") if isinstance(stdout, bytes) else stdout,
-        stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else stderr,
-    )
+    return run_plumbum_command(command, method="run", env=env, cwd=env.get("PWD"))
 
 
 def test_confirmation_success(tmp_path: Path) -> None:
     """Accept matching confirmation phrases."""
-    returncode, stdout, stderr = run_confirm(
-        tmp_path, expected="release v1.2.3", confirm="release v1.2.3"
-    )
+    result = run_confirm(tmp_path, expected="release v1.2.3", confirm="release v1.2.3")
 
-    assert returncode == 0, stderr
-    assert "Manual confirmation OK." in stdout
+    assert result.returncode == 0, result.stderr
+    assert "Manual confirmation OK." in result.stdout
 
 
 def test_confirmation_failure(tmp_path: Path) -> None:
     """Reject confirmation attempts with mismatched input."""
-    returncode, _, stderr = run_confirm(
-        tmp_path, expected="release v1.2.3", confirm="nope"
-    )
+    result = run_confirm(tmp_path, expected="release v1.2.3", confirm="nope")
 
-    assert returncode == 1
-    assert "Confirmation failed" in stderr
+    assert result.returncode == 1
+    assert "Confirmation failed" in result.stderr

--- a/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_confirm_release.py
@@ -8,15 +8,17 @@ from pathlib import Path
 from plumbum import local
 from shared_actions_conftest import REQUIRES_UV
 
+from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
+
+if typ.TYPE_CHECKING:
+    from cmd_utils import RunResult
+else:
+    RunResult = import_cmd_utils().RunResult
 
 from .test_determine_release import base_env
 
 pytestmark = REQUIRES_UV
-
-
-if typ.TYPE_CHECKING:
-    from cmd_utils import RunResult
 
 
 def run_confirm(tmp_path: Path, expected: str, confirm: str) -> RunResult:

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -9,13 +9,15 @@ from pathlib import Path
 from plumbum import local
 from shared_actions_conftest import REQUIRES_UV
 
+from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
-
-pytestmark = REQUIRES_UV
-
 
 if typ.TYPE_CHECKING:
     from cmd_utils import RunResult
+else:
+    RunResult = import_cmd_utils().RunResult
+
+pytestmark = REQUIRES_UV
 
 
 def run_script(script: Path, *, env: dict[str, str]) -> RunResult:

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -23,7 +23,12 @@ pytestmark = REQUIRES_UV
 def run_script(script: Path, *, env: dict[str, str]) -> RunResult:
     """Execute ``determine_release`` with a controlled environment."""
     command = local["uv"]["run", "--script", str(script)]
-    return run_plumbum_command(command, method="run", env=env, cwd=env.get("PWD"))
+    scrubbed_env = env.copy()
+    for unset_key in ("GITHUB_REF_NAME", "GITHUB_REF_TYPE", "INPUT_TAG"):
+        scrubbed_env.setdefault(unset_key, "")
+    return run_plumbum_command(
+        command, method="run", env=scrubbed_env, cwd=scrubbed_env.get("PWD")
+    )
 
 
 def base_env(tmp_path: Path) -> dict[str, str]:

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -6,6 +6,7 @@ import os
 import typing as typ
 from pathlib import Path
 
+from plumbum import local
 from shared_actions_conftest import REQUIRES_UV
 
 from cmd_utils import run_completed_process
@@ -20,9 +21,9 @@ def run_script(
     script: Path, *, env: dict[str, str]
 ) -> subprocess.CompletedProcess[str]:
     """Execute ``determine_release`` with a controlled environment."""
-    cmd = ["uv", "run", "--script", str(script)]
+    command = local["uv"]["run", "--script", str(script)]
     return run_completed_process(
-        cmd,
+        command,
         capture_output=True,
         encoding="utf-8",
         errors="replace",

--- a/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_determine_release.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import os
-import subprocess
+import typing as typ
 from pathlib import Path
 
 from shared_actions_conftest import REQUIRES_UV
+
+from cmd_utils import run_completed_process
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+    import subprocess
 
 pytestmark = REQUIRES_UV
 
@@ -16,7 +21,7 @@ def run_script(
 ) -> subprocess.CompletedProcess[str]:
     """Execute ``determine_release`` with a controlled environment."""
     cmd = ["uv", "run", "--script", str(script)]
-    return subprocess.run(  # noqa: S603
+    return run_completed_process(
         cmd,
         capture_output=True,
         encoding="utf-8",

--- a/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
+++ b/.github/actions/release-to-pypi-uv/tests/test_publish_release.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import types
 import typing as typ
+from pathlib import Path
 
 if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
     from types import ModuleType
@@ -46,8 +47,10 @@ def test_publish_index_behaviour(
     """Exercise publishing for both default and custom index inputs."""
     calls: list[list[str]] = []
 
-    def fake_run_cmd(args: list[str], **_: object) -> None:
-        calls.append(args)
+    def fake_run_cmd(cmd: object, **_: object) -> None:
+        formulated = list(cmd.formulate())
+        formulated[0] = Path(formulated[0]).name
+        calls.append(formulated)
 
     monkeypatch.setattr(publish_module, "run_cmd", fake_run_cmd)
 
@@ -83,7 +86,7 @@ def test_publish_run_cmd_error(
     class DummyError(Exception):
         pass
 
-    def fake_run_cmd(_: list[str], **__: object) -> None:
+    def fake_run_cmd(cmd: object, **__: object) -> None:
         message = "uv publish failed"
         raise DummyError(message)
 
@@ -115,8 +118,10 @@ def test_cli_runner_default_index(
     """Exercise the CLI behaviour when no index is provided."""
     calls: list[list[str]] = []
 
-    def fake_run_cmd(args: list[str], **_: object) -> None:
-        calls.append(args)
+    def fake_run_cmd(cmd: object, **_: object) -> None:
+        formulated = list(cmd.formulate())
+        formulated[0] = Path(formulated[0]).name
+        calls.append(formulated)
 
     monkeypatch.setattr(publish_module, "run_cmd", fake_run_cmd)
 
@@ -136,8 +141,10 @@ def test_cli_runner_respects_env_index(
     """Accept the index from the GitHub Action input environment variable."""
     calls: list[list[str]] = []
 
-    def fake_run_cmd(args: list[str], **_: object) -> None:
-        calls.append(args)
+    def fake_run_cmd(cmd: object, **_: object) -> None:
+        formulated = list(cmd.formulate())
+        formulated[0] = Path(formulated[0]).name
+        calls.append(formulated)
 
     monkeypatch.setattr(publish_module, "run_cmd", fake_run_cmd)
 

--- a/.github/actions/rust-build-release/src/action_setup.py
+++ b/.github/actions/rust-build-release/src/action_setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["typer"]
+# dependencies = ["plumbum", "typer"]
 # ///
 """Helper utilities for composite action setup steps."""
 

--- a/.github/actions/rust-build-release/src/cross_manager.py
+++ b/.github/actions/rust-build-release/src/cross_manager.py
@@ -6,7 +6,6 @@ import hashlib
 import shutil
 import sys
 import tempfile
-import typing as typ
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -131,13 +130,10 @@ def install_cross_release(required_version: str) -> bool:
                 cross_exec = ensure_allowed_executable(
                     destination, ("cross", "cross.exe")
                 )
-                _, stdout, _ = typ.cast(
-                    "tuple[int, str, str]",
-                    run_validated(
-                        cross_exec,
-                        ["--version"],
-                        allowed_names=("cross", "cross.exe"),
-                    ),
+                result = run_validated(
+                    cross_exec,
+                    ["--version"],
+                    allowed_names=("cross", "cross.exe"),
                 )
             except (OSError, ProcessExecutionError) as exc:
                 typer.echo(
@@ -145,7 +141,7 @@ def install_cross_release(required_version: str) -> bool:
                     err=True,
                 )
                 return False
-            if version_output := stdout.strip():
+            if version_output := result.stdout.strip():
                 typer.echo(f"Installed cross binary reports: {version_output}")
     except urllib.error.URLError as exc:  # pragma: no cover - network failure
         typer.echo(
@@ -169,15 +165,12 @@ def ensure_cross(required_cross_version: str) -> tuple[str | None, str | None]:
     def get_cross_version(path: str) -> str | None:
         try:
             cross_exec = ensure_allowed_executable(path, ("cross", "cross.exe"))
-            _, stdout, _ = typ.cast(
-                "tuple[int, str, str]",
-                run_validated(
-                    cross_exec,
-                    ["--version"],
-                    allowed_names=("cross", "cross.exe"),
-                ),
+            result = run_validated(
+                cross_exec,
+                ["--version"],
+                allowed_names=("cross", "cross.exe"),
             )
-            version_line = stdout.strip().split("\n")[0]
+            version_line = result.stdout.strip().split("\n")[0]
             if version_line.startswith("cross "):
                 return version_line.split(" ")[1]
         except (

--- a/.github/actions/rust-build-release/src/cross_manager.py
+++ b/.github/actions/rust-build-release/src/cross_manager.py
@@ -22,7 +22,9 @@ from utils import (
     run_validated,
 )
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 _NON_HTTPS_ERROR = "non-HTTPS URL"
 _EMPTY_HASH_ERROR = "empty hash file"

--- a/.github/actions/rust-build-release/src/cross_manager.py
+++ b/.github/actions/rust-build-release/src/cross_manager.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import typer
 from packaging import version as pkg_version
+from plumbum import local
 from utils import (
     UnexpectedExecutableError,
     ensure_allowed_executable,
@@ -209,8 +210,7 @@ def ensure_cross(required_cross_version: str) -> tuple[str | None, str | None]:
         if not installed:
             try:
                 run_cmd(
-                    [
-                        "cargo",
+                    local["cargo"][
                         "install",
                         "--locked",
                         "cross",
@@ -221,8 +221,7 @@ def ensure_cross(required_cross_version: str) -> tuple[str | None, str | None]:
             except subprocess.CalledProcessError:
                 try:
                     run_cmd(
-                        [
-                            "cargo",
+                        local["cargo"][
                             "install",
                             "--locked",
                             "cross",

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -23,7 +23,9 @@ from runtime import CROSS_CONTAINER_ERROR_CODES, DEFAULT_HOST_TARGET, runtime_av
 from toolchain import configure_windows_linkers, read_default_toolchain
 from utils import UnexpectedExecutableError, ensure_allowed_executable, run_validated
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 DEFAULT_TOOLCHAIN = read_default_toolchain()
 

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -101,16 +101,13 @@ def should_probe_container(host_platform: str, target: str) -> bool:
 
 def _list_installed_toolchains(rustup_exec: str) -> list[str]:
     """Return installed rustup toolchain names."""
-    _, stdout, _ = typ.cast(
-        "tuple[int, str, str]",
-        run_validated(
-            rustup_exec,
-            ["toolchain", "list"],
-            allowed_names=("rustup", "rustup.exe"),
-            method="run",
-        ),
+    result = run_validated(
+        rustup_exec,
+        ["toolchain", "list"],
+        allowed_names=("rustup", "rustup.exe"),
+        method="run",
     )
-    installed = stdout.splitlines()
+    installed = result.stdout.splitlines()
     return [line.split()[0] for line in installed if line.strip()]
 
 

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["typer", "packaging"]
+# dependencies = ["packaging", "plumbum", "typer"]
 # ///
 """Build a Rust project in release mode for a target triple."""
 

--- a/.github/actions/rust-build-release/src/runtime.py
+++ b/.github/actions/rust-build-release/src/runtime.py
@@ -148,17 +148,14 @@ def _run_probe(
 ) -> tuple[int, str, str] | None:
     """Execute a runtime probe and handle common failure modes."""
     try:
-        return typ.cast(
-            "tuple[int, str, str]",
-            run_validated(
-                exec_path,
-                args,
-                allowed_names=(name, f"{name}.exe"),
-                timeout=PROBE_TIMEOUT,
-                cwd=cwd,
-                method="run",
-                **kwargs,
-            ),
+        return run_validated(
+            exec_path,
+            args,
+            allowed_names=(name, f"{name}.exe"),
+            timeout=PROBE_TIMEOUT,
+            cwd=cwd,
+            method="run",
+            **kwargs,
         )
     except ProcessTimedOut:
         typer.echo(
@@ -225,7 +222,9 @@ def runtime_available(name: str, *, cwd: str | Path | None = None) -> bool:
     if result is None:
         return False
 
-    if result[0] != 0:
+    returncode, _stdout, _stderr = result
+
+    if returncode != 0:
         return False
 
     if name == "podman":
@@ -240,7 +239,8 @@ def runtime_available(name: str, *, cwd: str | Path | None = None) -> bool:
             return False
 
         try:
-            security = json.loads(security_info[1] or "{}")
+            _security_code, security_stdout, _security_stderr = security_info
+            security = json.loads(security_stdout or "{}")
         except json.JSONDecodeError:
             return False
 

--- a/.github/actions/rust-build-release/src/utils.py
+++ b/.github/actions/rust-build-release/src/utils.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
+
 RunMethod = typ.Literal["call", "run", "run_fg"]
+
+_cmd_utils = import_cmd_utils()
 
 if typ.TYPE_CHECKING:  # pragma: no cover - typing only
     import cmd_utils
@@ -27,9 +31,11 @@ if typ.TYPE_CHECKING:  # pragma: no cover - typing only
             **run_kwargs: object,
         ) -> object: ...
 
-    run_cmd: _RunCmd
+    run_cmd = typ.cast("_RunCmd", cmd_utils.run_cmd)
+    coerce_run_result = cmd_utils.coerce_run_result
 else:
-    from cmd_utils import coerce_run_result, run_cmd
+    coerce_run_result = _cmd_utils.coerce_run_result
+    run_cmd = _cmd_utils.run_cmd
 
 
 class UnexpectedExecutableError(ValueError):

--- a/.github/actions/rust-build-release/src/utils.py
+++ b/.github/actions/rust-build-release/src/utils.py
@@ -3,9 +3,35 @@
 from __future__ import annotations
 
 import os  # noqa: TC003
-import subprocess
 import typing as typ
 from pathlib import Path
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+    import collections.abc as cabc
+    import subprocess
+
+    class _RunCompletedProcess(typ.Protocol):
+        def __call__(
+            self,
+            args: cabc.Sequence[str],
+            *,
+            capture_output: bool = False,
+            check: bool = False,
+            text: bool | None = None,
+            encoding: str | None = None,
+            errors: str | None = None,
+            timeout: float | None = None,
+            env: cabc.Mapping[str, str] | None = None,
+            cwd: str | os.PathLike[str] | None = None,
+            stdin: object | None = None,
+            stdout: object | None = None,
+            stderr: object | None = None,
+            universal_newlines: bool | None = None,
+        ) -> subprocess.CompletedProcess[str | bytes | None]: ...
+
+    run_completed_process: _RunCompletedProcess
+else:
+    from cmd_utils import run_completed_process
 
 
 class UnexpectedExecutableError(ValueError):
@@ -43,5 +69,5 @@ def run_validated(
         and "universal_newlines" not in subprocess_kwargs
     ):
         subprocess_kwargs["text"] = True
-    result = subprocess.run([exec_path, *args], **subprocess_kwargs)  # noqa: S603
+    result = run_completed_process([exec_path, *args], **subprocess_kwargs)
     return typ.cast("subprocess.CompletedProcess[str]", result)

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 from plumbum import local
 
-from cmd_utils import run_cmd, run_completed_process
+from cmd_utils import run_cmd
 
 if typ.TYPE_CHECKING:
     from cmd_utils import SupportsFormulate
@@ -201,14 +201,15 @@ def ensure_toolchain_ready() -> cabc.Callable[[str, str], None]:
         rustup_path = shutil.which("rustup")
         if rustup_path is None:  # pragma: no cover - guarded by caller checks
             pytest.skip("rustup not installed")
-        result = run_completed_process(
-            local[rustup_path]["toolchain", "list"],
-            capture_output=True,
-            text=True,
-            check=True,
+        _, stdout, _ = typ.cast(
+            "tuple[int, str, str]",
+            run_cmd(
+                local[rustup_path]["toolchain", "list"],
+                method="run",
+            ),
         )
         installed_names = [
-            line.split()[0] for line in result.stdout.splitlines() if line.strip()
+            line.split()[0] for line in stdout.splitlines() if line.strip()
         ]
         expected = {
             toolchain_version,

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -13,7 +13,9 @@ from pathlib import Path
 import pytest
 from plumbum import local
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 if typ.TYPE_CHECKING:
     from cmd_utils import SupportsFormulate

--- a/.github/actions/rust-build-release/tests/test_action_setup.py
+++ b/.github/actions/rust-build-release/tests/test_action_setup.py
@@ -7,6 +7,7 @@ import typing as typ
 from pathlib import Path
 
 import pytest
+from plumbum import local
 from typer.testing import CliRunner
 
 from cmd_utils import run_completed_process
@@ -104,13 +105,9 @@ def test_cli_validate_emits_error(action_setup_module: ModuleType) -> None:
 
 def test_script_validate_step_reports_error() -> None:
     """Running the script like the composite action reports invalid targets."""
+    command = local[sys.executable][str(SCRIPT_PATH), "validate", "short"]
     result = run_completed_process(
-        [
-            sys.executable,
-            str(SCRIPT_PATH),
-            "validate",
-            "short",
-        ],
+        command,
         capture_output=True,
         text=True,
     )
@@ -122,18 +119,18 @@ def test_script_validate_step_reports_error() -> None:
 def test_script_toolchain_step_resolves_windows(toolchain_module: ModuleType) -> None:
     """Script execution mirrors the composite action's toolchain resolution."""
     default = toolchain_module.read_default_toolchain()
+    command = local[sys.executable][
+        str(SCRIPT_PATH),
+        "toolchain",
+        "--target",
+        "aarch64-pc-windows-gnu",
+        "--runner-os",
+        "Windows",
+        "--runner-arch",
+        "ARM64",
+    ]
     result = run_completed_process(
-        [
-            sys.executable,
-            str(SCRIPT_PATH),
-            "toolchain",
-            "--target",
-            "aarch64-pc-windows-gnu",
-            "--runner-os",
-            "Windows",
-            "--runner-arch",
-            "ARM64",
-        ],
+        command,
         capture_output=True,
         text=True,
         check=False,

--- a/.github/actions/rust-build-release/tests/test_action_setup.py
+++ b/.github/actions/rust-build-release/tests/test_action_setup.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import typing as typ
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
+
+from cmd_utils import run_completed_process
 
 if typ.TYPE_CHECKING:
     from types import ModuleType
@@ -103,7 +104,7 @@ def test_cli_validate_emits_error(action_setup_module: ModuleType) -> None:
 
 def test_script_validate_step_reports_error() -> None:
     """Running the script like the composite action reports invalid targets."""
-    result = subprocess.run(  # noqa: S603
+    result = run_completed_process(
         [
             sys.executable,
             str(SCRIPT_PATH),
@@ -121,7 +122,7 @@ def test_script_validate_step_reports_error() -> None:
 def test_script_toolchain_step_resolves_windows(toolchain_module: ModuleType) -> None:
     """Script execution mirrors the composite action's toolchain resolution."""
     default = toolchain_module.read_default_toolchain()
-    result = subprocess.run(  # noqa: S603
+    result = run_completed_process(
         [
             sys.executable,
             str(SCRIPT_PATH),

--- a/.github/actions/rust-build-release/tests/test_runtime.py
+++ b/.github/actions/rust-build-release/tests/test_runtime.py
@@ -11,16 +11,18 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from plumbum.commands.processes import ProcessTimedOut
 
+from cmd_utils import RunResult
+
 if typ.TYPE_CHECKING:
     from .conftest import HarnessFactory, ModuleHarness
 
 
-RunOutput = tuple[int, str, str]
+RunOutput = RunResult
 
 
-def _run_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> RunOutput:
-    """Return a tuple matching the run_cmd ``method='run'`` contract."""
-    return (returncode, stdout, stderr)
+def _run_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> RunResult:
+    """Return a :class:`RunResult` mirroring plumbum ``run`` semantics."""
+    return RunResult(returncode, stdout, stderr)
 
 
 def _patch_run_validated_timeout(

--- a/.github/actions/rust-build-release/tests/test_runtime.py
+++ b/.github/actions/rust-build-release/tests/test_runtime.py
@@ -11,7 +11,9 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from plumbum.commands.processes import ProcessTimedOut
 
-from cmd_utils import RunResult
+from cmd_utils_importer import import_cmd_utils
+
+RunResult = import_cmd_utils().RunResult
 
 if typ.TYPE_CHECKING:
     from .conftest import HarnessFactory, ModuleHarness

--- a/.github/actions/rust-build-release/tests/test_smoke.py
+++ b/.github/actions/rust-build-release/tests/test_smoke.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
 
 SRC_DIR = Path(__file__).resolve().parents[1] / "src"
@@ -76,6 +77,8 @@ TARGET_PARAMS = [_param_for_target(target) for target in _targets]
 
 if typ.TYPE_CHECKING:
     from cmd_utils import RunResult
+else:
+    RunResult = import_cmd_utils().RunResult
 
 
 def run_script(script: Path, *args: str, cwd: Path | None = None) -> RunResult:

--- a/.github/actions/rust-build-release/tests/test_smoke.py
+++ b/.github/actions/rust-build-release/tests/test_smoke.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import importlib
 import shutil
-import subprocess
 import sys
 import typing as typ
 from pathlib import Path
 
 import pytest
+
+from cmd_utils import run_completed_process
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+    import subprocess
 
 SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_DIR) not in sys.path:
@@ -82,7 +86,7 @@ def run_script(
         cmd = [uv_path, "run", python_exe, str(script), *args]
     else:
         cmd = [python_exe, str(script), *args]
-    return subprocess.run(  # noqa: S603
+    return run_completed_process(
         cmd,
         capture_output=True,
         encoding="utf-8",

--- a/.github/actions/rust-build-release/tests/test_smoke.py
+++ b/.github/actions/rust-build-release/tests/test_smoke.py
@@ -9,6 +9,7 @@ import typing as typ
 from pathlib import Path
 
 import pytest
+from plumbum import local
 
 from cmd_utils import run_completed_process
 
@@ -83,11 +84,13 @@ def run_script(
     python_exe = sys.executable or shutil.which("python") or "python"
     uv_path = shutil.which("uv")
     if uv_path is not None:
-        cmd = [uv_path, "run", python_exe, str(script), *args]
+        command = local[uv_path]["run", python_exe, str(script)]
     else:
-        cmd = [python_exe, str(script), *args]
+        command = local[python_exe][str(script)]
+    if args:
+        command = command[list(args)]
     return run_completed_process(
-        cmd,
+        command,
         capture_output=True,
         encoding="utf-8",
         errors="replace",

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -14,7 +14,7 @@ import pytest
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
-from cmd_utils import run_cmd
+from cmd_utils import run_cmd, run_completed_process
 
 
 def test_toolchain_channel_strips_host_triple(main_module: ModuleType) -> None:
@@ -45,7 +45,7 @@ def run_script(
     """Execute *script* in *cwd* and return the completed process."""
     cmd = [str(script), *args]
     try:
-        return subprocess.run(  # noqa: S603
+        return run_completed_process(
             cmd,
             capture_output=True,
             encoding="utf-8",

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -12,11 +12,15 @@ import pytest
 from plumbum import local
 from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut
 
+from cmd_utils_importer import import_cmd_utils
+from test_support.plumbum_helpers import run_plumbum_command
+
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
-from cmd_utils import RunResult, run_cmd
-from test_support.plumbum_helpers import run_plumbum_command
+_cmd_utils = import_cmd_utils()
+RunResult = _cmd_utils.RunResult
+run_cmd = _cmd_utils.run_cmd
 
 
 def test_toolchain_channel_strips_host_triple(main_module: ModuleType) -> None:

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -15,15 +15,8 @@ from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
-from cmd_utils import run_cmd
-
-
-class RunResult(typ.NamedTuple):
-    """Container for script execution results."""
-
-    returncode: int
-    stdout: str
-    stderr: str
+from cmd_utils import RunResult, run_cmd
+from test_support.plumbum_helpers import run_plumbum_command
 
 
 def test_toolchain_channel_strips_host_triple(main_module: ModuleType) -> None:
@@ -54,19 +47,7 @@ def run_script(script: Path, *args: str, cwd: Path | None = None) -> RunResult:
     if args:
         command = command[list(args)]
     try:
-        code, stdout, stderr = typ.cast(
-            "tuple[int, str | bytes, str | bytes]",
-            run_cmd(
-                command,
-                method="run",
-                cwd=cwd,
-            ),
-        )
-        return RunResult(
-            code,
-            stdout.decode("utf-8", "replace") if isinstance(stdout, bytes) else stdout,
-            stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else stderr,
-        )
+        return run_plumbum_command(command, method="run", cwd=cwd)
     except (  # pragma: no cover - defensive path
         OSError,
         ProcessExecutionError,

--- a/.github/actions/rust-build-release/tests/test_utils.py
+++ b/.github/actions/rust-build-release/tests/test_utils.py
@@ -11,6 +11,10 @@ import pytest
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
+    from cmd_utils import SupportsFormulate
+else:  # pragma: no cover - typing helper fallback
+    SupportsFormulate = typ.Any
+
 
 def test_ensure_allowed_executable_accepts_valid_name(
     utils_module: ModuleType, tmp_path: Path
@@ -46,11 +50,11 @@ def test_run_validated_invokes_run_completed_process(
     captured_calls: list[tuple[list[str], dict[str, object]]] = []
 
     def fake_run_completed_process(
-        args: typ.Sequence[str],
+        cmd: SupportsFormulate,
         **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
-        captured_calls.append((list(args), dict(kwargs)))
-        return subprocess.CompletedProcess(tuple(args), 0, "ok", "")
+        captured_calls.append((list(cmd.formulate()), dict(kwargs)))
+        return subprocess.CompletedProcess(tuple(cmd.formulate()), 0, "ok", "")
 
     monkeypatch.setattr(
         utils_module, "run_completed_process", fake_run_completed_process

--- a/.github/actions/rust-build-release/tests/test_utils.py
+++ b/.github/actions/rust-build-release/tests/test_utils.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from cmd_utils import RunResult
+
 if typ.TYPE_CHECKING:
     from types import ModuleType
 
@@ -61,7 +63,7 @@ def test_run_validated_invokes_run_cmd(
                 {"method": method, "env": env, "kwargs": dict(kwargs)},
             )
         )
-        return (0, "ok", "")
+        return RunResult(0, "ok", "")
 
     monkeypatch.setattr(utils_module, "run_cmd", fake_run_cmd)
 
@@ -73,7 +75,7 @@ def test_run_validated_invokes_run_cmd(
         retcode=0,
     )
 
-    assert result == (0, "ok", "")
+    assert result == RunResult(0, "ok", "")
     assert captured_calls == [
         (
             [str(exe_path), "info"],

--- a/.github/actions/rust-build-release/tests/test_utils.py
+++ b/.github/actions/rust-build-release/tests/test_utils.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pytest
 
-from cmd_utils import RunResult
+from cmd_utils_importer import import_cmd_utils
+
+RunResult = import_cmd_utils().RunResult
 
 if typ.TYPE_CHECKING:
     from types import ModuleType

--- a/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
+++ b/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
@@ -16,6 +16,7 @@ import shutil
 from pathlib import Path  # noqa: TC003
 
 import typer
+from plumbum import local
 
 from cmd_utils import run_cmd
 
@@ -41,9 +42,8 @@ def main(artifact_dir: Path, nightly_sysroot: Path) -> None:
         shutil.copytree(artifact_dir, tmp)
     else:
         tmp.mkdir(parents=True, exist_ok=True)
-        cmd = ["rsync", "-a", "--delete", f"{artifact_dir}/", str(tmp)]
         try:
-            run_cmd(cmd)
+            run_cmd(local["rsync"]["-a", "--delete", f"{artifact_dir}/", str(tmp)])
         except FileNotFoundError:
             # Fallback when rsync is not available.
             shutil.copytree(artifact_dir, tmp, dirs_exist_ok=True)

--- a/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
+++ b/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
@@ -18,7 +18,9 @@ from pathlib import Path  # noqa: TC003
 import typer
 from plumbum import local
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 app = typer.Typer(add_completion=False)
 

--- a/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
+++ b/.github/actions/setup-rust/scripts/copy_openbsd_stdlib.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["typer"]
+# dependencies = ["plumbum", "typer"]
 # ///
 """Copy OpenBSD standard library build artifacts into the nightly sysroot.
 

--- a/.github/actions/setup-rust/tests/test_copy_stdlib.py
+++ b/.github/actions/setup-rust/tests/test_copy_stdlib.py
@@ -8,15 +8,10 @@ from pathlib import Path
 
 from plumbum import local
 
-from cmd_utils import run_cmd
+from test_support.plumbum_helpers import run_plumbum_command
 
-
-class RunResult(typ.NamedTuple):
-    """Container for script execution results."""
-
-    returncode: int
-    stdout: str
-    stderr: str
+if typ.TYPE_CHECKING:
+    from cmd_utils import RunResult
 
 
 def run_script(script: Path, *args: str) -> RunResult:
@@ -29,19 +24,7 @@ def run_script(script: Path, *args: str) -> RunResult:
     current_pp = merged.get("PYTHONPATH", "")
     merged["PYTHONPATH"] = f"{root}{os.pathsep}{current_pp}" if current_pp else root
     merged["PYTHONIOENCODING"] = "utf-8"
-    code, stdout, stderr = typ.cast(
-        "tuple[int, str | bytes, str | bytes]",
-        run_cmd(
-            command,
-            method="run",
-            env=merged,
-        ),
-    )
-    return RunResult(
-        code,
-        stdout.decode("utf-8", "replace") if isinstance(stdout, bytes) else stdout,
-        stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else stderr,
-    )
+    return run_plumbum_command(command, method="run", env=merged)
 
 
 def test_copy_success(tmp_path: Path) -> None:

--- a/.github/actions/setup-rust/tests/test_copy_stdlib.py
+++ b/.github/actions/setup-rust/tests/test_copy_stdlib.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import os
-import subprocess
+import typing as typ
 from pathlib import Path
+
+from cmd_utils import run_completed_process
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+    import subprocess
 
 
 def run_script(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -15,7 +20,7 @@ def run_script(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
     current_pp = merged.get("PYTHONPATH", "")
     merged["PYTHONPATH"] = f"{root}{os.pathsep}{current_pp}" if current_pp else root
     merged["PYTHONIOENCODING"] = "utf-8"
-    return subprocess.run(  # noqa: S603
+    return run_completed_process(
         cmd,
         capture_output=True,
         encoding="utf-8",

--- a/.github/actions/setup-rust/tests/test_copy_stdlib.py
+++ b/.github/actions/setup-rust/tests/test_copy_stdlib.py
@@ -8,10 +8,13 @@ from pathlib import Path
 
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
 
 if typ.TYPE_CHECKING:
     from cmd_utils import RunResult
+else:
+    RunResult = import_cmd_utils().RunResult
 
 
 def run_script(script: Path, *args: str) -> RunResult:

--- a/.github/actions/setup-rust/tests/test_copy_stdlib.py
+++ b/.github/actions/setup-rust/tests/test_copy_stdlib.py
@@ -6,6 +6,8 @@ import os
 import typing as typ
 from pathlib import Path
 
+from plumbum import local
+
 from cmd_utils import run_completed_process
 
 if typ.TYPE_CHECKING:  # pragma: no cover - typing only
@@ -14,14 +16,16 @@ if typ.TYPE_CHECKING:  # pragma: no cover - typing only
 
 def run_script(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Execute *script* using ``uv run --script`` and return the process."""
-    cmd = ["uv", "run", "--script", str(script), *args]
+    command = local["uv"]["run", "--script", str(script)]
+    if args:
+        command = command[list(args)]
     merged = {**os.environ}
     root = str(Path(__file__).resolve().parents[4])
     current_pp = merged.get("PYTHONPATH", "")
     merged["PYTHONPATH"] = f"{root}{os.pathsep}{current_pp}" if current_pp else root
     merged["PYTHONIOENCODING"] = "utf-8"
     return run_completed_process(
-        cmd,
+        command,
         capture_output=True,
         encoding="utf-8",
         errors="replace",

--- a/.github/actions/setup-rust/tests/test_validate_workspaces.py
+++ b/.github/actions/setup-rust/tests/test_validate_workspaces.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
+import typing as typ
 from pathlib import Path
 
 import pytest
+
+from cmd_utils import run_completed_process
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing only
+    import subprocess
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_workspaces.py"
 UV_NOT_FOUND_MESSAGE = "uv executable not found on PATH"
@@ -24,7 +29,7 @@ def run_validator(workspaces: str) -> subprocess.CompletedProcess[str]:
     uv_path = shutil.which("uv")
     if uv_path is None:
         pytest.skip(UV_NOT_FOUND_MESSAGE)
-    return subprocess.run(  # noqa: S603
+    return run_completed_process(
         [uv_path, "run", "--script", str(SCRIPT_PATH)],
         capture_output=True,
         encoding="utf-8",

--- a/.github/actions/setup-rust/tests/test_validate_workspaces.py
+++ b/.github/actions/setup-rust/tests/test_validate_workspaces.py
@@ -8,6 +8,7 @@ import typing as typ
 from pathlib import Path
 
 import pytest
+from plumbum import local
 
 from cmd_utils import run_completed_process
 
@@ -29,8 +30,9 @@ def run_validator(workspaces: str) -> subprocess.CompletedProcess[str]:
     uv_path = shutil.which("uv")
     if uv_path is None:
         pytest.skip(UV_NOT_FOUND_MESSAGE)
+    command = local[uv_path]["run", "--script", str(SCRIPT_PATH)]
     return run_completed_process(
-        [uv_path, "run", "--script", str(SCRIPT_PATH)],
+        command,
         capture_output=True,
         encoding="utf-8",
         errors="replace",

--- a/.github/actions/setup-rust/tests/test_validate_workspaces.py
+++ b/.github/actions/setup-rust/tests/test_validate_workspaces.py
@@ -10,14 +10,16 @@ from pathlib import Path
 import pytest
 from plumbum import local
 
+from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
-
-SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_workspaces.py"
-UV_NOT_FOUND_MESSAGE = "uv executable not found on PATH"
-
 
 if typ.TYPE_CHECKING:
     from cmd_utils import RunResult
+else:
+    RunResult = import_cmd_utils().RunResult
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_workspaces.py"
+UV_NOT_FOUND_MESSAGE = "uv executable not found on PATH"
 
 
 def run_validator(workspaces: str) -> RunResult:

--- a/.github/actions/validate-linux-packages/tests/test_action_manifest.py
+++ b/.github/actions/validate-linux-packages/tests/test_action_manifest.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import typing as typ
 from pathlib import Path
 
 import yaml
+
+from cmd_utils import run_completed_process
 
 if typ.TYPE_CHECKING:
     from cmd_mox import CmdMox
@@ -69,6 +70,6 @@ def test_action_run_step_invokes_validate_script(
     env["GITHUB_ACTION_PATH"] = str(action_dir)
 
     command = ["/usr/bin/env", "bash", "-c", run_script]
-    subprocess.run(command, check=True, cwd=tmp_path, env=env)  # noqa: S603
+    run_completed_process(command, check=True, cwd=tmp_path, env=env)
 
     cmd_mox.verify()

--- a/.github/actions/validate-linux-packages/tests/test_action_manifest.py
+++ b/.github/actions/validate-linux-packages/tests/test_action_manifest.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import yaml
 from plumbum import local
 
-from cmd_utils import run_cmd
+from cmd_utils_importer import import_cmd_utils
+
+run_cmd = import_cmd_utils().run_cmd
 
 if typ.TYPE_CHECKING:
     from cmd_mox import CmdMox

--- a/.github/actions/validate-linux-packages/tests/test_action_manifest.py
+++ b/.github/actions/validate-linux-packages/tests/test_action_manifest.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import yaml
 from plumbum import local
 
-from cmd_utils import run_completed_process
+from cmd_utils import run_cmd
 
 if typ.TYPE_CHECKING:
     from cmd_mox import CmdMox
@@ -71,6 +71,6 @@ def test_action_run_step_invokes_validate_script(
     env["GITHUB_ACTION_PATH"] = str(action_dir)
 
     command = local["/usr/bin/env"]["bash", "-c", run_script]
-    run_completed_process(command, check=True, cwd=tmp_path, env=env)
+    run_cmd(command, method="run", cwd=tmp_path, env=env)
 
     cmd_mox.verify()

--- a/.github/actions/validate-linux-packages/tests/test_action_manifest.py
+++ b/.github/actions/validate-linux-packages/tests/test_action_manifest.py
@@ -7,6 +7,7 @@ import typing as typ
 from pathlib import Path
 
 import yaml
+from plumbum import local
 
 from cmd_utils import run_completed_process
 
@@ -69,7 +70,7 @@ def test_action_run_step_invokes_validate_script(
     env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', '')}"
     env["GITHUB_ACTION_PATH"] = str(action_dir)
 
-    command = ["/usr/bin/env", "bash", "-c", run_script]
+    command = local["/usr/bin/env"]["bash", "-c", run_script]
     run_completed_process(command, check=True, cwd=tmp_path, env=env)
 
     cmd_mox.verify()

--- a/Makefile
+++ b/Makefile
@@ -24,23 +24,25 @@ lint: ## Check test scripts and actions
 
 typecheck: .venv ## Run static type checking with Ty
 	./.venv/bin/ty check \
-	    --extra-search-path .github/actions/generate-coverage/scripts \
-	    --extra-search-path .github/actions/ratchet-coverage/scripts \
-	    --extra-search-path .github/actions/rust-build-release \
-	    --extra-search-path .github/actions/rust-build-release/src \
-	    --extra-search-path .github/actions/linux-packages \
-	    --extra-search-path .github/actions/linux-packages/scripts \
-	    --extra-search-path .github/actions/setup-rust/scripts \
-	    cmd_utils.py \
-	    .github/actions/generate-coverage/scripts \
-	    .github/actions/ratchet-coverage/scripts \
-	    .github/actions/linux-packages/scripts \
-	    .github/actions/rust-build-release/src \
-	    .github/actions/setup-rust/scripts \
-	    shellstub.py
+		--extra-search-path . \
+		--extra-search-path .github/actions/generate-coverage/scripts \
+		--extra-search-path .github/actions/ratchet-coverage/scripts \
+		--extra-search-path .github/actions/rust-build-release \
+		--extra-search-path .github/actions/rust-build-release/src \
+		--extra-search-path .github/actions/linux-packages \
+		--extra-search-path .github/actions/linux-packages/scripts \
+		--extra-search-path .github/actions/setup-rust/scripts \
+		cmd_utils.py \
+		.github/actions/generate-coverage/scripts \
+		.github/actions/ratchet-coverage/scripts \
+		.github/actions/linux-packages/scripts \
+		.github/actions/rust-build-release/src \
+		.github/actions/setup-rust/scripts \
+		shellstub.py
 	./.venv/bin/ty check \
-	          --extra-search-path .github/actions/macos-package/scripts \
-	          .github/actions/macos-package/scripts
+		--extra-search-path . \
+		--extra-search-path .github/actions/macos-package/scripts \
+		.github/actions/macos-package/scripts
 fmt: ## Format Python files and auto-fix selected lint rules
 	uvx ruff format
 	uvx ruff check --select $(RUFF_FIX_RULES) --fix

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: fmt lint typecheck test ## Run format, lint, typecheck, then tests
 
 clean: ## Remove transient artefacts
-	rm -rf .venv .pytest_cache .ruff_cache .pyright workspace/.ruff_cache
+	rm -rf .venv .pytest_cache .ruff_cache workspace/.ruff_cache
 
 BUILD_JOBS ?=
 MDLINT ?= markdownlint
@@ -39,9 +39,8 @@ typecheck: .venv ## Run static type checking with Ty
 	    .github/actions/setup-rust/scripts \
 	    shellstub.py
 	./.venv/bin/ty check \
-	  --extra-search-path .github/actions/macos-package/scripts \
-	  .github/actions/macos-package/scripts
-	uvx pyright
+	          --extra-search-path .github/actions/macos-package/scripts \
+	          .github/actions/macos-package/scripts
 fmt: ## Format Python files and auto-fix selected lint rules
 	uvx ruff format
 	uvx ruff check --select $(RUFF_FIX_RULES) --fix

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 .PHONY: all clean help test lint markdownlint nixie fmt check-fmt typecheck
 
+export GITHUB_ACTION_PATH ?= $(CURDIR)
+
+ifndef PYTHONPATH
+export PYTHONPATH := $(CURDIR)
+else
+export PYTHONPATH := $(PYTHONPATH):$(CURDIR)
+endif
+
 all: fmt lint typecheck test ## Run format, lint, typecheck, then tests
 
 clean: ## Remove transient artefacts

--- a/cmd_utils.py
+++ b/cmd_utils.py
@@ -73,10 +73,12 @@ def _collect_runtime_env(
     """Return an environment mapping reflecting local and process mutations."""
     plumbum_env = typ.cast("cabc.Mapping[str, str]", local.env)
     base_env = {key: str(value) for key, value in plumbum_env.items()}
+
+    if env is not None:
+        return {key: str(value) for key, value in env.items()}
+
     runtime_env = base_env.copy()
     runtime_env.update({key: str(value) for key, value in os.environ.items()})
-    if env is not None:
-        runtime_env.update({key: str(value) for key, value in env.items()})
     if runtime_env == base_env:
         return None
     return runtime_env

--- a/cmd_utils.py
+++ b/cmd_utils.py
@@ -1,38 +1,18 @@
-"""Utilities for echoing and running external commands.
-
-Provides helpers that uniformly echo commands or execute them via
-``plumbum`` while returning :class:`subprocess.CompletedProcess` objects.
-
-Examples
---------
->>> from plumbum import local
->>> run_cmd(local["echo"]["hello"])
-"""
+"""Utilities for running plumbum command invocations."""
 
 from __future__ import annotations
 
 import collections.abc as cabc  # noqa: TC003
-import contextlib
 import os
-import shlex
-import subprocess
 import typing as typ
 
 import typer
 from plumbum import local
-from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut
 
-__all__: list[str] = [
-    "run_cmd",
-    "run_completed_process",
-]
+__all__ = ["RunMethod", "run_cmd"]
 
 
-class TimeoutConflictError(TypeError):
-    """Raised when mutually exclusive timeout options are provided."""
-
-    def __init__(self) -> None:
-        super().__init__("timeout specified via parameter and run_kwargs")
+RunMethod = typ.Literal["call", "run", "run_fg"]
 
 
 @typ.runtime_checkable
@@ -42,15 +22,20 @@ class SupportsFormulate(typ.Protocol):
     def formulate(self) -> cabc.Sequence[str]:  # pragma: no cover - protocol
         ...
 
+
+@typ.runtime_checkable
+class SupportsCall(SupportsFormulate, typ.Protocol):
+    """Commands that can be invoked like ``cmd()``."""
+
     def __call__(
-        self, *args: object, **run_kwargs: object
+        self, *args: object, **kwargs: object
     ) -> object:  # pragma: no cover - protocol
         ...
 
 
 @typ.runtime_checkable
-class SupportsRun(typ.Protocol):
-    """Commands that support ``run`` with keyword arguments."""
+class SupportsRun(SupportsFormulate, typ.Protocol):
+    """Commands that implement :meth:`run`."""
 
     def run(
         self, *args: object, **run_kwargs: object
@@ -59,69 +44,27 @@ class SupportsRun(typ.Protocol):
 
 
 @typ.runtime_checkable
-class SupportsRunFg(typ.Protocol):
-    """Commands that expose ``run_fg`` for foreground execution."""
+class SupportsRunFg(SupportsFormulate, typ.Protocol):
+    """Commands that expose :meth:`run_fg` for foreground execution."""
 
     def run_fg(self, **run_kwargs: object) -> object:  # pragma: no cover - protocol
         ...
 
 
 @typ.runtime_checkable
-class SupportsAnd(typ.Protocol):
-    """Commands that implement ``cmd & FG`` semantics."""
+class SupportsAnd(SupportsFormulate, typ.Protocol):
+    """Commands that can be combined with ``FG`` using ``&``."""
 
     def __and__(self, other: object) -> object:  # pragma: no cover - protocol
         ...
 
 
 @typ.runtime_checkable
-class _SupportsPlumbumRun(typ.Protocol):
-    """Commands that can spawn subprocesses via :meth:`popen`."""
+class SupportsWithEnv(SupportsFormulate, typ.Protocol):
+    """Commands that support environment overrides via :meth:`with_env`."""
 
-    def with_env(self, **env: str) -> _SupportsPlumbumRun: ...
-
-    def popen(self, /, **kwargs: object) -> subprocess.Popen[typ.Any]: ...
-
-
-KwargDict = dict[str, object]
-
-
-def _prepare_stdio_kwargs(
-    *,
-    capture_output: bool,
-    stdout: object | None,
-    stderr: object | None,
-) -> dict[str, object]:
-    """Return keyword arguments that configure stdio handling."""
-    if capture_output and (stdout is not None or stderr is not None):
-        msg = "stdout and stderr arguments may not be used with capture_output"
-        raise ValueError(msg)
-
-    stdio_kwargs: dict[str, object] = {}
-    if capture_output:
-        stdio_kwargs["stdout"] = subprocess.PIPE
-        stdio_kwargs["stderr"] = subprocess.PIPE
-        return stdio_kwargs
-
-    if stdout is not None:
-        stdio_kwargs["stdout"] = stdout
-    if stderr is not None:
-        stdio_kwargs["stderr"] = stderr
-    return stdio_kwargs
-
-
-def _normalize_text_mode(
-    *,
-    text: bool | None,
-    encoding: str | None,
-    errors: str | None,
-    universal_newlines: bool | None,
-) -> bool | None:
-    """Return the text mode flag derived from subprocess compatibility args."""
-    text_mode = text if text is not None else universal_newlines
-    if encoding is not None or errors is not None:
-        return True
-    return text_mode
+    def with_env(self, **env: str) -> SupportsWithEnv:  # pragma: no cover - protocol
+        ...
 
 
 def _collect_runtime_env(
@@ -129,7 +72,7 @@ def _collect_runtime_env(
 ) -> dict[str, str] | None:
     """Return an environment mapping reflecting local and process mutations."""
     plumbum_env = typ.cast("cabc.Mapping[str, str]", local.env)
-    base_env: dict[str, str] = {key: str(value) for key, value in plumbum_env.items()}
+    base_env = {key: str(value) for key, value in plumbum_env.items()}
     runtime_env = base_env.copy()
     runtime_env.update({key: str(value) for key, value in os.environ.items()})
     if env is not None:
@@ -139,233 +82,62 @@ def _collect_runtime_env(
     return runtime_env
 
 
-def _build_popen_kwargs(
-    *,
-    capture_output: bool,
-    stdout: object | None,
-    stderr: object | None,
-    text_mode: bool | None,
-    encoding: str | None,
-    errors: str | None,
-    cwd: str | os.PathLike[str] | None,
-    stdin: object | None,
-) -> dict[str, object]:
-    """Return the keyword arguments passed to ``popen``."""
-    popen_kwargs = _prepare_stdio_kwargs(
-        capture_output=capture_output,
-        stdout=stdout,
-        stderr=stderr,
-    )
-    if text_mode is not None:
-        popen_kwargs["text"] = text_mode
-    if encoding is not None:
-        popen_kwargs["encoding"] = encoding
-    if errors is not None:
-        popen_kwargs["errors"] = errors
-    if cwd is not None:
-        popen_kwargs["cwd"] = os.fspath(cwd)
-    if stdin is not None:
-        popen_kwargs["stdin"] = stdin
-    return popen_kwargs
-
-
-def run_completed_process(
-    cmd: object,
-    *,
-    capture_output: bool = False,
-    check: bool = False,
-    text: bool | None = None,
-    encoding: str | None = None,
-    errors: str | None = None,
-    timeout: float | None = None,
-    env: cabc.Mapping[str, str] | None = None,
-    cwd: str | os.PathLike[str] | None = None,
-    stdin: object | None = None,
-    stdout: object | None = None,
-    stderr: object | None = None,
-    universal_newlines: bool | None = None,
-) -> subprocess.CompletedProcess[str | bytes | None]:
-    """Execute *cmd* using :mod:`plumbum` and return a completed process."""
-    if not isinstance(cmd, SupportsFormulate) or not isinstance(
-        cmd, _SupportsPlumbumRun
-    ):
-        msg = "run_completed_process requires a plumbum command invocation"
+def _apply_environment(
+    cmd: SupportsFormulate,
+    runtime_env: dict[str, str] | None,
+) -> SupportsFormulate:
+    """Return *cmd* with *runtime_env* applied when provided."""
+    if runtime_env is None:
+        return cmd
+    if not isinstance(cmd, SupportsWithEnv):  # pragma: no cover - defensive
+        msg = "Command does not support environment overrides"
         raise TypeError(msg)
-
-    typer.echo(f"$ {cmd}")
-
-    runtime_env = _collect_runtime_env(env)
-    command_obj = typ.cast("SupportsFormulate | _SupportsPlumbumRun", cmd)
-    if runtime_env:
-        command_obj = typ.cast(
-            "SupportsFormulate | _SupportsPlumbumRun",
-            typ.cast("_SupportsPlumbumRun", command_obj).with_env(**runtime_env),
-        )
-
-    command_for_display = typ.cast("SupportsFormulate", command_obj)
-    command_for_process = typ.cast("_SupportsPlumbumRun", command_obj)
-    command_args = list(command_for_display.formulate())
-    if not command_args:
-        msg = "run_completed_process requires a plumbum command invocation"
-        raise TypeError(msg)
-
-    text_mode = _normalize_text_mode(
-        text=text,
-        encoding=encoding,
-        errors=errors,
-        universal_newlines=universal_newlines,
-    )
-    popen_kwargs = _build_popen_kwargs(
-        capture_output=capture_output,
-        stdout=stdout,
-        stderr=stderr,
-        text_mode=text_mode,
-        encoding=encoding,
-        errors=errors,
-        cwd=cwd,
-        stdin=stdin,
-    )
-
-    escaped_args = tuple(shlex.quote(part) for part in command_args)
-    process = command_for_process.popen(**popen_kwargs)
-
-    try:
-        stdout_data, stderr_data = process.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired as exc:
-        process.kill()
-        with contextlib.suppress(Exception):
-            process.communicate()
-        timeout_value = timeout if timeout is not None else exc.timeout
-        raise subprocess.TimeoutExpired(
-            escaped_args, timeout_value, output=exc.output, stderr=exc.stderr
-        ) from exc
-
-    captured_stdout: str | bytes | None = None
-    captured_stderr: str | bytes | None = None
-    if popen_kwargs.get("stdout") == subprocess.PIPE:
-        captured_stdout = stdout_data
-    if popen_kwargs.get("stderr") == subprocess.PIPE:
-        captured_stderr = stderr_data
-
-    completed: subprocess.CompletedProcess[str | bytes | None]
-    completed = subprocess.CompletedProcess(
-        escaped_args,
-        process.returncode,
-        stdout=captured_stdout,
-        stderr=captured_stderr,
-    )
-
-    if check and process.returncode != 0:
-        raise subprocess.CalledProcessError(
-            process.returncode,
-            escaped_args,
-            output=captured_stdout,
-            stderr=captured_stderr,
-        )
-
-    return completed
-
-
-def _merge_timeout(timeout: float | None, run_kwargs: KwargDict) -> float | None:
-    """Return a merged timeout value."""
-    if "timeout" in run_kwargs:
-        if timeout is not None:
-            raise TimeoutConflictError
-        value = run_kwargs.pop("timeout")
-        return typ.cast("float | None", value)
-    return timeout
-
-
-def _effective_timeout(
-    timeout: float | None, exc: BaseException | None = None
-) -> float:
-    """Return the timeout value to report to ``TimeoutExpired``."""
-    if timeout is not None:
-        return timeout
-    fallback = getattr(exc, "timeout", None)
-    if isinstance(fallback, (int, float)):
-        return float(fallback)
-    return 0.0
+    return typ.cast("SupportsFormulate", cmd.with_env(**runtime_env))
 
 
 def run_cmd(
     cmd: object,
     *,
-    fg: bool = False,
-    timeout: float | None = None,
+    method: RunMethod = "call",
+    env: cabc.Mapping[str, str] | None = None,
     **run_kwargs: object,
 ) -> object:
-    """Execute ``cmd`` while echoing it to stderr."""
+    """Execute ``cmd`` using plumbum semantics after echoing it."""
     if not isinstance(cmd, SupportsFormulate):
         msg = "run_cmd requires a plumbum command invocation"
         raise TypeError(msg)
 
-    command_args = [str(part) for part in cmd.formulate()]
     typer.echo(f"$ {cmd}")
 
-    timeout = _merge_timeout(timeout, run_kwargs)
+    prepared = _apply_environment(cmd, _collect_runtime_env(env))
 
-    if fg:
-        capture_output = bool(run_kwargs.pop("capture_output", False))
-        if capture_output:
-            msg = "capture_output may not be used with fg=True"
+    if method == "call":
+        if not isinstance(prepared, SupportsCall):
+            msg = "Command does not support call semantics"
             raise TypeError(msg)
-        if timeout is not None:
-            run_kwargs.setdefault("timeout", timeout)
-        if isinstance(cmd, SupportsRunFg):
-            try:
-                if run_kwargs:
-                    return cmd.run_fg(**run_kwargs)
-                return cmd.run_fg()
-            except ProcessTimedOut as exc:
-                raise subprocess.TimeoutExpired(
-                    command_args, _effective_timeout(timeout, exc)
-                ) from exc
-            except ProcessExecutionError as exc:
-                raise subprocess.CalledProcessError(
-                    typ.cast("int", exc.retcode),
-                    command_args,
-                    output=typ.cast("str | bytes | None", exc.stdout),
-                    stderr=typ.cast("str | bytes | None", exc.stderr),
-                ) from exc
-        if isinstance(cmd, SupportsAnd) and not run_kwargs:
+        return prepared(**run_kwargs)
+
+    if method == "run":
+        if not isinstance(prepared, SupportsRun):
+            msg = "Command does not support run()"
+            raise TypeError(msg)
+        run_options = dict(run_kwargs)
+        run_options.setdefault("retcode", None)
+        return prepared.run(**run_options)
+
+    if method == "run_fg":
+        if isinstance(prepared, SupportsRunFg):
+            return prepared.run_fg(**run_kwargs)
+        if run_kwargs:
+            invalid = ", ".join(sorted(run_kwargs.keys()))
+            msg = f"Foreground execution does not accept keyword arguments: {invalid}"
+            raise TypeError(msg)
+        if isinstance(prepared, SupportsAnd):
             from plumbum import FG  # pyright: ignore[reportMissingTypeStubs]
 
-            return cmd & FG
+            return prepared & FG
         msg = "Command does not support foreground execution"
         raise TypeError(msg)
 
-    if timeout is not None:
-        run_kwargs.setdefault("timeout", timeout)
-
-    if run_kwargs:
-        if not isinstance(cmd, SupportsRun):
-            invalid_keys = sorted(run_kwargs.keys())
-            msg = f"Command does not accept keyword arguments: {invalid_keys}"
-            raise TypeError(msg)
-        try:
-            return cmd.run(**run_kwargs)
-        except ProcessTimedOut as exc:
-            raise subprocess.TimeoutExpired(
-                command_args, _effective_timeout(timeout, exc)
-            ) from exc
-        except ProcessExecutionError as exc:
-            raise subprocess.CalledProcessError(
-                typ.cast("int", exc.retcode),
-                command_args,
-                output=typ.cast("str | bytes | None", exc.stdout),
-                stderr=typ.cast("str | bytes | None", exc.stderr),
-            ) from exc
-    try:
-        return cmd()
-    except ProcessTimedOut as exc:
-        raise subprocess.TimeoutExpired(
-            command_args, _effective_timeout(timeout, exc)
-        ) from exc
-    except ProcessExecutionError as exc:
-        raise subprocess.CalledProcessError(
-            typ.cast("int", exc.retcode),
-            command_args,
-            output=typ.cast("str | bytes | None", exc.stdout),
-            stderr=typ.cast("str | bytes | None", exc.stderr),
-        ) from exc
+    msg = f"Unknown run method: {method}"
+    raise ValueError(msg)

--- a/cmd_utils.pyi
+++ b/cmd_utils.pyi
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import collections.abc as cabc
+import typing as typ
+from subprocess import CalledProcessError, TimeoutExpired
+
+from plumbum.commands.processes import ProcessExecutionError, ProcessTimedOut
+
+RunMethod = typ.Literal["call", "run", "run_fg"]
+
+class RunResult(typ.NamedTuple):
+    returncode: int
+    stdout: str
+    stderr: str
+
+@typ.runtime_checkable
+class SupportsFormulate(typ.Protocol):
+    def formulate(self) -> cabc.Sequence[str]: ...
+
+@typ.runtime_checkable
+class SupportsCall(SupportsFormulate, typ.Protocol):
+    def __call__(self, *args: object, **kwargs: object) -> object: ...
+
+@typ.runtime_checkable
+class SupportsRun(SupportsFormulate, typ.Protocol):
+    def run(self, *args: object, **kwargs: object) -> object: ...
+
+@typ.runtime_checkable
+class SupportsRunFg(SupportsFormulate, typ.Protocol):
+    def run_fg(self, **kwargs: object) -> object: ...
+
+@typ.runtime_checkable
+class SupportsAnd(SupportsFormulate, typ.Protocol):
+    def __and__(self, other: object) -> object: ...
+
+@typ.runtime_checkable
+class SupportsWithEnv(SupportsFormulate, typ.Protocol):
+    def with_env(self, **env: str) -> SupportsWithEnv: ...
+
+def coerce_run_result(result: RunResult | cabc.Sequence[object]) -> RunResult: ...
+def process_error_to_run_result(exc: ProcessExecutionError) -> RunResult: ...
+def process_error_to_subprocess(
+    exc: ProcessExecutionError | ProcessTimedOut,
+    command: SupportsFormulate,
+    *,
+    timeout: float | None = ...,
+) -> CalledProcessError | TimeoutExpired: ...
+def run_cmd(
+    cmd: object,
+    *,
+    method: RunMethod = ...,
+    env: cabc.Mapping[str, str] | None = ...,
+    **run_kwargs: object,
+) -> object: ...
+
+__all__ = [
+    "RunMethod",
+    "RunResult",
+    "coerce_run_result",
+    "process_error_to_run_result",
+    "process_error_to_subprocess",
+    "run_cmd",
+]

--- a/cmd_utils_importer.py
+++ b/cmd_utils_importer.py
@@ -1,0 +1,91 @@
+"""Helpers for importing :mod:`cmd_utils` using ``GITHUB_ACTION_PATH``."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from functools import cache
+from pathlib import Path
+from types import ModuleType
+
+MODULE_NAME = "cmd_utils"
+MODULE_FILENAME = f"{MODULE_NAME}.py"
+ENV_VAR_NAME = "GITHUB_ACTION_PATH"
+
+
+class CmdUtilsDiscoveryError(RuntimeError):
+    """Raised when :mod:`cmd_utils` cannot be located or imported."""
+
+    def __init__(self, message: str, *, searched: list[Path] | None = None) -> None:
+        details = message
+        if searched:
+            joined = " -> ".join(str(path) for path in searched)
+            details = f"{message}; searched: {joined}"
+        super().__init__(details)
+        self.searched = searched or []
+
+
+def _action_path() -> Path:
+    try:
+        raw_path = os.environ[ENV_VAR_NAME]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        message = f"{ENV_VAR_NAME} is not set in the environment"
+        raise CmdUtilsDiscoveryError(message) from exc
+    path = Path(raw_path).expanduser().resolve()
+    if not path.exists():  # pragma: no cover - defensive guard
+        message = f"{ENV_VAR_NAME}={raw_path!r} does not exist"
+        raise CmdUtilsDiscoveryError(message)
+    return path
+
+
+def _candidate_module_paths() -> tuple[list[Path], Path]:
+    action_path = _action_path()
+    searched: list[Path] = []
+    for directory in (action_path, *action_path.parents):
+        candidate = directory / MODULE_FILENAME
+        searched.append(candidate)
+        if candidate.is_file() and not candidate.is_symlink():
+            return searched, candidate
+    message = f"{MODULE_FILENAME} not found via {ENV_VAR_NAME}"
+    raise CmdUtilsDiscoveryError(message, searched=searched)
+
+
+@cache
+def import_cmd_utils() -> ModuleType:
+    """Import and return the repository-level :mod:`cmd_utils` module."""
+    existing = sys.modules.get(MODULE_NAME)
+    if isinstance(existing, ModuleType):
+        return existing
+
+    searched, module_path = _candidate_module_paths()
+    module_dir = str(module_path.parent)
+    if module_dir not in sys.path:
+        sys.path.insert(0, module_dir)
+
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - import failure
+        message = f"Failed to load spec for {module_path}"
+        raise CmdUtilsDiscoveryError(message, searched=searched)
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)  # type: ignore[call-arg]
+    except Exception as exc:  # pragma: no cover - import-time failure
+        message = f"Failed to import cmd_utils from {module_path}"
+        raise CmdUtilsDiscoveryError(message, searched=searched) from exc
+
+    sys.modules[MODULE_NAME] = module
+    return module
+
+
+def ensure_cmd_utils_imported() -> None:
+    """Ensure :mod:`cmd_utils` is importable and loaded."""
+    import_cmd_utils()
+
+
+__all__ = [
+    "CmdUtilsDiscoveryError",
+    "ensure_cmd_utils_imported",
+    "import_cmd_utils",
+]

--- a/conftest.py
+++ b/conftest.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 import collections
 import collections.abc as cabc
+import os
 import shutil
 import sys
 import typing as typ
+from pathlib import Path
 
 import pytest
+
+
+def _default_action_path() -> str:
+    """Return the repository action directory used for cmd_utils discovery."""
+    return str(Path(__file__).resolve().parent / ".github" / "actions")
+
+
+os.environ.setdefault("GITHUB_ACTION_PATH", _default_action_path())
 
 CMD_MOX_UNSUPPORTED = pytest.mark.skipif(
     sys.platform == "win32", reason="cmd-mox does not support Windows"
@@ -18,10 +28,6 @@ HAS_UV = shutil.which("uv") is not None
 REQUIRES_UV = pytest.mark.usefixtures("require_uv")
 
 sys.modules.setdefault("shared_actions_conftest", sys.modules[__name__])
-
-
-if typ.TYPE_CHECKING:  # pragma: no cover - imported for annotations only
-    from pathlib import Path
 
 
 class CmdDouble(typ.Protocol):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,13 +127,3 @@ package = true
 requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.pyright]
-typeCheckingMode = "strict"
-reportUnknownVariableType = "error"
-reportUnknownParameterType = "error"
-reportUnknownMemberType = "error"
-reportMissingTypeStubs = "warning"
-reportUnusedFunction = "none"
-pythonVersion = "3.12"
-venvPath = "."
-venv = ".venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,12 @@ msgspec = "ms"
 "msgspec.json" = "msjson"
 typing = "typ"
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"subprocess.run".msg = "Use `plumbum` instead of `subprocess.run`"
+"subprocess.check_call".msg = "Use `plumbum` instead of `subprocess.check_call`"
+"subprocess.check_output".msg = "Use `plumbum` instead of `subprocess.check_output`"
+"subprocess.check_returncode".msg = "Use `plumbum` instead of `subprocess.check_returncode`"
+
 [tool.ruff.lint.pydocstyle]
 # Enforce NumPy docstring style
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ timeout = 30
 [tool.setuptools]
 py-modules = [
     "cmd_utils",
+    "cmd_utils_importer",
     "shellstub",
 ]
 

--- a/test_support/plumbum_helpers.py
+++ b/test_support/plumbum_helpers.py
@@ -1,0 +1,24 @@
+"""Shared helpers for normalising plumbum command results in tests."""
+
+from __future__ import annotations
+
+from plumbum.commands.processes import ProcessExecutionError
+
+import cmd_utils
+
+
+def run_plumbum_command(
+    command: cmd_utils.SupportsFormulate,
+    *,
+    method: cmd_utils.RunMethod = "run",
+    **run_kwargs: object,
+) -> cmd_utils.RunResult:
+    """Execute *command* and always return a :class:`RunResult`."""
+    try:
+        outcome = cmd_utils.run_cmd(command, method=method, **run_kwargs)
+    except ProcessExecutionError as exc:
+        return cmd_utils.process_error_to_run_result(exc)
+    return cmd_utils.coerce_run_result(outcome)
+
+
+__all__ = ["run_plumbum_command"]

--- a/test_support/plumbum_helpers.py
+++ b/test_support/plumbum_helpers.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from plumbum.commands.processes import ProcessExecutionError
 
-import cmd_utils
+from cmd_utils_importer import import_cmd_utils
+
+cmd_utils = import_cmd_utils()
 
 
 def run_plumbum_command(

--- a/tests/test_cmd_utils.py
+++ b/tests/test_cmd_utils.py
@@ -1,0 +1,58 @@
+"""Tests for :mod:`cmd_utils` helpers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from cmd_utils import run_completed_process
+
+
+def test_run_completed_process_returns_bytes_by_default() -> None:
+    """run_completed_process should return bytes when text mode is disabled."""
+    script = "import sys; sys.stdout.buffer.write(b'hello')"
+    result = run_completed_process(
+        [sys.executable, "-c", script],
+        capture_output=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == b"hello"
+    assert result.stderr == b""
+
+
+def test_run_completed_process_supports_text_mode() -> None:
+    """Enabling text mode should decode stdout and stderr as strings."""
+    script = "import sys; sys.stdout.write('hello'); sys.stderr.write('oops')"
+    result = run_completed_process(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout == "hello"
+    assert result.stderr == "oops"
+
+
+def test_run_completed_process_raises_on_non_zero_return() -> None:
+    """check=True should raise :class:`subprocess.CalledProcessError`."""
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        run_completed_process(
+            [sys.executable, "-c", "import sys; sys.exit(7)"],
+            capture_output=True,
+            check=True,
+        )
+
+    assert excinfo.value.returncode == 7
+
+
+def test_run_completed_process_enforces_timeouts() -> None:
+    """Commands exceeding the timeout should raise :class:`TimeoutExpired`."""
+    script = "import time; time.sleep(10)"
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_completed_process(
+            [sys.executable, "-c", script],
+            timeout=0.1,
+        )

--- a/tests/test_cmd_utils.py
+++ b/tests/test_cmd_utils.py
@@ -10,13 +10,33 @@ import pytest
 from plumbum import local
 from plumbum.commands.processes import ProcessExecutionError
 
-from cmd_utils import (
-    RunMethod,
-    RunResult,
-    coerce_run_result,
-    process_error_to_run_result,
-    run_cmd,
+from cmd_utils_importer import import_cmd_utils
+
+if typ.TYPE_CHECKING:
+    from cmd_utils import (
+        RunMethod as _RunMethod,
+    )
+    from cmd_utils import (
+        RunResult as _RunResult,
+    )
+    from cmd_utils import (
+        coerce_run_result as _coerce_run_result,
+    )
+    from cmd_utils import (
+        process_error_to_run_result as _process_error_to_run_result,
+    )
+    from cmd_utils import (
+        run_cmd as _run_cmd,
+    )
+
+_cmd_utils = import_cmd_utils()
+run_cmd = typ.cast("_run_cmd", _cmd_utils.run_cmd)
+coerce_run_result = typ.cast("_coerce_run_result", _cmd_utils.coerce_run_result)
+process_error_to_run_result = typ.cast(
+    "_process_error_to_run_result", _cmd_utils.process_error_to_run_result
 )
+RunResult = typ.cast("type[_RunResult]", _cmd_utils.RunResult)
+RunMethod = typ.cast("_RunMethod", _cmd_utils.RunMethod)
 
 
 def _python_command(*args: str) -> object:

--- a/tests/test_cmd_utils.py
+++ b/tests/test_cmd_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import typing as typ
 
@@ -74,6 +75,23 @@ def test_run_cmd_supports_explicit_environment_overrides() -> None:
     result = run_cmd(command, env={"CMD_UTILS_TOKEN": "override"})
 
     assert result == "override"
+
+
+def test_run_cmd_env_allows_variable_removal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Providing env should replace the inherited environment entirely."""
+    monkeypatch.setenv("CMD_UTILS_TOKEN", "runtime")
+    script = (
+        "import os; import sys; sys.stdout.write(str('CMD_UTILS_TOKEN' in os.environ))"
+    )
+    command = _python_command("-c", script)
+
+    sanitized_env = {
+        key: value for key, value in os.environ.items() if key != "CMD_UTILS_TOKEN"
+    }
+
+    result = run_cmd(command, env=sanitized_env)
+
+    assert result == "False"
 
 
 def test_run_cmd_run_fg_streams_output(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_cmd_utils.py
+++ b/tests/test_cmd_utils.py
@@ -23,6 +23,12 @@ def test_run_completed_process_returns_bytes_by_default() -> None:
     assert result.stderr == b""
 
 
+def test_run_completed_process_empty_args_raises_value_error() -> None:
+    """run_completed_process should reject empty argument sequences."""
+    with pytest.raises(ValueError, match="requires at least one argument"):
+        run_completed_process([])
+
+
 def test_run_completed_process_supports_text_mode() -> None:
     """Enabling text mode should decode stdout and stderr as strings."""
     script = "import sys; sys.stdout.write('hello'); sys.stderr.write('oops')"
@@ -36,6 +42,43 @@ def test_run_completed_process_supports_text_mode() -> None:
     assert result.stderr == "oops"
 
 
+def test_run_completed_process_text_mode_with_encoding() -> None:
+    """Explicit encodings should be honoured when decoding text output."""
+    script = (
+        "import sys; "
+        "sys.stdout.buffer.write(b'caf\\xe9'); "
+        "sys.stderr.buffer.write(b'err\\xe9')"
+    )
+    result = run_completed_process(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        encoding="latin-1",
+    )
+
+    assert result.stdout == "café"
+    assert result.stderr == "erré"
+
+
+def test_run_completed_process_text_mode_with_errors() -> None:
+    """The errors parameter should control decoder error handling."""
+    script = (
+        "import sys; "
+        "sys.stdout.buffer.write(b'bad\\xff'); "
+        "sys.stderr.buffer.write(b'fail\\xff')"
+    )
+    result = run_completed_process(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    assert result.stdout == "bad�"
+    assert result.stderr == "fail�"
+
+
 def test_run_completed_process_raises_on_non_zero_return() -> None:
     """check=True should raise :class:`subprocess.CalledProcessError`."""
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
@@ -46,6 +89,8 @@ def test_run_completed_process_raises_on_non_zero_return() -> None:
         )
 
     assert excinfo.value.returncode == 7
+    assert excinfo.value.output in {b"", ""}
+    assert excinfo.value.stderr in {b"", ""}
 
 
 def test_run_completed_process_enforces_timeouts() -> None:
@@ -55,4 +100,16 @@ def test_run_completed_process_enforces_timeouts() -> None:
         run_completed_process(
             [sys.executable, "-c", script],
             timeout=0.1,
+        )
+
+
+def test_run_completed_process_capture_output_conflict() -> None:
+    """capture_output may not be combined with explicit stdout/stderr streams."""
+    with pytest.raises(
+        ValueError, match="stdout and stderr arguments may not be used"
+    ):
+        run_completed_process(
+            [sys.executable, "-c", "print('hi')"],
+            capture_output=True,
+            stdout=subprocess.PIPE,
         )


### PR DESCRIPTION
## Summary
- Refactor
  - Migrated command execution from subprocess to plumbum across actions and tests, unifying via run_cmd and standardised RunResult/tuple outputs. Replaced foreground flag with method parameter.
- Bug Fixes
  - Improved error and timeout handling with clearer stdout/stderr decoding and more reliable env/cwd propagation.
- Chores
  - Added lint rules banning direct subprocess APIs; updated dependencies to include plumbum.
- Tests
  - Updated tests to new execution model; added comprehensive coverage for cmd_utils and runtime behaviours.

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e0cb8975a883229f579628af50af81

## Summary by Sourcery

Migrate command execution to plumbum via a new run_completed_process utility, update scripts and tests to use it, and enforce lint bans on direct subprocess usage.

New Features:
- Introduce run_completed_process helper that uses plumbum to execute commands and return subprocess.CompletedProcess results.

Enhancements:
- Migrate direct subprocess.run/check_call invocations in run_cmd, action scripts, and supporting modules to use the new helper.
- Add plumbum to script dependency metadata and remove direct subprocess imports.

Build:
- Add lint bans in pyproject.toml to forbid direct use of subprocess.run, check_call, check_output, and check_returncode.

Tests:
- Replace subprocess.run calls in existing action and CI tests with run_completed_process.
- Add dedicated tests for run_completed_process covering return codes, text mode, timeouts, and error handling.

## Summary by Sourcery

Replace direct subprocess invocations with plumbum-based command execution and unify test helpers around a new run_cmd API

Bug Fixes:
- Improve timeout and error propagation by catching plumbum ProcessExecutionError/ProcessTimedOut and preserving stdout/stderr

Enhancements:
- Introduce run_cmd in cmd_utils to execute plumbum commands with explicit RunMethod and environment merging
- Migrate all internal and action scripts to use plumbum.local commands and run_cmd/run_validated instead of subprocess APIs
- Standardize run_validated to delegate to run_cmd and return uniform tuples for returncode, stdout, stderr

Build:
- Add lint rules banning direct subprocess APIs in pyproject.toml
- Update script dependencies to include plumbum across actions

Tests:
- Refactor tests to use run_cmd and named RunResult tuples instead of subprocess.CompletedProcess
- Add comprehensive coverage for cmd_utils, cross_manager, and runtime modules under the new execution model