### PR TITLE
Ensure linux packages script_utils can load cmd utils under uv

### DIFF
--- a/.github/actions/linux-packages/scripts/script_utils.py
+++ b/.github/actions/linux-packages/scripts/script_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import importlib.machinery
 import importlib.util
@@ -27,23 +28,28 @@ CmdUtilsImporter = typ.Callable[[], _CmdUtilsModule]
 
 def _ensure_repo_root_on_sys_path() -> Path | None:
     """Ensure the repository root containing ``cmd_utils_importer`` is importable."""
+    action_path = os.environ.get("GITHUB_ACTION_PATH")
+    roots: list[Path] = []
+    if action_path:
+        roots.append(Path(action_path).resolve())
+    roots.extend([PKG_DIR, *PKG_DIR.parents])
 
-    def _candidate_roots() -> typ.Iterable[Path]:
-        action_path = os.environ.get("GITHUB_ACTION_PATH")
-        if action_path:
-            yield Path(action_path).resolve()
-        yield PKG_DIR
+    repo_root = next(
+        (
+            candidate
+            for candidate in roots
+            if (candidate / "cmd_utils_importer.py").is_file()
+        ),
+        None,
+    )
+    if repo_root is None:
+        return None
 
-    for base in _candidate_roots():
-        for candidate in (base, *base.parents):
-            target = candidate / "cmd_utils_importer.py"
-            if target.exists():
-                root_path = candidate
-                root_str = str(root_path)
-                if root_str not in sys.path:
-                    sys.path.insert(0, root_str)
-                return root_path
-    return None
+    root_str = str(repo_root)
+    with contextlib.suppress(ValueError):
+        sys.path.remove(root_str)
+    sys.path.insert(0, root_str)
+    return repo_root
 
 
 def _resolve_import_cmd_utils() -> CmdUtilsImporter:

--- a/.github/actions/linux-packages/scripts/script_utils.py
+++ b/.github/actions/linux-packages/scripts/script_utils.py
@@ -16,6 +16,15 @@ from plumbum import local
 PKG_DIR = Path(__file__).resolve().parent
 
 
+class _CmdUtilsModule(typ.Protocol):
+    """Typed view of the :mod:`cmd_utils` module."""
+
+    run_cmd: typ.Callable[..., typ.Any]
+
+
+CmdUtilsImporter = typ.Callable[[], _CmdUtilsModule]
+
+
 def _ensure_repo_root_on_sys_path() -> Path | None:
     """Ensure the repository root containing ``cmd_utils_importer`` is importable."""
 
@@ -37,9 +46,16 @@ def _ensure_repo_root_on_sys_path() -> Path | None:
     return None
 
 
-_ensure_repo_root_on_sys_path()
+def _resolve_import_cmd_utils() -> CmdUtilsImporter:
+    """Return the ``import_cmd_utils`` callable with ``sys.path`` primed."""
+    if not __package__:
+        _ensure_repo_root_on_sys_path()
+    from cmd_utils_importer import import_cmd_utils as importer
 
-from cmd_utils_importer import import_cmd_utils
+    return typ.cast("CmdUtilsImporter", importer)
+
+
+import_cmd_utils = _resolve_import_cmd_utils()
 
 if typ.TYPE_CHECKING:
     from plumbum.commands.base import BaseCommand


### PR DESCRIPTION
## Summary
- add a sys.path bootstrapper in script_utils so standalone execution can import cmd_utils via the repository root
- extend the loader fallback test to simulate a minimal sys.path and confirm the helper module still loads

## Testing
- `uv run --with typer --with packaging --with plumbum --with pyyaml pytest .github/actions/linux-packages/tests/test_script_utils_helpers.py`
- `uv run --with typer --with packaging --with plumbum --with pyyaml pytest .github/actions/linux-packages/tests/test_deb_package.py .github/actions/linux-packages/tests/test_rpm_package.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2787073588322a73b6c4c386ea796

## Summary by Sourcery

Bootstrap the repository root onto sys.path in script_utils to ensure cmd_utils_importer can be imported when running standalone under uv, and extend fallback loader test to verify this behavior.

New Features:
- Implement _ensure_repo_root_on_sys_path to locate and insert the repo root into sys.path at import time so cmd_utils_importer can be loaded in isolated executions.

Tests:
- Enhance the loader fallback test to simulate a minimal sys.path and GITHUB_ACTION_PATH environment, and assert that sys.path is correctly updated and cmd_utils_importer is imported from the repo root.