### PR TITLE
Refactor manpage assertion helper

### DIFF
--- a/.github/actions/validate-linux-packages/tests/test_validate_packages.py
+++ b/.github/actions/validate-linux-packages/tests/test_validate_packages.py
@@ -97,6 +97,11 @@ def test_validate_deb_package_runs_sandbox_checks(
         "inspect_deb_package",
         lambda *_: metadata,
     )
+    monkeypatch.setattr(
+        validate_packages_module.platform,
+        "machine",
+        lambda: "x86_64",
+    )
     calls: list[tuple[tuple[str, ...], int | None]] = []
     sandbox = DummySandbox(tmp_path / "sandbox", calls)
 
@@ -317,6 +322,11 @@ def test_install_and_verify_wraps_validation_errors(
         validate_packages_module,
         "inspect_deb_package",
         lambda *_: metadata,
+    )
+    monkeypatch.setattr(
+        validate_packages_module.platform,
+        "machine",
+        lambda: "x86_64",
     )
 
     error = validate_packages_module.ValidationError("command failed")

--- a/rust-toy-app/tests/common/mod.rs
+++ b/rust-toy-app/tests/common/mod.rs
@@ -1,3 +1,5 @@
+//! Shared helpers, fixtures, and utilities for rust-toy-app integration tests.
+
 use glob::glob;
 use std::path::Path;
 
@@ -7,7 +9,8 @@ pub fn assert_manpage_exists() {
     assert_manpage_exists_in(Path::new(&target));
 }
 
-pub fn assert_manpage_exists_in(root: &Path) {
+pub fn assert_manpage_exists_in(root: impl AsRef<Path>) {
+    let root = root.as_ref();
     let patterns = [
         root.join("debug/build/rust-toy-app-*/out/rust-toy-app.1"),
         root.join("release/build/rust-toy-app-*/out/rust-toy-app.1"),
@@ -20,6 +23,6 @@ pub fn assert_manpage_exists_in(root: &Path) {
             .expect("valid glob")
             .any(|entry| entry.map(|p| p.exists()).unwrap_or(false))
     });
-    assert!(found, "man page not found; searched: {display_patterns:?}");
+    assert!(found, "man page not found; searched: {:?}", display_patterns);
 }
 

--- a/rust-toy-app/tests/common/mod.rs
+++ b/rust-toy-app/tests/common/mod.rs
@@ -3,6 +3,10 @@
 use glob::glob;
 use std::path::Path;
 
+#[expect(
+    dead_code,
+    reason = "helper is only needed when tests execute the default-target path"
+)]
 pub fn assert_manpage_exists() {
     let target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
     assert_manpage_exists_in(Path::new(&target));
@@ -24,4 +28,3 @@ pub fn assert_manpage_exists_in(root: impl AsRef<Path>) {
     });
     assert!(found, "man page not found; searched: {:?}", display_patterns);
 }
-

--- a/rust-toy-app/tests/common/mod.rs
+++ b/rust-toy-app/tests/common/mod.rs
@@ -3,7 +3,6 @@
 use glob::glob;
 use std::path::Path;
 
-#[allow(dead_code)]
 pub fn assert_manpage_exists() {
     let target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
     assert_manpage_exists_in(Path::new(&target));

--- a/rust-toy-app/tests/common/mod.rs
+++ b/rust-toy-app/tests/common/mod.rs
@@ -1,17 +1,25 @@
 use glob::glob;
+use std::path::Path;
 
+#[allow(dead_code)]
 pub fn assert_manpage_exists() {
     let target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
-    let patterns = [
-        format!("{}/debug/build/rust-toy-app-*/out/rust-toy-app.1", target),
-        format!("{}/release/build/rust-toy-app-*/out/rust-toy-app.1", target),
-    ];
+    assert_manpage_exists_in(Path::new(&target));
+}
 
-    let found = patterns.iter().any(|pat| {
-        glob(pat)
+pub fn assert_manpage_exists_in(root: &Path) {
+    let patterns = [
+        root.join("debug/build/rust-toy-app-*/out/rust-toy-app.1"),
+        root.join("release/build/rust-toy-app-*/out/rust-toy-app.1"),
+    ];
+    let display_patterns: Vec<String> =
+        patterns.iter().map(|p| p.display().to_string()).collect();
+
+    let found = patterns.iter().any(|pattern| {
+        glob(pattern.to_str().expect("pattern should be valid UTF-8"))
             .expect("valid glob")
             .any(|entry| entry.map(|p| p.exists()).unwrap_or(false))
     });
-    assert!(found, "man page not found; searched: {patterns:?}");
+    assert!(found, "man page not found; searched: {display_patterns:?}");
 }
 

--- a/rust-toy-app/tests/manpage_generation.rs
+++ b/rust-toy-app/tests/manpage_generation.rs
@@ -1,6 +1,7 @@
+mod common;
 
 use assert_cmd::prelude::*;
-use glob::glob;
+use common::assert_manpage_exists;
 use std::process::Command;
 
 #[test]
@@ -10,18 +11,7 @@ fn generates_manpage() {
         .assert()
         .success();
 
-    let target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
-    let patterns = [
-        format!("{}/debug/build/rust-toy-app-*/out/rust-toy-app.1", target),
-        format!("{}/release/build/rust-toy-app-*/out/rust-toy-app.1", target),
-    ];
-
-    let found = patterns.iter().any(|pat| {
-        glob(pat)
-            .expect("valid glob")
-            .any(|entry| entry.map(|p| p.exists()).unwrap_or(false))
-    });
-    assert!(found, "man page not found; searched: {patterns:?}");
+    assert_manpage_exists();
 }
 
 

--- a/rust-toy-app/tests/rust_build_release.rs
+++ b/rust-toy-app/tests/rust_build_release.rs
@@ -27,10 +27,6 @@ fn builds_release_binary_and_manpage() {
         action_dir.to_str().expect("valid UTF-8 path"),
     );
 
-    // Reference the default-target helper so it remains reachable even in binaries
-    // that only validate cross-compiled artifacts.
-    let _ = assert_manpage_exists as fn();
-
     for target in TARGETS {
         if *target != "x86_64-unknown-linux-gnu" {
             let docker_available = runtime_available("docker");

--- a/rust-toy-app/tests/rust_build_release.rs
+++ b/rust-toy-app/tests/rust_build_release.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use assert_cmd::prelude::*;
-use common::assert_manpage_exists_in;
+use common::{assert_manpage_exists, assert_manpage_exists_in};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -26,6 +26,10 @@ fn builds_release_binary_and_manpage() {
         "GITHUB_ACTION_PATH",
         action_dir.to_str().expect("valid UTF-8 path"),
     );
+
+    // Reference the default-target helper so it remains reachable even in binaries
+    // that only validate cross-compiled artifacts.
+    let _ = assert_manpage_exists as fn();
 
     for target in TARGETS {
         if *target != "x86_64-unknown-linux-gnu" {

--- a/rust-toy-app/tests/rust_build_release.rs
+++ b/rust-toy-app/tests/rust_build_release.rs
@@ -1,7 +1,9 @@
 //! Integration test: ensure the composite action's Python entrypoint builds a release binary and man page.
 
+mod common;
+
 use assert_cmd::prelude::*;
-use glob::glob;
+use common::assert_manpage_exists_in;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -42,14 +44,10 @@ fn builds_release_binary_and_manpage() {
             .assert()
             .success();
 
-        assert!(
-            project_dir
-                .join(format!("target/{target}/release/rust-toy-app"))
-                .exists()
-        );
-        let pattern = project_dir.join(format!(
-            "target/{target}/release/build/rust-toy-app-*/out/rust-toy-app.1"
-        ));
-        assert!(glob(pattern.to_str().unwrap()).unwrap().next().is_some());
+        assert!(project_dir
+            .join(format!("target/{target}/release/rust-toy-app"))
+            .exists());
+        let target_root = project_dir.join(format!("target/{target}"));
+        assert_manpage_exists_in(&target_root);
     }
 }


### PR DESCRIPTION
## Summary
- extract the manpage glob assertion into a reusable helper that accepts a target root
- update the integration tests to call the helper instead of duplicating the glob logic

## Testing
- `GITHUB_ACTION_PATH=../.github/actions/rust-build-release cargo test -p rust-toy-app --tests` *(fails: aarch64 cross-compilation requires unavailable tooling in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c617c8588322bf324ebab41e8eae

## Summary by Sourcery

Extract the manpage existence check into reusable test helper functions and update all integration tests to use them instead of duplicating glob logic

Enhancements:
- Extract manpage assertion logic into common helper functions assert_manpage_exists and assert_manpage_exists_in

Tests:
- Refactor integration tests to call the new helper functions instead of inlining glob patterns