### PR TITLE
Handle sys.path bootstrap order and cache isolation support

### DIFF
--- a/.github/actions/rust-build-release/src/action_setup.py
+++ b/.github/actions/rust-build-release/src/action_setup.py
@@ -59,8 +59,18 @@ def bootstrap_environment() -> tuple[Path, Path]:
     if not repo_root.exists():
         message = f"Repository root does not exist: {repo_root}"
         raise FileNotFoundError(message)
-    if str(repo_root) not in sys.path:
-        sys.path.insert(0, str(repo_root))
+    repo_root_str = str(repo_root)
+    script_dir = script_path.parent
+    if repo_root_str not in sys.path:
+        insert_index = 0
+        if sys.path:
+            try:
+                first_entry_path = Path(sys.path[0]).resolve()
+            except (OSError, RuntimeError):  # pragma: no cover - defensive guard
+                first_entry_path = None
+            if first_entry_path == script_dir:
+                insert_index = 1
+        sys.path.insert(insert_index, repo_root_str)
 
     try:
         from cmd_utils_importer import ensure_cmd_utils_imported

--- a/.github/actions/validate-linux-packages/scripts/validate_polythene.py
+++ b/.github/actions/validate-linux-packages/scripts/validate_polythene.py
@@ -167,7 +167,7 @@ class PolytheneSession:
 
         cmd = local["uv"][tuple(cmd_args)]
         try:
-            return run_text(cmd, timeout=effective_timeout)
+            result = run_text(cmd, timeout=effective_timeout)
         except ValidationError as exc:
             if include_isolation and _is_unknown_isolation_option_error(exc):
                 logger.info(
@@ -179,6 +179,10 @@ class PolytheneSession:
                 fallback_cmd = local["uv"][tuple(no_isolation_args)]
                 return run_text(fallback_cmd, timeout=effective_timeout)
             raise
+        else:
+            if include_isolation:
+                self._supports_isolation_option = True
+            return result
 
 
 def default_polythene_command() -> Command:


### PR DESCRIPTION
## Summary
- adjust the rust-build-release bootstrap so the repository root is inserted after the script directory when appropriate
- mark the polythene session as supporting isolation after a successful run to avoid redundant detection attempts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3af53a77883229db9c16dff6af10d