### PR TITLE
Normalize script directory path in rust-build-release test

### DIFF
--- a/.github/actions/rust-build-release/tests/test_action_setup.py
+++ b/.github/actions/rust-build-release/tests/test_action_setup.py
@@ -45,7 +45,7 @@ def test_bootstrap_inserts_repo_root_after_script_dir_prefix(
 ) -> None:
     """Repo root insertion honours a leading script directory entry."""
     script_dir = Path(action_setup_module.__file__).resolve().parent
-    path_entries = [script_dir.as_posix(), "other"]
+    path_entries = [str(script_dir), "other"]
     monkeypatch.setattr(action_setup_module.sys, "path", path_entries)
     _reset_bootstrap_cache(action_setup_module, monkeypatch)
 

--- a/.github/actions/rust-build-release/tests/test_action_setup.py
+++ b/.github/actions/rust-build-release/tests/test_action_setup.py
@@ -45,7 +45,8 @@ def test_bootstrap_inserts_repo_root_after_script_dir_prefix(
 ) -> None:
     """Repo root insertion honours a leading script directory entry."""
     script_dir = Path(action_setup_module.__file__).resolve().parent
-    path_entries = [str(script_dir), "other"]
+    script_dir_str = str(script_dir)
+    path_entries: list[str] = [script_dir_str, "other"]
     monkeypatch.setattr(action_setup_module.sys, "path", path_entries)
     _reset_bootstrap_cache(action_setup_module, monkeypatch)
 


### PR DESCRIPTION
## Summary
- ensure the test uses the same path normalization as the action implementation when seeding sys.path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e453e584b08322b15d02f47415bf4a

## Summary by Sourcery

Tests:
- Normalize the script directory path in rust-build-release tests by using str(script_dir) instead of as_posix()