### PR TITLE
Refine action setup bootstrapping helpers

### DIFF
--- a/.github/actions/rust-build-release/src/action_setup.py
+++ b/.github/actions/rust-build-release/src/action_setup.py
@@ -26,7 +26,6 @@ def _compute_sys_path_insert_index(
     script_dir: Path, path_entries: typ.Sequence[str]
 ) -> int:
     """Return the insertion index for ``script_dir`` aware path updates."""
-
     if not path_entries:
         return 0
 
@@ -49,7 +48,6 @@ def _compute_sys_path_insert_index(
 
 def _initialise_cmd_utils() -> None:
     """Load ``cmd_utils`` helpers for downstream imports."""
-
     try:
         from cmd_utils_importer import ensure_cmd_utils_imported
 

--- a/.github/actions/rust-build-release/tests/test_action_setup.py
+++ b/.github/actions/rust-build-release/tests/test_action_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import typing as typ
 from pathlib import Path
@@ -39,6 +40,12 @@ def test_bootstrap_inserts_repo_root_first_when_path_empty(
 
     assert path_entries[0] == str(repo_root)
 
+    repo_root_str = str(repo_root)
+    _reset_bootstrap_cache(action_setup_module, monkeypatch)
+    action_setup_module.bootstrap_environment()
+
+    assert len([entry for entry in path_entries if entry == repo_root_str]) == 1
+
 
 def test_bootstrap_inserts_repo_root_after_script_dir_prefix(
     action_setup_module: ModuleType, monkeypatch: pytest.MonkeyPatch
@@ -60,11 +67,14 @@ def test_bootstrap_ignores_blank_first_entry_for_insertion_index(
     """Blank ``sys.path`` entries do not offset repo root insertion."""
     path_entries = ["", "other"]
     monkeypatch.setattr(action_setup_module.sys, "path", path_entries)
+    sentinel = "sentinel-action-path"
+    monkeypatch.setenv("GITHUB_ACTION_PATH", sentinel)
     _reset_bootstrap_cache(action_setup_module, monkeypatch)
 
     _, repo_root = action_setup_module.bootstrap_environment()
 
     assert path_entries[0] == str(repo_root)
+    assert os.environ["GITHUB_ACTION_PATH"] == sentinel
 
 
 def test_validate_target_accepts_valid(action_setup_module: ModuleType) -> None:


### PR DESCRIPTION
## Summary
- extract helpers to encapsulate sys.path insertion and cmd utils initialisation during bootstrap
- preserve existing environment defaults while hardening duplicate path handling in tests

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e45408379c8322a6461eef9aa85f6a