### PR TITLE
Support private self-checkout for linux-packages

### DIFF
--- a/.github/actions/linux-packages/README.md
+++ b/.github/actions/linux-packages/README.md
@@ -22,6 +22,7 @@ nFPM.
 | maintainer | string | _empty_ | Maintainer entry for the generated package metadata. | no |
 | homepage | string | _empty_ | Homepage URL recorded in package metadata. | no |
 | license | string | _empty_ | Software license declared in the package metadata. | no |
+| action-token | string | _empty_ | Personal access token used to clone this action when consumed from a private repository. Defaults to the workflow `github.token`. | no |
 | section | string | _empty_ | Package section/category used by Debian-based distributions. | no |
 | description | string | _empty_ | Long description stored in the package metadata. | no |
 | man-paths | string | _empty_ | Comma-, space-, or newline-separated list of man page paths relative to `project-dir`. | no |
@@ -32,6 +33,10 @@ nFPM.
 | config-path | string | _empty_ | Location to write the generated `nfpm.yaml` configuration. | no |
 | deb-depends | string | _empty_ | Comma-, space-, or newline-separated Debian runtime dependencies (each entry becomes a separate dependency in the generated manifest). | no |
 | rpm-depends | string | _empty_ | Comma-, space-, or newline-separated RPM runtime dependencies. Falls back to Debian deps when omitted. | no |
+
+When running inside a private repository, provide `action-token` so the action
+can authenticate the self-checkout step. When omitted, the composite falls back
+to the default workflow `github.token`.
 
 ## Outputs
 

--- a/.github/actions/linux-packages/action.yml
+++ b/.github/actions/linux-packages/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: Software license recorded in package metadata.
     required: false
     default: ''
+  action-token:
+    description: Personal access token used to clone this action for private repositories.
+    required: false
+    default: ''
   section:
     description: Package section/category used for Debian metadata.
     required: false
@@ -86,10 +90,17 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check out action sources
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.action_repository }}
+        ref: ${{ github.action_ref }}
+        path: _self
+        token: ${{ inputs.action-token || github.token }}
     - name: Setup uv
       uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6
     - name: Install nfpm
-      uses: ./.github/actions/install-nfpm
+      uses: ./_self/.github/actions/install-nfpm
     - name: Build Linux packages
       shell: bash
       working-directory: ${{ inputs.project-dir }}

--- a/.github/actions/linux-packages/tests/test_action_workdir.py
+++ b/.github/actions/linux-packages/tests/test_action_workdir.py
@@ -1,17 +1,22 @@
-"""Tests for packaging workdir in action.yml."""
+"""Structural tests for the linux-packages composite action definition."""
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import yaml
 
 
-def test_action_uses_workdir() -> None:
-    """Ensure packaging runs from project dir."""
+def _load_action() -> dict[str, object]:
     action = Path(__file__).resolve().parents[1] / "action.yml"
     text = action.read_text(encoding="utf-8")
-    data = yaml.safe_load(text)
+    return yaml.safe_load(text)
+
+
+def test_action_uses_workdir() -> None:
+    """Ensure packaging runs from project dir."""
+    data = _load_action()
     steps = data["runs"]["steps"]
     package_step = next(
         (step for step in steps if "package.py" in step.get("run", "")),
@@ -19,3 +24,53 @@ def test_action_uses_workdir() -> None:
     )
     assert package_step is not None, "Packaging step not found"
     assert package_step.get("working-directory") == "${{ inputs.project-dir }}"
+
+
+def test_action_performs_self_checkout() -> None:
+    """Ensure the composite checks out its own repository copy."""
+    data = _load_action()
+    steps = data["runs"]["steps"]
+    checkout_step = steps[0]
+    assert checkout_step["uses"] == "actions/checkout@v4"
+    checkout_with = checkout_step.get("with", {})
+    assert checkout_with == {
+        "repository": "${{ github.action_repository }}",
+        "ref": "${{ github.action_ref }}",
+        "path": "_self",
+        "token": "${{ inputs.action-token || github.token }}",
+    }
+
+
+def test_action_uses_self_checkout_paths() -> None:
+    """Ensure nested actions resolve inside the self checkout directory."""
+    data = _load_action()
+    steps = data["runs"]["steps"]
+    install_step = next(
+        (step for step in steps if step.get("name") == "Install nfpm"),
+        None,
+    )
+    assert install_step is not None, "Install nfpm step not found"
+    assert install_step["uses"] == "./_self/.github/actions/install-nfpm"
+
+
+def test_action_install_step_resolves_from_external_checkout(tmp_path: Path) -> None:
+    """Simulate a remote workflow workspace and ensure the install action is accessible."""
+    data = _load_action()
+    steps = data["runs"]["steps"]
+    install_step = next(
+        (step for step in steps if step.get("name") == "Install nfpm"),
+        None,
+    )
+    assert install_step is not None, "Install nfpm step not found"
+    repo_root = Path(__file__).resolve().parents[4]
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # Simulate the checkout step cloning the repository into "_self".
+    checkout_path = workspace / "_self"
+    shutil.copytree(
+        repo_root,
+        checkout_path,
+        ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc", "target"),
+    )
+    install_path = workspace / install_step["uses"]
+    assert install_path.is_dir(), "Install nfpm action should exist under _self checkout"


### PR DESCRIPTION
## Summary
- add an optional `action-token` input so the composite can authenticate when cloning itself
- run `actions/checkout@v4` into `_self` and resolve the `install-nfpm` helper from that copy
- document the new input and extend tests to cover the self-checkout workflow

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e45b1218c883228ccd415123a43476