### PR TITLE
Fix PowerShell string interpolation for WiX install

### DIFF
--- a/.github/actions/windows-package/scripts/install_wix_cli.ps1
+++ b/.github/actions/windows-package/scripts/install_wix_cli.ps1
@@ -18,10 +18,10 @@ dotnet tool update @installArgs 2>&1 | Tee-Object -Variable updateOutput | Out-N
 $updateExitCode = $LASTEXITCODE
 if ($updateExitCode -ne 0) {
     if ($updateOutput) {
-        Write-Warning "dotnet tool update failed with exit code $updateExitCode:`n$updateOutput"
+        Write-Warning "dotnet tool update failed with exit code $($updateExitCode):`n$updateOutput"
     }
     else {
-        Write-Warning "dotnet tool update failed with exit code $updateExitCode."
+        Write-Warning "dotnet tool update failed with exit code $($updateExitCode)."
     }
 
     dotnet tool install @installArgs 2>&1 | Tee-Object -Variable installOutput | Out-Null

--- a/.github/actions/windows-package/scripts/install_wix_cli.ps1
+++ b/.github/actions/windows-package/scripts/install_wix_cli.ps1
@@ -18,7 +18,7 @@ dotnet tool update @installArgs 2>&1 | Tee-Object -Variable updateOutput | Out-N
 $updateExitCode = $LASTEXITCODE
 if ($updateExitCode -ne 0) {
     if ($updateOutput) {
-        Write-Warning "dotnet tool update failed with exit code $($updateExitCode):`n$updateOutput"
+        Write-Warning "dotnet tool update failed with exit code $($updateExitCode):`n$($updateOutput)"
     }
     else {
         Write-Warning "dotnet tool update failed with exit code $($updateExitCode)."
@@ -27,10 +27,10 @@ if ($updateExitCode -ne 0) {
     dotnet tool install @installArgs 2>&1 | Tee-Object -Variable installOutput | Out-Null
     if ($LASTEXITCODE -ne 0) {
         if ($installOutput) {
-            Write-Error "Failed to install WiX CLI via dotnet tool (exit code $LASTEXITCODE):`n$installOutput"
+            Write-Error "Failed to install WiX CLI via dotnet tool (exit code $($LASTEXITCODE)):`n$($installOutput)"
         }
         else {
-            Write-Error "Failed to install WiX CLI via dotnet tool (exit code $LASTEXITCODE)."
+            Write-Error "Failed to install WiX CLI via dotnet tool (exit code $($LASTEXITCODE))."
         }
         exit $LASTEXITCODE
     }


### PR DESCRIPTION
## Summary
- ensure PowerShell warning messages use valid variable interpolation when reporting dotnet tool update failures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c191d5d48322b6694fb234d5ddb2

## Summary by Sourcery

Bug Fixes:
- Correct string interpolation of the exit code variable in warning messages using $($updateExitCode) syntax