### PR TITLE
Add system temp fallback test for polythene store

### DIFF
--- a/.github/actions/validate-linux-packages/tests/test_validate_cli.py
+++ b/.github/actions/validate-linux-packages/tests/test_validate_cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import sys
-import tempfile
 import typing as typ
 from pathlib import Path
 
@@ -860,14 +859,13 @@ def test_polythene_store_defaults_to_system_temp(
     tmp_path: Path,
 ) -> None:
     """When no environment hints exist the system temp directory is used."""
-
     module = validate_cli_module
     fallback_temp = tmp_path / "system-tmp"
     fallback_temp.mkdir()
 
     monkeypatch.delenv("RUNNER_TEMP", raising=False)
     monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
-    monkeypatch.setattr(module.tempfile, "tempdir", fallback_temp.as_posix(), raising=False)
+    monkeypatch.setattr(module.tempfile, "tempdir", None, raising=False)
     monkeypatch.setattr(
         module.tempfile,
         "gettempdir",

--- a/.github/actions/validate-linux-packages/tests/test_validate_cli.py
+++ b/.github/actions/validate-linux-packages/tests/test_validate_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import sys
+import tempfile
 import typing as typ
 from pathlib import Path
 
@@ -851,6 +852,32 @@ def test_polythene_store_falls_back_to_runner_temp(
 
     with module._polythene_store(None) as store_base:
         assert store_base.parent == runner_temp
+
+
+def test_polythene_store_defaults_to_system_temp(
+    validate_cli_module: object,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When no environment hints exist the system temp directory is used."""
+
+    module = validate_cli_module
+    fallback_temp = tmp_path / "system-tmp"
+    fallback_temp.mkdir()
+
+    monkeypatch.delenv("RUNNER_TEMP", raising=False)
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.setattr(module.tempfile, "tempdir", fallback_temp.as_posix(), raising=False)
+    monkeypatch.setattr(
+        module.tempfile,
+        "gettempdir",
+        lambda: fallback_temp.as_posix(),
+        raising=False,
+    )
+
+    with module._polythene_store(None) as store_base:
+        assert store_base.parent == fallback_temp
+        assert store_base.name.startswith("polythene-validate-")
 
 
 def test_main_raises_for_missing_package_dir(


### PR DESCRIPTION
## Summary
- import `tempfile` in the validate CLI test module
- add a test covering `_polythene_store` falling back to the system temp directory when no environment hints are set

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e60eb4d90083229194b676bea1896f

## Summary by Sourcery

Tests:
- Add test_polythene_store_defaults_to_system_temp to validate that _polythene_store falls back to tempfile.gettempdir when RUNNER_TEMP and GITHUB_WORKSPACE are unset