### PR TITLE
Fix WiX variable argument syntax

### DIFF
--- a/.github/actions/windows-package/scripts/build_msi.ps1
+++ b/.github/actions/windows-package/scripts/build_msi.ps1
@@ -98,7 +98,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:WIX_EXTENSION)) {
     }
 }
 
-$arguments += @('-arch', $arch, "-dVersion=$($env:VERSION)", '-o', $outputPath)
+$arguments += @('-arch', $arch, '-d', "Version=$($env:VERSION)", '-o', $outputPath)
 wix @arguments
 
 if (-not (Test-Path -LiteralPath $outputPath)) {


### PR DESCRIPTION
## Summary
- separate the WiX -d flag from the Version assignment so wix.exe accepts the variable definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e665b14ed88322987e29255f8fcfca

## Summary by Sourcery

Bug Fixes:
- Separate the WiX -d flag from the variable assignment in the PowerShell build script to correctly define the Version variable for wix.exe.