### PR TITLE
Remove macOS package upload step from rust workflow

### DIFF
--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -111,10 +111,3 @@ jobs:
           manpage: ${{ steps.verify-artifacts.outputs.manpage }}
           license-file: rust-toy-app/LICENSE
           version: ${{ steps.crate-version.outputs.version }}
-      - name: Upload macOS package
-        if: contains(matrix.target, 'apple-darwin')
-        # v4.3.4
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
-        with:
-          name: rust-toy-app-${{ matrix.target }}-pkg-${{ steps.crate-version.outputs.version }}
-          path: ${{ steps.package-macos.outputs.pkg-path }}


### PR DESCRIPTION
## Summary
- remove the macOS artifact upload step from the rust-toy-app workflow so only packaging runs

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e6b2cdc29083228c0fb22c0cae3157

## Summary by Sourcery

CI:
- Remove Upload macOS package step from rust-toy-app workflow