### PR TITLE
Export clone_packaging_project from packaging utils

### DIFF
--- a/.github/actions/linux-packages/tests/_packaging_utils.py
+++ b/.github/actions/linux-packages/tests/_packaging_utils.py
@@ -399,6 +399,7 @@ __all__ = sorted(
     [
         "build_release_artifacts",
         "BuildArtifacts",
+        "clone_packaging_project",
         "ChecksumMismatchError",
         "ChecksumDownloadError",
         "ChecksumManifestEntryMissingError",


### PR DESCRIPTION
## Summary
- add clone_packaging_project to the packaging utils export list so it can be imported externally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6b4028db48322aa85637e81a89fa0

## Summary by Sourcery

Export clone_packaging_project from packaging utils to allow external imports and update tests accordingly

Enhancements:
- Add clone_packaging_project to the packaging utils export list

Tests:
- Include clone_packaging_project in the test import stub for packaging utils