### PR TITLE
Improve MSI version parsing

### DIFF
--- a/.github/actions/windows-package/scripts/resolve_version.ps1
+++ b/.github/actions/windows-package/scripts/resolve_version.ps1
@@ -9,9 +9,34 @@ function Get-MsiVersion([string] $candidate) {
     }
 
     $trimmed = $candidate.Trim()
-    $trimmed = $trimmed.TrimStart('v', 'V')
+    $numeric = $trimmed.TrimStart('v', 'V')
+
+    if ([string]::IsNullOrWhiteSpace($numeric)) {
+        return $null
+    }
+
+    $rawParts = $numeric.Split('.')
+    if ($rawParts.Count -gt 3) {
+        return $null
+    }
+
+    $parts = @()
+    foreach ($rawPart in $rawParts) {
+        $part = $rawPart.Trim()
+        if ($part.Length -eq 0) {
+            return $null
+        }
+        $parts += $part
+    }
+
+    while ($parts.Count -lt 3) {
+        $parts += '0'
+    }
+
+    $normalized = $parts -join '.'
+
     try {
-        $version = [System.Version]$trimmed
+        $version = [System.Version]$normalized
     }
     catch {
         return $null


### PR DESCRIPTION
## Summary
- rely on System.Version parsing to normalise MSI version strings before use
- ensure build numbers default to zero and reject invalid four-part versions to avoid 0.0.0 fallbacks

## Testing
- not run (powershell script changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e845ed741083229b8996824693d5ab