### PR TITLE
Use cyclopts UsageError directly in generate_wxs

### DIFF
--- a/.github/actions/windows-package/scripts/generate_wxs.py
+++ b/.github/actions/windows-package/scripts/generate_wxs.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import cyclopts
 from cyclopts import App, Parameter
-from cyclopts.exceptions import CycloptsError
+
+try:
+    from cyclopts.exceptions import UsageError  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - compatibility with older cyclopts
+    from cyclopts.exceptions import CycloptsError as UsageError
 
 if __package__ in {None, ""}:
     _MODULE_DIR = Path(__file__).resolve().parent
@@ -33,8 +37,6 @@ if __name__ not in sys.modules:
     sys.modules[__name__] = _SELF_MODULE
 else:
     _SELF_MODULE = sys.modules[__name__]
-
-UsageError = typ.cast("type[Exception]", CycloptsError)
 
 app = App(config=cyclopts.config.Env("INPUT_", command=False))  # type: ignore[unknown-argument]
 


### PR DESCRIPTION
## Summary
- import `UsageError` from `cyclopts.exceptions` in the Windows packaging WiX generator while keeping a fallback for older Cyclopts releases

## Testing
- make check-fmt
- make typecheck
- make lint
- make test


------
https://chatgpt.com/codex/tasks/task_e_68ed8123d46c8322a0c9ebeafd02dffe

## Summary by Sourcery

Use the UsageError exception directly in the WiX generator with a fallback to CycloptsError for older cyclopts versions to maintain compatibility

Enhancements:
- Import UsageError from cyclopts.exceptions with a compatibility fallback to CycloptsError in generate_wxs.py
- Remove the redundant alias assignment for UsageError