### PR TITLE
Handle python fallback for executable validation

### DIFF
--- a/.github/actions/validate-linux-packages/tests/test_validate_packages_diagnostics.py
+++ b/.github/actions/validate-linux-packages/tests/test_validate_packages_diagnostics.py
@@ -278,9 +278,17 @@ def sandbox_with_python_fallback(
 
         def exec(self, *args: str, timeout: int | None = None) -> str:
             if tuple(args) == ("test", "-x", path):
-                calls.append((tuple(args), timeout))
+                command = tuple(args)
+                calls.append((command, timeout))
+                cause = ProcessExecutionError(
+                    list(command),
+                    1,
+                    "",
+                    "permission denied",
+                )
                 message = "not executable"
-                raise validate_packages_module.ValidationError(message)
+                err = validate_packages_module.ValidationError(message)
+                raise err from cause
             return super().exec(*args, timeout=timeout)
 
     sandbox = FallbackSandbox()


### PR DESCRIPTION
## Summary
- run a python os.access fallback when sandbox `test -x` reports a binary as non-executable and record a diagnostic log on success
- add a sandbox fixture and test that exercises the fallback path for executable validation

## Testing
- uv run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist pytest -n auto -v .github/actions/validate-linux-packages/tests/test_validate_packages_diagnostics.py -k python_fallback

------
https://chatgpt.com/codex/tasks/task_e_68f23008cd188322b48f8fdf678c09eb

## Summary by Sourcery

Add a python os.access fallback for executable validation when the sandbox `test -x` check fails, and include a diagnostic log on success.

New Features:
- Introduce a python os.access fallback in _validate_paths_executable to succeed executables that the sandbox reports as non-executable.

Tests:
- Add a sandbox fixture and a pytest that exercises and verifies the python fallback path for executable validation.