### PR TITLE
Refactor build_artifact_name and main with dataclasses

### DIFF
--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -778,13 +778,10 @@ def test_build_artifact_name_with_extra_suffix(
 ) -> None:
     """``set_outputs.build_artifact_name`` normalises custom suffixes."""
     mod = _load_module(monkeypatch, "set_outputs")
+    job_info = mod.JobInfo(name="coverage", index="2")
+    platform_info = mod.PlatformInfo(os_segment="linux", arch_segment="x64")
     artifact = mod.build_artifact_name(
-        "cobertura",
-        "coverage",
-        "2",
-        "linux",
-        "x64",
-        "Nightly Build!",
+        "cobertura", job_info, platform_info, "Nightly Build!"
     )
     assert artifact == "cobertura-coverage-2-linux-x64-nightly-build"
 


### PR DESCRIPTION
## Summary
- Refactors artifact naming and main flow to use dataclasses for clearer structure and better testability.
- Introduces JobInfo, PlatformInfo, ArtifactOptions, and RunnerDetails dataclasses.
- Updates build_artifact_name to accept JobInfo and PlatformInfo, and updates main to use new dataclass-based inputs.
- Maintains existing behavior by deriving values from environment variables when inputs are not provided.
- Exports new dataclasses via __all__ for external use in tests.

## Changes
### Core functionality
- Added dataclasses: JobInfo, PlatformInfo, ArtifactOptions, RunnerDetails.
- Refactored build_artifact_name(fmt, job_info: JobInfo, platform_info: PlatformInfo, extra_suffix: str | None) to compose names from dataclass fields.
- Reworked main to accept artifact: ArtifactOptions and runner: RunnerDetails (with default_factory) and resolve values from environment variables when needed.
- Constructed JobInfo and PlatformInfo from resolved inputs and use them to generate artifact names.
- Updated __all__ to export ArtifactOptions, JobInfo, PlatformInfo, RunnerDetails.

### Tests
- Updated tests to construct JobInfo and PlatformInfo instances and call build_artifact_name with the new signature.
- Example test now passes: build_artifact_name("cobertura", JobInfo(name="coverage", index="2"), PlatformInfo(os_segment="linux", arch_segment="x64"), "Nightly Build!")

## Why
- Improves type-safety and readability by encapsulating related data into dedicated dataclasses.
- Simplifies testing and future extensions by reducing the number of primitive parameters passed around.

## Migration notes
- Internal API changes: build_artifact_name now takes JobInfo and PlatformInfo; main uses ArtifactOptions and RunnerDetails.
- Callers within the repository have been updated accordingly.

## Test plan
- [x] Update tests to use new dataclasses for artifact naming.
- [x] Ensure existing behavior is preserved when environment variables are provided.
- [x] Run full test suite for the generate-coverage scripts.

## Documentation
- No user-facing docs updated; changes are internal and self-describing via dataclass structure.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0dce2a55-82b5-4317-ba31-e5e1ae60da24

## Summary by Sourcery

Refactor artifact naming and main flow to leverage dataclasses for clearer structure and improved testability

Enhancements:
- Introduce JobInfo, PlatformInfo, ArtifactOptions and RunnerDetails dataclasses to encapsulate artifact and runner configuration
- Refactor build_artifact_name signature to accept JobInfo and PlatformInfo objects
- Rework main to consume ArtifactOptions and RunnerDetails dataclasses and derive values from environment variables
- Export new dataclasses via __all__ for external use

Tests:
- Update tests to construct JobInfo and PlatformInfo and invoke build_artifact_name with the new dataclass signature