### PR TITLE
Fix ensure-cargo-version input parsing

### DIFF
--- a/.github/actions/ensure-cargo-version/scripts/ensure_cargo_version.py
+++ b/.github/actions/ensure-cargo-version/scripts/ensure_cargo_version.py
@@ -153,11 +153,6 @@ def _display_path(path: Path) -> str:
         return str(path)
 
 
-def _parse_check_tag(value: bool | str) -> bool:  # noqa: FBT001
-    """Normalize the check-tag input to a boolean."""
-    return coerce_bool_strict(value, parameter="check-tag")
-
-
 @app.default
 def main(
     *,
@@ -170,7 +165,7 @@ def main(
     resolved = _resolve_paths(manifest_args)
 
     try:
-        should_check_tag = _parse_check_tag(check_tag)
+        should_check_tag = coerce_bool_strict(check_tag, parameter="check-tag")
     except ValueError as exc:
         _emit_error("Invalid input", str(exc))
         raise SystemExit(1) from exc

--- a/.github/actions/ensure-cargo-version/scripts/tests/test_ensure_cargo_version.py
+++ b/.github/actions/ensure-cargo-version/scripts/tests/test_ensure_cargo_version.py
@@ -42,30 +42,6 @@ def _write_raw_manifest(path: Path, contents: str) -> None:
     path.write_text(contents, encoding="utf-8")
 
 
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("true", True),
-        ("FALSE", False),
-        ("", False),
-        (True, True),
-        (False, False),
-    ],
-)
-def test_parse_check_tag_normalises_values(
-    value: bool | str,  # noqa: FBT001
-    expected: bool,  # noqa: FBT001
-) -> None:
-    """check_tag inputs are normalised to booleans."""
-    assert ensure._parse_check_tag(value) is expected
-
-
-def test_parse_check_tag_rejects_invalid_value() -> None:
-    """Unexpected check_tag values should raise ValueError."""
-    with pytest.raises(ValueError, match="check-tag"):
-        ensure._parse_check_tag("maybe")
-
-
 def test_app_parses_check_tag_from_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Normalize the check_tag parameter to a string with a default of "true" to avoid incorrect parsing of boolean inputs from the GitHub Actions environment.