### PR TITLE
Dependabot auto merge

### DIFF
--- a/.github/actions/linux-packages/tests/test_action_workdir.py
+++ b/.github/actions/linux-packages/tests/test_action_workdir.py
@@ -23,6 +23,22 @@ def _find_repo_root(start: Path) -> Path:
     raise AssertionError(message)
 
 
+def test_find_repo_root_with_git_file(tmp_path: Path) -> None:
+    """_find_repo_root should treat a .git file (worktree) as a repo root."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    # Simulate a git worktree where .git is a file pointing to another directory.
+    git_file = repo_root / ".git"
+    git_file.write_text("gitdir: /path/to/actual/git/dir\n")
+
+    # Start from a nested directory and ensure we still resolve to repo_root.
+    nested = repo_root / "subdir" / "deeper"
+    nested.mkdir(parents=True)
+
+    assert _find_repo_root(nested) == repo_root
+
+
 def test_action_uses_workdir() -> None:
     """Ensure packaging runs from project dir."""
     data = _load_action()

--- a/.github/actions/linux-packages/tests/test_action_workdir.py
+++ b/.github/actions/linux-packages/tests/test_action_workdir.py
@@ -16,7 +16,8 @@ def _load_action() -> dict[str, object]:
 
 def _find_repo_root(start: Path) -> Path:
     for candidate in (start, *start.parents):
-        if (candidate / ".git").is_dir():
+        git_path = candidate / ".git"
+        if git_path.is_dir() or git_path.is_file():
             return candidate
     message = "Could not locate repository root from test file"
     raise AssertionError(message)

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,84 @@
+name: Dependabot auto-merge
+
+on:
+  workflow_call:
+    inputs:
+      required-label:
+        type: string
+        default: dependencies
+      merge-method:
+        type: string
+        default: squash
+      dry-run:
+        type: boolean
+        default: false
+      pull-request-number:
+        type: number
+        required: false
+      repository:
+        type: string
+        required: false
+    secrets:
+      github-token:
+        required: false
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - name: Resolve workflow source
+        id: workflow-source
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${WORKFLOW_REF}" ]]; then
+            repo="${WORKFLOW_REF%%/.github/workflows/*}"
+            ref="${WORKFLOW_REF##*@}"
+          else
+            repo="${REPO}"
+            ref="${REF}"
+          fi
+          echo "repo=${repo}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+      - name: Checkout workflow repository
+        # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          repository: ${{ steps.workflow-source.outputs.repo }}
+          ref: ${{ steps.workflow-source.outputs.ref }}
+          path: workflow-src
+          fetch-depth: 1
+      - name: Setup uv
+        # v6.4.3
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        with:
+          python-version: '3.13'
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            **/workflow_scripts/*.py
+      - name: Run Dependabot auto-merge
+        shell: bash
+        env:
+          INPUT_GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
+          INPUT_REQUIRED_LABEL: ${{ inputs.required-label }}
+          INPUT_MERGE_METHOD: ${{ inputs.merge-method }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${{ inputs.pull-request-number }}" ]]; then
+            export INPUT_PULL_REQUEST_NUMBER="${{ inputs.pull-request-number }}"
+          fi
+          if [[ -n "${{ inputs.repository }}" ]]; then
+            export INPUT_REPOSITORY="${{ inputs.repository }}"
+          fi
+          uv run workflow-src/workflow_scripts/dependabot_automerge.py

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -40,6 +40,13 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           set -euo pipefail
+          if [[ "${ACT:-}" == "true" ]]; then
+            echo "checkout=false" >> "${GITHUB_OUTPUT}"
+            echo "workflow_dir=${GITHUB_WORKSPACE}" >> "${GITHUB_OUTPUT}"
+            echo "repo=${REPO}" >> "${GITHUB_OUTPUT}"
+            echo "ref=" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
           if [[ -n "${WORKFLOW_REF}" ]]; then
             repo="${WORKFLOW_REF%%/.github/workflows/*}"
             ref="${WORKFLOW_REF##*@}"
@@ -47,9 +54,12 @@ jobs:
             repo="${REPO}"
             ref="${REF}"
           fi
+          echo "checkout=true" >> "${GITHUB_OUTPUT}"
+          echo "workflow_dir=workflow-src" >> "${GITHUB_OUTPUT}"
           echo "repo=${repo}" >> "${GITHUB_OUTPUT}"
           echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
       - name: Checkout workflow repository
+        if: ${{ steps.workflow-source.outputs.checkout == 'true' }}
         # v4
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -57,7 +67,14 @@ jobs:
           ref: ${{ steps.workflow-source.outputs.ref }}
           path: workflow-src
           fetch-depth: 1
+      - name: Install uv (act)
+        if: ${{ env.ACT == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade --break-system-packages uv
       - name: Setup uv
+        if: ${{ env.ACT != 'true' }}
         # v6.4.3
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
         with:
@@ -81,4 +98,8 @@ jobs:
           if [[ -n "${{ inputs.repository }}" ]]; then
             export INPUT_REPOSITORY="${{ inputs.repository }}"
           fi
-          uv run workflow-src/workflow_scripts/dependabot_automerge.py
+          if [[ "${ACT:-}" == "true" ]]; then
+            export UV_PROJECT_ENVIRONMENT="/tmp/uv-project"
+            export UV_CACHE_DIR="/tmp/uv-cache"
+          fi
+          uv run "${{ steps.workflow-source.outputs.workflow_dir }}/workflow_scripts/dependabot_automerge.py"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup uv
         if: ${{ env.ACT != 'true' }}
         # v6.4.3
-        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
         with:
           python-version: '3.13'
           cache-dependency-glob: |

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout workflow repository
         if: ${{ steps.workflow-source.outputs.checkout == 'true' }}
         # v4
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: ${{ steps.workflow-source.outputs.repo }}
           ref: ${{ steps.workflow-source.outputs.ref }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout workflow repository
         if: ${{ steps.workflow-source.outputs.checkout == 'true' }}
         # v4
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ${{ steps.workflow-source.outputs.repo }}
           ref: ${{ steps.workflow-source.outputs.ref }}

--- a/.github/workflows/test-dependabot-automerge.yml
+++ b/.github/workflows/test-dependabot-automerge.yml
@@ -1,0 +1,19 @@
+name: Test Dependabot auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  automerge:
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    uses: ./.github/workflows/dependabot-automerge.yml
+    with:
+      required-label: dependencies
+      merge-method: squash
+      dry-run: true
+    secrets:
+      github-token: test-token

--- a/.github/workflows/test-dependabot-automerge.yml
+++ b/.github/workflows/test-dependabot-automerge.yml
@@ -16,4 +16,5 @@ jobs:
       merge-method: squash
       dry-run: true
     secrets:
+      # Dummy token for dry-run testing only; not used in API calls
       github-token: test-token

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ GitHub Actions
 | Validate Linux packages   | `.github/actions/validate-linux-packages`   | v1           |
 | Windows package           | [`./.github/actions/windows-package`](./.github/actions/windows-package/README.md) | v0           |
 
+## Reusable workflows
+
+| Name                     | Path                                           |
+| ------------------------ | ---------------------------------------------- |
+| Dependabot auto-merge    | `.github/workflows/dependabot-automerge.yml`   |
+
 ## Development
 
 Format, validate and test the repository:

--- a/docs/dependabot-automerge-workflow.md
+++ b/docs/dependabot-automerge-workflow.md
@@ -1,0 +1,83 @@
+# Dependabot auto-merge reusable workflow
+
+This workflow enables GitHub auto-merge for eligible Dependabot pull requests.
+It is designed to be called from other repositories via `workflow_call` and
+uses a Cyclopts-based Python helper that reads `INPUT_*` environment variables.
+
+## Eligibility rules
+
+The helper script only enables auto-merge when all of the following are true:
+
+- The pull request author is `dependabot[bot]`.
+- The pull request is not marked as a draft.
+- The required label (default `dependencies`) is present.
+
+If any rule fails, the workflow logs a `automerge_status=skipped` entry with a
+reason and exits successfully.
+
+## Required permissions
+
+The calling workflow must grant at least:
+
+- `contents: write`
+- `pull-requests: write`
+- `checks: read`
+- `statuses: read`
+
+Job-level permissions in the caller are authoritative and cannot be elevated by
+this reusable workflow.
+
+## Usage
+
+```yaml
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+jobs:
+  automerge:
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    uses: your-org/shared-actions/.github/workflows/dependabot-automerge.yml@v1
+    with:
+      required-label: dependencies
+      merge-method: squash
+    secrets:
+      github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
+```
+
+## Inputs
+
+- `required-label` (string, default: `dependencies`): label required to enable
+  auto-merge. Set to an empty string to disable the label requirement.
+- `merge-method` (string, default: `squash`): one of `squash`, `merge`, `rebase`.
+- `dry-run` (boolean, default: `false`): if `true`, no API calls are made; the
+  workflow logs the decision and exits.
+- `pull-request-number` (number, optional): override the PR number if the event
+  payload is not a pull request.
+- `repository` (string, optional): override the `owner/repo` when the event
+  payload or `GITHUB_REPOSITORY` are unavailable.
+
+## Secrets
+
+- `github-token` (optional): token with the required permissions. If omitted,
+  the workflow uses `github.token`.
+
+## Local validation
+
+To exercise the workflow locally, run the act harness with the provided
+fixture. The integration test in `tests/workflows/test_dependabot_automerge_workflow.py`
+uses `ACT_WORKFLOW_TESTS=1` and the `pull_request_dependabot.event.json` fixture
+in `tests/workflows/fixtures/`.
+
+## Notes
+
+- Auto-merge must be enabled for the target repository. If the repo disables
+  auto-merge, the workflow will fail with a clear error message.
+- Branch protection rules still apply; auto-merge will wait for required checks
+  to pass.

--- a/docs/dependabot-automerge-workflow.md
+++ b/docs/dependabot-automerge-workflow.md
@@ -45,6 +45,8 @@ jobs:
       statuses: read
     uses: example-org/shared-actions/.github/workflows/dependabot-automerge.yml@v1
     with:
+      # Required: pass the PR number explicitly for workflow_call contexts
+      pull-request-number: ${{ github.event.pull_request.number }}
       required-label: dependencies
       merge-method: squash
     secrets:
@@ -58,8 +60,12 @@ jobs:
 - `merge-method` (string, default: `squash`): one of `squash`, `merge`, `rebase`.
 - `dry-run` (boolean, default: `false`): if `true`, no API calls are made; the
   workflow logs the decision and exits.
-- `pull-request-number` (number, optional): override the PR number if the event
-  payload is not a pull request.
+- `pull-request-number` (number, recommended): the pull request number. When
+  calling this workflow via `workflow_call`, the event context is the caller's
+  `workflow_call` payload, not the original `pull_request` event. Pass
+  `${{ github.event.pull_request.number }}` explicitly to ensure the PR number
+  is available. The fallback to event parsing is only reliable for direct
+  `pull_request` triggers.
 - `repository` (string, optional): override the `owner/repo` when the event
   payload or `GITHUB_REPOSITORY` are unavailable.
 

--- a/docs/dependabot-automerge-workflow.md
+++ b/docs/dependabot-automerge-workflow.md
@@ -12,7 +12,7 @@ The helper script only enables auto-merge when all of the following are true:
 - The pull request is not marked as a draft.
 - The required label (default `dependencies`) is present.
 
-If any rule fails, the workflow logs a `automerge_status=skipped` entry with a
+If any rule fails, the workflow logs an `automerge_status=skipped` entry with a
 reason and exits successfully.
 
 ## Required permissions
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
       checks: read
       statuses: read
-    uses: your-org/shared-actions/.github/workflows/dependabot-automerge.yml@v1
+    uses: example-org/shared-actions/.github/workflows/dependabot-automerge.yml@v1
     with:
       required-label: dependencies
       merge-method: squash

--- a/docs/execplans/dependabot-auto-merge.md
+++ b/docs/execplans/dependabot-auto-merge.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 PLANS.md: none found in this repo.
 
@@ -76,6 +76,7 @@ local validation path via `pytest` + `act`.
 - [x] (2026-01-12 00:00Z) Reordered dry-run validation to require event payload before PR number resolution.
 - [x] (2026-01-12 00:00Z) Adjusted linux-packages worktree repo-root test to accept `.git` files.
 - [x] (2026-01-12 00:00Z) Ran format, lint, typecheck, and test gates.
+- [x] (2026-01-12 00:00Z) Committed implementation changes.
 
 ## Surprises & Discoveries
 
@@ -131,7 +132,14 @@ local validation path via `pytest` + `act`.
 
 ## Outcomes & Retrospective
 
-- Pending. This will be updated after implementation.
+- Delivered a reusable Dependabot auto-merge workflow, a Cyclopts-based helper
+  script with dry-run support, unit tests, and `act`-driven workflow tests, plus
+  documentation and README updates.
+- Quality gates completed: `make fmt`, `make check-fmt`, `make lint`,
+  `make typecheck`, and `make test` passed (typecheck emitted an existing
+  warning in `.github/actions/windows-package/scripts/generate_wxs.py`).
+- Learned: worktree environments surface `.git` as a file, so repo-root probes
+  should accept both file and directory forms.
 
 ## Context and Orientation
 
@@ -315,3 +323,5 @@ unit tests run by default.
 
 Revision 2026-01-12: Fixed dry-run validation ordering and worktree repo-root
 handling; captured gate runs and decisions.
+
+Revision 2026-01-12: Marked plan complete and summarized outcomes.

--- a/docs/execplans/dependabot-auto-merge.md
+++ b/docs/execplans/dependabot-auto-merge.md
@@ -93,6 +93,13 @@ local validation path via `pytest` + `act`.
   a file.
   Impact: Broaden repo-root detection to accept `.git` files.
 
+- Observation: `act` runs failed with `setup-uv` under Node 18 and with pip's
+  PEP 668 protections when installing uv.
+  Evidence: `ACT_WORKFLOW_TESTS=1 make test` failures in the reusable workflow
+  job during the `setup-uv` and `pip install uv` steps.
+  Impact: Use act-specific installation (pip with `--break-system-packages`),
+  and redirect uv's environment/cache to `/tmp` during act runs.
+
 ## Decision Log
 
 - Decision: Implement auto-merge enablement via GitHub GraphQL API
@@ -128,6 +135,12 @@ local validation path via `pytest` + `act`.
   environments.
   Rationale: git worktrees store metadata in a file, and tests should pass in
   that layout.
+  Date/Author: 2026-01-12 (assistant).
+
+- Decision: Add act-only workflow branches to skip `setup-uv`, install uv via
+  pip with `--break-system-packages`, and redirect uv paths to `/tmp`.
+  Rationale: act uses Node 18 and Debian PEP 668 defaults; this keeps workflow
+  tests green without affecting GitHub runner behavior.
   Date/Author: 2026-01-12 (assistant).
 
 ## Outcomes & Retrospective
@@ -325,3 +338,6 @@ Revision 2026-01-12: Fixed dry-run validation ordering and worktree repo-root
 handling; captured gate runs and decisions.
 
 Revision 2026-01-12: Marked plan complete and summarized outcomes.
+
+Revision 2026-01-12: Added act-only uv installation and cache redirection
+notes based on workflow test failures.

--- a/docs/execplans/dependabot-auto-merge.md
+++ b/docs/execplans/dependabot-auto-merge.md
@@ -1,0 +1,260 @@
+# Dependabot auto-merge reusable workflow (plan)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+PLANS.md: none found in this repo.
+
+## Purpose / Big Picture
+
+Create a reusable workflow that enables safe, auditable auto-merge of
+Dependabot pull requests, with a small Python script (Cyclopts + env vars) that
+handles gating rules and the GitHub API calls. Success looks like a caller
+workflow being able to reference a single workflow file in this repo and have
+Dependabot PRs auto-merged once policy gates are satisfied, with a deterministic
+local validation path via `pytest` + `act`.
+
+## Constraints
+
+- Follow `docs/scripting-standards.md` for all new scripts (Python 3.13, `uv`
+  script block, Cyclopts env-first config, pathlib usage, and no ad-hoc shell
+  parsing).
+- Follow `docs/local-validation-of-github-actions-with-act-and-pytest.md` for
+  workflow integration tests (black-box, `act --json`, artefacts/log assertions).
+- Pin all third-party actions to a full commit SHA.
+- Use least-privilege workflow permissions and avoid elevating permissions in
+  callers (document required permissions explicitly).
+- Do not introduce shell `eval` or unvalidated user input execution.
+- Keep existing action interfaces stable; only add new files/sections needed
+  for the reusable workflow.
+
+## Tolerances (Exception Triggers)
+
+- Scope: if implementation requires changes to more than 12 files or more than
+  900 net new lines, stop and escalate.
+- Dependencies: if a new external dependency (not already in `pyproject.toml`)
+  is required, stop and escalate.
+- Interface: if existing public action interfaces must change, stop and
+  escalate.
+- Iterations: if tests still fail after two full fix attempts, stop and
+  escalate with the failures and hypotheses.
+- Ambiguity: if GitHub API behaviour or workflow-call semantics appear unclear
+  in practice, stop and ask before proceeding.
+
+## Risks
+
+- Risk: The workflow could merge a PR that is not authored by Dependabot if the
+  event payload differs from expectations.
+  Severity: high
+  Likelihood: low
+  Mitigation: check `pull_request.user.login` in the event payload and re-check
+  via API before enabling auto-merge.
+
+- Risk: Auto-merge enablement fails due to missing permissions or repo settings.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: detect and log explicit errors; surface a clear, non-zero exit
+  with remediation instructions; document required permissions in README/docs.
+
+- Risk: Local `act` tests diverge from GitHub runner behaviour.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: keep `act` tests in dry-run mode and document that GitHub runner
+  validation is authoritative.
+
+## Progress
+
+- [x] (2026-01-12 00:00Z) Drafted initial ExecPlan.
+- [ ] Implement reusable workflow and helper script.
+- [ ] Add unit tests for the helper script.
+- [ ] Add workflow integration test via `act` harness.
+- [ ] Update documentation with usage guidance.
+
+## Surprises & Discoveries
+
+- Observation: none yet.
+  Evidence: n/a.
+  Impact: n/a.
+
+## Decision Log
+
+- Decision: Implement auto-merge enablement via GitHub GraphQL API
+  (`enablePullRequestAutoMerge`) rather than immediate merge.
+  Rationale: GraphQL auto-merge defers the merge until checks pass and branch
+  protections are satisfied, reducing race conditions and simplifying check
+  evaluation logic.
+  Date/Author: 2026-01-12 (assistant).
+
+- Decision: Provide a dry-run mode for tests and local validation.
+  Rationale: avoids network dependency in `act`/pytest while still exercising
+  workflow wiring and logic paths.
+  Date/Author: 2026-01-12 (assistant).
+
+## Outcomes & Retrospective
+
+- Pending. This will be updated after implementation.
+
+## Context and Orientation
+
+Relevant repository locations:
+
+- `.github/workflows/`: location for reusable workflows and workflow tests.
+- `tests/workflows/`: existing `act`-based integration harness and fixtures.
+- `docs/scripting-standards.md`: defines the Cyclopts + `uv` script pattern.
+- `docs/local-validation-of-github-actions-with-act-and-pytest.md`: defines the
+  `act` harness and how to test workflows locally.
+
+This change adds a new reusable workflow file under `.github/workflows/` and a
+new Python script under `scripts/` (new directory) to implement the auto-merge
+logic. Tests will be added under `scripts/tests/` for unit coverage and under
+`tests/workflows/` for black-box workflow validation.
+
+Key terms used here:
+
+- Reusable workflow: a workflow declared with `on: workflow_call` so other
+  repositories can call it via `jobs.<id>.uses`.
+- Auto-merge: GitHub's built-in feature that merges once checks and protections
+  are satisfied.
+
+## Plan of Work
+
+Stage A: confirm requirements and align on interfaces (no code changes).
+
+- Review existing workflow conventions in `.github/workflows/` and confirm the
+  pinned-action SHA pattern for new workflows.
+- Validate the desired inputs for the reusable workflow (label gate, merge
+  method, dry-run toggle, optional PR number override).
+- Confirm the decision to use GraphQL auto-merge and the required permissions
+  (`contents: write`, `pull-requests: write`, `checks: read`, `statuses: read`).
+
+Stage B: scaffold script and unit tests (small, verifiable diffs).
+
+- Add `scripts/dependabot_automerge.py` with a `uv` script block targeting
+  Python 3.13, using Cyclopts env-first config (`Env("INPUT_", command=False)`).
+- Implement structured logging (JSON or key-value lines) so workflow tests can
+  assert on logs.
+- Add unit tests in `scripts/tests/test_dependabot_automerge.py` using
+  `cyclopts.testing.invoke` plus `monkeypatch`/`pytest-mock` to stub HTTP calls.
+- Ensure graceful error messages and exit codes as per scripting standards.
+
+Stage C: create reusable workflow and integration test harness.
+
+- Add `.github/workflows/dependabot-automerge.yml` with `on: workflow_call` and
+  job-level permissions pinned to least privilege.
+- Add `.github/workflows/test-dependabot-automerge.yml` that exercises the
+  reusable workflow in dry-run mode for `act`.
+- Add `tests/workflows/test_dependabot_automerge_workflow.py` and a fixture
+  event JSON (for a Dependabot-authored PR) to validate the workflow output
+  logs using the existing `run_act` harness.
+
+Stage D: documentation and cleanup.
+
+- Update `README.md` to add a small “Reusable workflows” section or mention
+  the new workflow alongside existing actions.
+- Add a short usage guide (likely `docs/dependabot-automerge-workflow.md`)
+  with copy-paste example and required permissions.
+- Ensure all new files follow repository formatting and lint rules.
+
+Each stage ends with validation; do not proceed if validation fails.
+
+## Concrete Steps
+
+All commands run from repository root: `/data/leynos/Projects/shared-actions.worktrees/dependabot-auto-merge`.
+
+1) Create the script and unit tests.
+
+    - Create `scripts/dependabot_automerge.py`.
+    - Create `scripts/tests/test_dependabot_automerge.py`.
+
+2) Add workflows and fixtures.
+
+    - Add `.github/workflows/dependabot-automerge.yml`.
+    - Add `.github/workflows/test-dependabot-automerge.yml`.
+    - Add `tests/workflows/fixtures/pull_request_dependabot.event.json`.
+    - Add `tests/workflows/test_dependabot_automerge_workflow.py`.
+
+3) Update documentation.
+
+    - Update `README.md` with the reusable workflow entry.
+    - Add `docs/dependabot-automerge-workflow.md` with usage and permissions.
+
+4) Run quality gates (per AGENTS.md) with tee logging.
+
+    - `make check-fmt 2>&1 | tee /tmp/check-fmt.log`
+    - `make typecheck 2>&1 | tee /tmp/typecheck.log`
+    - `make lint 2>&1 | tee /tmp/lint.log`
+    - `make test 2>&1 | tee /tmp/test.log`
+
+    If `act` tests are required and Docker/Podman needs sudo:
+
+    - `ACT_WORKFLOW_TESTS=1 sudo -E make test 2>&1 | tee /tmp/test-act.log`
+
+5) Commit in small steps, gating each commit with relevant checks.
+
+## Validation and Acceptance
+
+Behavioural acceptance:
+
+- A consuming repo can call the workflow via `jobs.<id>.uses` and see the job
+  skip non-Dependabot PRs, skip drafts, and enable auto-merge for Dependabot PRs
+  when label requirements are met.
+- Logs include deterministic markers (e.g. `automerge_status=enabled` or
+  `automerge_status=skipped`) that tests can assert on.
+
+Quality criteria:
+
+- Tests: `make test` passes; `ACT_WORKFLOW_TESTS=1` optional run passes when the
+  container runtime is available.
+- Lint/typecheck/format: `make check-fmt`, `make typecheck`, `make lint` pass.
+- Security: actions pinned to SHAs, minimal permissions documented.
+
+## Idempotence and Recovery
+
+- The script will be idempotent: enabling auto-merge on an already-enabled PR
+  should detect the existing state and exit successfully without changes.
+- Dry-run mode should avoid any network calls and still emit deterministic logs.
+- If the workflow fails due to permissions, rerun after updating permissions;
+  no state changes are left behind by the script unless auto-merge was enabled.
+
+## Artifacts and Notes
+
+Expected log snippets (examples to align tests):
+
+    automerge_status=enabled
+    automerge_reason=label:dependencies
+
+Or for skips:
+
+    automerge_status=skipped
+    automerge_reason=author-not-dependabot
+
+## Interfaces and Dependencies
+
+Script: `scripts/dependabot_automerge.py`
+
+- CLI: Cyclopts app with env-first config (`Env("INPUT_", command=False)`).
+- Inputs (env or CLI):
+  - `github_token` (required): token with `pull-requests: write`.
+  - `merge_method` (optional): `squash|merge|rebase` (default `squash`).
+  - `required_label` (optional): default `dependencies`.
+  - `dry_run` (optional): boolean, default `false`.
+  - `pull_request_number` (optional): override; otherwise parse from event.
+  - `repository` (optional): override; otherwise use `GITHUB_REPOSITORY`.
+- Behaviour:
+  - Load event payload from `GITHUB_EVENT_PATH` when available.
+  - Validate PR author is `dependabot[bot]` and PR is not draft.
+  - Enforce label requirement if configured.
+  - If `dry_run`, emit logs and exit 0 without API calls.
+  - Otherwise, call GitHub GraphQL API to enable auto-merge and report status.
+
+Dependencies (script-level `uv` block):
+
+- `cyclopts>=3.24` (already in repo) for CLI.
+- `httpx>=0.28` (already in repo) for HTTP API calls.
+
+## Revision note
+
+Initial plan created on 2026-01-12. No revisions yet.

--- a/docs/execplans/dependabot-auto-merge.md
+++ b/docs/execplans/dependabot-auto-merge.md
@@ -140,7 +140,7 @@ local validation path via `pytest` + `act`.
 - Decision: Add act-only workflow branches to skip `setup-uv`, install uv via
   pip with `--break-system-packages`, and redirect uv paths to `/tmp`.
   Rationale: act uses Node 18 and Debian PEP 668 defaults; this keeps workflow
-  tests green without affecting GitHub runner behavior.
+  tests green without affecting GitHub runner behaviour.
   Date/Author: 2026-01-12 (assistant).
 
 ## Outcomes & Retrospective

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-testpaths = .github/actions
+testpaths =
+    .github/actions
+    workflow_scripts/tests

--- a/tests/workflows/fixtures/pull_request_dependabot.event.json
+++ b/tests/workflows/fixtures/pull_request_dependabot.event.json
@@ -1,0 +1,11 @@
+{
+  "pull_request": {
+    "number": 42,
+    "draft": false,
+    "user": {"login": "dependabot[bot]"},
+    "labels": [{"name": "dependencies"}],
+    "head": {"sha": "deadbeef"}
+  },
+  "repository": {"full_name": "acme/example"},
+  "sender": {"login": "dependabot[bot]"}
+}

--- a/tests/workflows/test_dependabot_automerge_workflow.py
+++ b/tests/workflows/test_dependabot_automerge_workflow.py
@@ -1,0 +1,43 @@
+"""Integration tests for the dependabot auto-merge reusable workflow."""
+
+from __future__ import annotations
+
+import re
+import typing as typ
+
+import pytest
+
+from .conftest import (
+    FIXTURES_DIR,
+    ActConfig,
+    run_act,
+    skip_unless_act,
+    skip_unless_workflow_tests,
+)
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def artifact_dir(tmp_path: Path) -> Path:
+    """Return a temporary directory for act artefacts."""
+    return tmp_path / "act-artifacts"
+
+
+@skip_unless_act
+@skip_unless_workflow_tests
+def test_dependabot_automerge_dry_run(artifact_dir: Path) -> None:
+    """Dependabot workflow logs dry-run readiness under act."""
+    event_path = FIXTURES_DIR / "pull_request_dependabot.event.json"
+    config = ActConfig(artifact_dir=artifact_dir, event_path=event_path)
+    code, logs = run_act(
+        "test-dependabot-automerge.yml", "pull_request", "automerge", config
+    )
+    assert code == 0, f"act failed:\n{logs}"
+    assert re.search(r"automerge_status=\s*dry-run", logs, flags=re.IGNORECASE), (
+        "automerge_status=dry-run not found in logs"
+    )
+    assert re.search(r"automerge_reason=eligible", logs, flags=re.IGNORECASE), (
+        "automerge_reason=eligible not found in logs"
+    )

--- a/workflow_scripts/__init__.py
+++ b/workflow_scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Workflow helper scripts for reusable workflows."""

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -65,8 +65,15 @@ from pathlib import Path
 
 from cyclopts import App, Parameter
 
-from .graphql_client import JsonValue, request_graphql
-from .output import emit, fail
+try:
+    from .graphql_client import JsonValue, request_graphql
+    from .output import emit, fail
+except ImportError:
+    from graphql_client import (  # type: ignore[import-not-found,no-redef]
+        JsonValue,
+        request_graphql,
+    )
+    from output import emit, fail  # type: ignore[import-not-found,no-redef]
 
 DEPENDABOT_LOGIN = "dependabot[bot]"
 

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -61,18 +61,14 @@ import dataclasses
 import json
 import os
 import sys
-import time
 import typing as typ
 from pathlib import Path
 
-import httpx
 from cyclopts import App, Parameter
 
-# Type alias for JSON-compatible values (parsed from json.loads)
-JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+from workflow_scripts.graphql_client import JsonValue, request_graphql
 
 DEPENDABOT_LOGIN = "dependabot[bot]"
-GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
 
 MERGE_METHODS = {
     "merge": "MERGE",
@@ -266,9 +262,12 @@ def _get_repo_from_event(event: dict[str, JsonValue] | None) -> str:
     """Return the repository full name from an event payload when available."""
     if not event:
         return ""
-    repo = event.get("repository", {}).get("full_name")
-    if isinstance(repo, str):
-        return repo.strip()
+    repository = event.get("repository")
+    if not isinstance(repository, dict):
+        return ""
+    full_name = repository.get("full_name")
+    if isinstance(full_name, str):
+        return full_name.strip()
     return ""
 
 
@@ -373,12 +372,11 @@ def _emit_decision(
     config: AutomergeConfig,
 ) -> None:
     """Emit structured decision output for the automerge workflow."""
+    reason = decision.reason
     if decision.status == "ready" and config.dry_run:
         status = "dry-run"
-        reason = decision.reason
     else:
         status = decision.status
-        reason = decision.reason
     _emit("automerge_status", status)
     _emit("automerge_reason", reason)
     _emit("automerge_merge_method", config.merge_method)
@@ -388,98 +386,6 @@ def _emit_decision(
     _emit("automerge_author", pr.author)
     _emit("automerge_draft", str(pr.is_draft).lower())
     _emit("automerge_labels", pr.labels)
-
-
-def _should_retry(attempt: int, max_retries: int) -> bool:
-    """Return True if more retry attempts remain."""
-    return attempt < max_retries
-
-
-def _backoff_sleep(attempt: int, base_seconds: float = 1.0) -> None:
-    """Sleep with exponential backoff based on attempt number."""
-    time.sleep(base_seconds * (2**attempt))
-
-
-def _attempt_retry_or_fail(attempt: int, max_retries: int, error_message: str) -> None:
-    """Sleep for backoff if retries remain, otherwise fail with the given message."""
-    if not _should_retry(attempt, max_retries):
-        _fail(error_message)
-    _backoff_sleep(attempt)
-
-
-def _parse_graphql_response(response: httpx.Response) -> dict[str, JsonValue]:
-    """Parse and validate a GraphQL response, returning the data payload."""
-    try:
-        payload = response.json()
-    except json.JSONDecodeError as exc:
-        _fail(f"GitHub API response was not valid JSON: {exc}")
-
-    errors = payload.get("errors")
-    if errors:
-        _fail(f"GitHub API GraphQL errors: {errors}")
-
-    data = payload.get("data")
-    if data is None:
-        _fail("GitHub API returned no data.")
-    return data
-
-
-def _execute_graphql_attempt(
-    token: str, query: str, variables: dict[str, JsonValue]
-) -> httpx.Response | None:
-    """Execute a single GraphQL request attempt, returning None on connection error."""
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-    }
-    try:
-        with httpx.Client(timeout=30) as client:
-            return client.post(
-                GRAPHQL_ENDPOINT,
-                json={"query": query, "variables": variables},
-                headers=headers,
-            )
-    except httpx.HTTPError:
-        return None
-
-
-def _handle_response_or_retry(
-    response: httpx.Response | None, attempt: int, max_retries: int
-) -> httpx.Response | None:
-    """Process response or decide to retry. Returns None to signal retry."""
-    if response is None:
-        _attempt_retry_or_fail(
-            attempt,
-            max_retries,
-            "GitHub API request failed after retries: connection error",
-        )
-        return None
-
-    if 400 <= response.status_code < 500:
-        _fail(f"GitHub API error {response.status_code}: {response.text}")
-
-    if response.status_code >= 500:
-        msg = f"GitHub API error {response.status_code} after retries"
-        _attempt_retry_or_fail(attempt, max_retries, f"{msg}: {response.text}")
-        return None
-
-    return response
-
-
-def _request_graphql(
-    token: str, query: str, variables: dict[str, JsonValue]
-) -> dict[str, JsonValue]:
-    """Execute a GraphQL request with retry logic and return the data payload."""
-    max_retries = 3
-
-    for attempt in range(max_retries + 1):
-        response = _execute_graphql_attempt(token, query, variables)
-        processed_response = _handle_response_or_retry(response, attempt, max_retries)
-        if processed_response is None:
-            continue
-        return _parse_graphql_response(processed_response)
-
-    _fail("GitHub API request failed unexpectedly.")
 
 
 def _extract_author_login(pull_request: dict[str, JsonValue]) -> str:
@@ -515,7 +421,7 @@ def _fetch_pull_request(
     token: str, owner: str, repo: str, number: int
 ) -> PullRequestContext:
     """Fetch PR metadata from the GitHub GraphQL API."""
-    data = _request_graphql(
+    data = request_graphql(
         token,
         PULL_REQUEST_QUERY,
         {"owner": owner, "name": repo, "number": number},
@@ -544,7 +450,7 @@ def _fetch_pull_request(
 
 def _enable_automerge(token: str, pull_request_id: str, merge_method: str) -> None:
     """Enable auto-merge on a pull request via the GitHub GraphQL API."""
-    _request_graphql(
+    request_graphql(
         token,
         ENABLE_AUTOMERGE_MUTATION,
         {"pullRequestId": pull_request_id, "mergeMethod": merge_method},
@@ -613,7 +519,22 @@ def _handle_live_execution(
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class AutomergeOptions:
-    """CLI options for automerge execution."""
+    """CLI options for automerge execution.
+
+    Attributes
+    ----------
+    merge_method : str
+        Merge method to use: ``squash``, ``merge``, or ``rebase``.
+    required_label : str or None
+        Label that must be present on the PR, or None to skip label checks.
+    dry_run : bool
+        If True, logs the decision without calling the GitHub API.
+    pull_request_number : int or None
+        Explicit PR number override, or None to resolve from event payload.
+    repository : str or None
+        Repository override in ``owner/repo`` form, or None to resolve from
+        event payload or environment.
+    """
 
     merge_method: typ.Annotated[
         str,

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -65,10 +65,10 @@ from pathlib import Path
 
 from cyclopts import App, Parameter
 
-try:
+if __package__:
     from .graphql_client import JsonValue, request_graphql
     from .output import emit, fail
-except ImportError:
+else:
     from graphql_client import (  # type: ignore[import-not-found,no-redef]
         JsonValue,
         request_graphql,

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -138,19 +138,24 @@ def _normalize_merge_method(merge_method: str) -> str:
     return MERGE_METHODS[normalized]
 
 
+def _get_repo_from_event(event: dict[str, typ.Any] | None) -> str:
+    """Return the repository full name from an event payload when available."""
+    if not event:
+        return ""
+    repo = event.get("repository", {}).get("full_name")
+    if isinstance(repo, str):
+        return repo.strip()
+    return ""
+
+
 def _resolve_repository(
     repository: str | None, event: dict[str, typ.Any] | None
 ) -> str:
-    if repository:
-        candidate = repository.strip()
-        if candidate:
-            return candidate
-    if event:
-        repo = event.get("repository", {}).get("full_name")
-        if isinstance(repo, str) and repo.strip():
-            return repo
-    repo = os.environ.get("GITHUB_REPOSITORY")
-    if repo:
+    if repository and (candidate := repository.strip()):
+        return candidate
+    if repo := _get_repo_from_event(event):
+        return repo
+    if repo := os.environ.get("GITHUB_REPOSITORY"):
         return repo
     _fail("Repository not provided. Set INPUT_REPOSITORY or GITHUB_REPOSITORY.")
 

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["cyclopts>=3.24,<4.0", "httpx>=0.28,<0.29"]
+# ///
+
+"""Enable GitHub auto-merge for eligible Dependabot pull requests."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import sys
+import typing as typ
+from pathlib import Path
+
+import cyclopts
+import httpx
+from cyclopts import App, Parameter
+
+DEPENDABOT_LOGIN = "dependabot[bot]"
+GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+
+MERGE_METHODS = {
+    "merge": "MERGE",
+    "rebase": "REBASE",
+    "squash": "SQUASH",
+}
+
+PULL_REQUEST_QUERY = """
+query PullRequestInfo($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      number
+      isDraft
+      author {
+        login
+      }
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+      autoMergeRequest {
+        enabledAt
+        mergeMethod
+      }
+    }
+  }
+}
+"""
+
+ENABLE_AUTOMERGE_MUTATION = """
+mutation EnableAutomerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+  enablePullRequestAutoMerge(
+    input: {pullRequestId: $pullRequestId, mergeMethod: $mergeMethod}
+  ) {
+    pullRequest {
+      number
+    }
+  }
+}
+"""
+
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+
+@dataclasses.dataclass(frozen=True)
+class PullRequestContext:
+    """Snapshot of the pull request metadata used for gating."""
+
+    number: int
+    owner: str
+    repo: str
+    author: str
+    is_draft: bool
+    labels: tuple[str, ...]
+    node_id: str | None = None
+    auto_merge_enabled: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class Decision:
+    """Decision describing whether auto-merge should proceed."""
+
+    status: str
+    reason: str
+
+
+def _log_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+def _emit(key: str, value: object, *, stream: typ.TextIO | None = None) -> None:
+    target = stream if stream is not None else sys.stdout
+    print(f"{key}={_log_value(value)}", file=target)
+
+
+def _fail(message: str) -> typ.NoReturn:
+    _emit("automerge_status", "error", stream=sys.stderr)
+    _emit("automerge_error", message, stream=sys.stderr)
+    raise SystemExit(1)
+
+
+def _load_event() -> dict[str, typ.Any] | None:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    path = Path(event_path)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        _fail(f"Failed to parse event payload: {exc}")
+
+
+def _normalize_label(required_label: str | None) -> str | None:
+    if required_label is None:
+        return None
+    label = required_label.strip()
+    return label or None
+
+
+def _normalize_merge_method(merge_method: str) -> str:
+    normalized = merge_method.strip().lower()
+    if normalized not in MERGE_METHODS:
+        allowed = ", ".join(sorted(MERGE_METHODS))
+        _fail(f"Invalid merge_method '{merge_method}'. Allowed: {allowed}.")
+    return MERGE_METHODS[normalized]
+
+
+def _resolve_repository(
+    repository: str | None, event: dict[str, typ.Any] | None
+) -> str:
+    if repository:
+        candidate = repository.strip()
+        if candidate:
+            return candidate
+    if event:
+        repo = event.get("repository", {}).get("full_name")
+        if isinstance(repo, str) and repo.strip():
+            return repo
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if repo:
+        return repo
+    _fail("Repository not provided. Set INPUT_REPOSITORY or GITHUB_REPOSITORY.")
+
+
+def _split_repo(full_name: str) -> tuple[str, str]:
+    parts = full_name.split("/")
+    if len(parts) != 2 or not all(parts):
+        _fail(f"Repository '{full_name}' must be in owner/repo form.")
+    return parts[0], parts[1]
+
+
+def _resolve_pull_request_number(
+    pull_request_number: int | None, event: dict[str, typ.Any] | None
+) -> int:
+    if pull_request_number is not None:
+        return pull_request_number
+    if event:
+        pr = event.get("pull_request", {})
+        number = pr.get("number")
+        if number is not None:
+            try:
+                return int(number)
+            except (TypeError, ValueError):
+                pass
+    _fail(
+        "Pull request number not provided. Set INPUT_PULL_REQUEST_NUMBER or include "
+        "it in the event payload."
+    )
+
+
+def _labels_from_event(event: dict[str, typ.Any]) -> tuple[str, ...]:
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        _fail("Event payload does not include pull_request data.")
+    labels = []
+    for label in pr.get("labels", []) or []:
+        if not isinstance(label, dict):
+            continue
+        name = label.get("name")
+        if isinstance(name, str) and name:
+            labels.append(name)
+    return tuple(labels)
+
+
+def _snapshot_from_event(
+    event: dict[str, typ.Any], repo_full_name: str
+) -> PullRequestContext:
+    pr = event.get("pull_request")
+    if not isinstance(pr, dict):
+        _fail("Event payload does not include pull_request data.")
+    number = pr.get("number")
+    if number is None:
+        _fail("Event payload missing pull_request.number.")
+    try:
+        pr_number = int(number)
+    except (TypeError, ValueError):
+        _fail("Event payload pull_request.number is not an integer.")
+    author = pr.get("user", {}).get("login")
+    author_login = author if isinstance(author, str) else ""
+    is_draft = bool(pr.get("draft", False))
+    owner, repo = _split_repo(repo_full_name)
+    return PullRequestContext(
+        number=pr_number,
+        owner=owner,
+        repo=repo,
+        author=author_login,
+        is_draft=is_draft,
+        labels=_labels_from_event(event),
+    )
+
+
+def _evaluate(pr: PullRequestContext, required_label: str | None) -> Decision:
+    if pr.author != DEPENDABOT_LOGIN:
+        return Decision(status="skipped", reason="author-not-dependabot")
+    if pr.is_draft:
+        return Decision(status="skipped", reason="draft-pr")
+    if required_label and required_label not in pr.labels:
+        return Decision(status="skipped", reason=f"missing-label:{required_label}")
+    return Decision(status="ready", reason="eligible")
+
+
+def _emit_decision(
+    pr: PullRequestContext,
+    decision: Decision,
+    *,
+    merge_method: str,
+    required_label: str | None,
+    dry_run: bool,
+) -> None:
+    if decision.status == "ready" and dry_run:
+        status = "dry-run"
+        reason = decision.reason
+    else:
+        status = decision.status
+        reason = decision.reason
+    _emit("automerge_status", status)
+    _emit("automerge_reason", reason)
+    _emit("automerge_merge_method", merge_method)
+    _emit("automerge_required_label", required_label or "")
+    _emit("automerge_repository", f"{pr.owner}/{pr.repo}")
+    _emit("automerge_pr_number", pr.number)
+    _emit("automerge_author", pr.author)
+    _emit("automerge_draft", str(pr.is_draft).lower())
+    _emit("automerge_labels", pr.labels)
+
+
+def _request_graphql(
+    token: str, query: str, variables: dict[str, typ.Any]
+) -> dict[str, typ.Any]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    try:
+        with httpx.Client(timeout=30) as client:
+            response = client.post(
+                GRAPHQL_ENDPOINT,
+                json={"query": query, "variables": variables},
+                headers=headers,
+            )
+    except httpx.HTTPError as exc:
+        _fail(f"GitHub API request failed: {exc}")
+
+    if response.status_code >= 400:
+        _fail(f"GitHub API error {response.status_code}: {response.text}")
+
+    try:
+        payload = response.json()
+    except json.JSONDecodeError as exc:
+        _fail(f"GitHub API response was not valid JSON: {exc}")
+
+    errors = payload.get("errors")
+    if errors:
+        _fail(f"GitHub API GraphQL errors: {errors}")
+    data = payload.get("data")
+    if data is None:
+        _fail("GitHub API returned no data.")
+    return data
+
+
+def _fetch_pull_request(
+    token: str, owner: str, repo: str, number: int
+) -> PullRequestContext:
+    data = _request_graphql(
+        token,
+        PULL_REQUEST_QUERY,
+        {"owner": owner, "name": repo, "number": number},
+    )
+    pull_request = data.get("repository", {}).get("pullRequest")
+    if pull_request is None:
+        _fail(f"Pull request {owner}/{repo}#{number} was not found.")
+    author = pull_request.get("author", {}).get("login")
+    author_login = author if isinstance(author, str) else ""
+    labels = [
+        node.get("name")
+        for node in pull_request.get("labels", {}).get("nodes", [])
+        if isinstance(node, dict) and isinstance(node.get("name"), str)
+    ]
+    auto_merge_enabled = pull_request.get("autoMergeRequest") is not None
+    return PullRequestContext(
+        number=number,
+        owner=owner,
+        repo=repo,
+        author=author_login,
+        is_draft=bool(pull_request.get("isDraft", False)),
+        labels=tuple(labels),
+        node_id=pull_request.get("id"),
+        auto_merge_enabled=auto_merge_enabled,
+    )
+
+
+def _enable_automerge(token: str, pull_request_id: str, merge_method: str) -> None:
+    _request_graphql(
+        token,
+        ENABLE_AUTOMERGE_MUTATION,
+        {"pullRequestId": pull_request_id, "mergeMethod": merge_method},
+    )
+
+
+@app.default
+def main(
+    *,
+    github_token: typ.Annotated[str, Parameter(required=True)],
+    merge_method: str = "squash",
+    required_label: str | None = "dependencies",
+    dry_run: bool = False,
+    pull_request_number: int | None = None,
+    repository: str | None = None,
+) -> None:
+    """Evaluate a PR and enable auto-merge when policy allows."""
+    normalized_label = _normalize_label(required_label)
+    normalized_merge_method = _normalize_merge_method(merge_method)
+
+    event = _load_event()
+    repo_full_name = _resolve_repository(repository, event)
+
+    if dry_run:
+        if event is None:
+            _fail("Dry-run mode requires GITHUB_EVENT_PATH with pull_request data.")
+        snapshot = _snapshot_from_event(event, repo_full_name)
+        decision = _evaluate(snapshot, normalized_label)
+        _emit_decision(
+            snapshot,
+            decision,
+            merge_method=normalized_merge_method,
+            required_label=normalized_label,
+            dry_run=True,
+        )
+        return
+
+    owner, repo = _split_repo(repo_full_name)
+    pr_number = _resolve_pull_request_number(pull_request_number, event)
+
+    pr = _fetch_pull_request(github_token, owner, repo, pr_number)
+    decision = _evaluate(pr, normalized_label)
+    if decision.status != "ready":
+        _emit_decision(
+            pr,
+            decision,
+            merge_method=normalized_merge_method,
+            required_label=normalized_label,
+            dry_run=False,
+        )
+        return
+
+    if pr.auto_merge_enabled:
+        _emit_decision(
+            pr,
+            Decision(status="enabled", reason="already-enabled"),
+            merge_method=normalized_merge_method,
+            required_label=normalized_label,
+            dry_run=False,
+        )
+        return
+
+    if not pr.node_id:
+        _fail("Pull request node ID missing from GitHub response.")
+
+    _enable_automerge(github_token, pr.node_id, normalized_merge_method)
+    _emit_decision(
+        pr,
+        Decision(status="enabled", reason="enabled"),
+        merge_method=normalized_merge_method,
+        required_label=normalized_label,
+        dry_run=False,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -15,7 +15,6 @@ import sys
 import typing as typ
 from pathlib import Path
 
-import cyclopts
 import httpx
 from cyclopts import App, Parameter
 
@@ -64,7 +63,7 @@ mutation EnableAutomerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMeth
 }
 """
 
-app = App(config=cyclopts.config.Env("INPUT_", command=False))
+app = App()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -460,7 +459,9 @@ DEFAULT_AUTOMERGE_OPTIONS = AutomergeOptions()
 @app.default
 def main(
     *,
-    github_token: typ.Annotated[str, Parameter(required=True)],
+    github_token: typ.Annotated[
+        str, Parameter(required=True, env_var="INPUT_GITHUB_TOKEN")
+    ],
     options: AutomergeOptions = DEFAULT_AUTOMERGE_OPTIONS,
 ) -> None:
     """Evaluate a PR and enable auto-merge when policy allows."""

--- a/workflow_scripts/graphql_client.py
+++ b/workflow_scripts/graphql_client.py
@@ -116,5 +116,5 @@ def request_graphql(
         return _parse_graphql_response(processed_response)
 
     # Defensive: unreachable if retry logic works correctly, but satisfies type checker
-    fail("GitHub API request failed unexpectedly.")
-    raise AssertionError  # unreachable
+    fail("GitHub API request failed unexpectedly.")  # pragma: no cover
+    raise AssertionError  # pragma: no cover

--- a/workflow_scripts/graphql_client.py
+++ b/workflow_scripts/graphql_client.py
@@ -11,7 +11,10 @@ import time
 
 import httpx
 
-from .output import fail
+if __package__:
+    from .output import fail
+else:
+    from output import fail  # type: ignore[import-not-found,no-redef]
 
 GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
 

--- a/workflow_scripts/graphql_client.py
+++ b/workflow_scripts/graphql_client.py
@@ -55,6 +55,8 @@ def _parse_graphql_response(response: httpx.Response) -> dict[str, JsonValue]:
     data = payload.get("data")
     if data is None:
         fail("GitHub API returned no data.")
+    if not isinstance(data, dict):
+        fail("GitHub API returned invalid data payload.")
     return data
 
 

--- a/workflow_scripts/graphql_client.py
+++ b/workflow_scripts/graphql_client.py
@@ -1,0 +1,121 @@
+"""GitHub GraphQL API client with retry logic.
+
+This module provides a simple GraphQL client for the GitHub API with
+exponential backoff retry handling for transient failures.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import typing as typ
+
+import httpx
+
+GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+
+# Type alias for JSON-compatible values (parsed from json.loads)
+type JsonValue = (
+    str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+)
+
+
+def _fail(message: str) -> typ.NoReturn:
+    """Log an error and exit with status code 1."""
+    import sys
+
+    print("automerge_status=error", file=sys.stderr)
+    print(f"automerge_error={message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _should_retry(attempt: int, max_retries: int) -> bool:
+    """Return True if more retry attempts remain."""
+    return attempt < max_retries
+
+
+def _backoff_sleep(attempt: int, base_seconds: float = 1.0) -> None:
+    """Sleep with exponential backoff based on attempt number."""
+    time.sleep(base_seconds * (2**attempt))
+
+
+def _attempt_retry_or_fail(attempt: int, max_retries: int, error_message: str) -> None:
+    """Sleep for backoff if retries remain, otherwise fail with the given message."""
+    if not _should_retry(attempt, max_retries):
+        _fail(error_message)
+    _backoff_sleep(attempt)
+
+
+def _parse_graphql_response(response: httpx.Response) -> dict[str, JsonValue]:
+    """Parse and validate a GraphQL response, returning the data payload."""
+    try:
+        payload = response.json()
+    except json.JSONDecodeError as exc:
+        _fail(f"GitHub API response was not valid JSON: {exc}")
+
+    errors = payload.get("errors")
+    if errors:
+        _fail(f"GitHub API GraphQL errors: {errors}")
+
+    data = payload.get("data")
+    if data is None:
+        _fail("GitHub API returned no data.")
+    return data
+
+
+def _execute_graphql_attempt(
+    token: str, query: str, variables: dict[str, JsonValue]
+) -> httpx.Response | None:
+    """Execute a single GraphQL request attempt, returning None on connection error."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    try:
+        with httpx.Client(timeout=30) as client:
+            return client.post(
+                GRAPHQL_ENDPOINT,
+                json={"query": query, "variables": variables},
+                headers=headers,
+            )
+    except httpx.TransportError:
+        return None
+
+
+def _handle_response_or_retry(
+    response: httpx.Response | None, attempt: int, max_retries: int
+) -> httpx.Response | None:
+    """Process response or decide to retry. Returns None to signal retry."""
+    if response is None:
+        _attempt_retry_or_fail(
+            attempt,
+            max_retries,
+            "GitHub API request failed after retries: connection error",
+        )
+        return None
+
+    if 400 <= response.status_code < 500:
+        _fail(f"GitHub API error {response.status_code}: {response.text}")
+
+    if response.status_code >= 500:
+        msg = f"GitHub API error {response.status_code} after retries"
+        _attempt_retry_or_fail(attempt, max_retries, f"{msg}: {response.text}")
+        return None
+
+    return response
+
+
+def request_graphql(
+    token: str, query: str, variables: dict[str, JsonValue]
+) -> dict[str, JsonValue]:
+    """Execute a GraphQL request with retry logic and return the data payload."""
+    max_retries = 3
+
+    for attempt in range(max_retries + 1):
+        response = _execute_graphql_attempt(token, query, variables)
+        processed_response = _handle_response_or_retry(response, attempt, max_retries)
+        if processed_response is None:
+            continue
+        return _parse_graphql_response(processed_response)
+
+    _fail("GitHub API request failed unexpectedly.")

--- a/workflow_scripts/graphql_client.py
+++ b/workflow_scripts/graphql_client.py
@@ -45,6 +45,9 @@ def _parse_graphql_response(response: httpx.Response) -> dict[str, JsonValue]:
     except json.JSONDecodeError as exc:
         fail(f"GitHub API response was not valid JSON: {exc}")
 
+    if not isinstance(payload, dict):
+        fail("GitHub API response was not a JSON object.")
+
     errors = payload.get("errors")
     if errors:
         fail(f"GitHub API GraphQL errors: {errors}")

--- a/workflow_scripts/output.py
+++ b/workflow_scripts/output.py
@@ -1,0 +1,35 @@
+"""Shared output utilities for workflow scripts.
+
+This module provides structured logging and error handling functions
+used across the dependabot automerge workflow scripts.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import typing as typ
+
+
+def _log_value(value: object) -> str:
+    """Format a value for key=value log output."""
+    if value is None:
+        return ""
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+def emit(key: str, value: object, *, stream: typ.TextIO | None = None) -> None:
+    """Print a key=value pair to stdout or the specified stream."""
+    target = stream if stream is not None else sys.stdout
+    print(f"{key}={_log_value(value)}", file=target)
+
+
+def fail(message: str) -> typ.NoReturn:
+    """Log an error and exit with status code 1."""
+    emit("automerge_status", "error", stream=sys.stderr)
+    emit("automerge_error", message, stream=sys.stderr)
+    raise SystemExit(1)

--- a/workflow_scripts/tests/test_dependabot_automerge.py
+++ b/workflow_scripts/tests/test_dependabot_automerge.py
@@ -42,8 +42,10 @@ def test_dry_run_skips_non_dependabot(
 
     dependabot_automerge.main(
         github_token=TEST_TOKEN,
-        dry_run=True,
-        required_label="dependencies",
+        options=dependabot_automerge.AutomergeOptions(
+            dry_run=True,
+            required_label="dependencies",
+        ),
     )
 
     captured = capsys.readouterr()
@@ -61,8 +63,10 @@ def test_dry_run_requires_event_payload(
     with pytest.raises(SystemExit):
         dependabot_automerge.main(
             github_token=TEST_TOKEN,
-            dry_run=True,
-            required_label="dependencies",
+            options=dependabot_automerge.AutomergeOptions(
+                dry_run=True,
+                required_label="dependencies",
+            ),
         )
 
     captured = capsys.readouterr()
@@ -91,8 +95,10 @@ def test_dry_run_eligible_dependabot(
 
     dependabot_automerge.main(
         github_token=TEST_TOKEN,
-        dry_run=True,
-        required_label="dependencies",
+        options=dependabot_automerge.AutomergeOptions(
+            dry_run=True,
+            required_label="dependencies",
+        ),
     )
 
     captured = capsys.readouterr()
@@ -128,8 +134,10 @@ def test_enables_automerge_when_ready(
 
     dependabot_automerge.main(
         github_token=TEST_TOKEN,
-        repository="acme/example",
-        pull_request_number=12,
+        options=dependabot_automerge.AutomergeOptions(
+            repository="acme/example",
+            pull_request_number=12,
+        ),
     )
 
     captured = capsys.readouterr()

--- a/workflow_scripts/tests/test_dependabot_automerge.py
+++ b/workflow_scripts/tests/test_dependabot_automerge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import typing as typ
 
+import httpx
 import pytest
 
 from workflow_scripts import dependabot_automerge
@@ -12,6 +13,7 @@ from workflow_scripts import dependabot_automerge
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
+# Test-only constant (not a real credential)
 TEST_TOKEN = "test-token"  # noqa: S105
 
 
@@ -21,23 +23,240 @@ def _write_event(tmp_path: Path, payload: dict[str, object]) -> Path:
     return event_path
 
 
-def test_dry_run_skips_non_dependabot(
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMergeMethod:
+    """Tests for _normalize_merge_method."""
+
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            ("squash", "SQUASH"),
+            ("SQUASH", "SQUASH"),
+            ("  squash  ", "SQUASH"),
+            ("merge", "MERGE"),
+            ("rebase", "REBASE"),
+        ],
+    )
+    def test_valid_values(self, input_value: str, expected: str) -> None:
+        """Valid merge methods are normalised correctly."""
+        result = dependabot_automerge._normalize_merge_method(input_value)
+        assert result == expected, f"Expected {expected} for input '{input_value}'"
+
+    def test_invalid_value_raises(self) -> None:
+        """Invalid merge methods cause a failure."""
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._normalize_merge_method("invalid")
+
+
+class TestNormalizeLabel:
+    """Tests for _normalize_label."""
+
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            ("dependencies", "dependencies"),
+            ("  dependencies  ", "dependencies"),
+            ("", None),
+            ("   ", None),
+            (None, None),
+        ],
+    )
+    def test_whitespace_handling(
+        self, input_value: str | None, expected: str | None
+    ) -> None:
+        """Labels are trimmed and empty strings become None."""
+        result = dependabot_automerge._normalize_label(input_value)
+        assert result == expected, f"Expected {expected!r} for input {input_value!r}"
+
+
+class TestResolveRepository:
+    """Tests for _resolve_repository."""
+
+    def test_explicit_repository_used(self) -> None:
+        """Explicit repository input takes precedence."""
+        result = dependabot_automerge._resolve_repository(
+            "explicit/repo", {"repository": {"full_name": "event/repo"}}
+        )
+        assert result == "explicit/repo", "Explicit repo should take precedence"
+
+    def test_event_fallback(self) -> None:
+        """Falls back to event payload when no explicit repo."""
+        result = dependabot_automerge._resolve_repository(
+            None, {"repository": {"full_name": "event/repo"}}
+        )
+        assert result == "event/repo", "Should fall back to event repo"
+
+    def test_env_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to GITHUB_REPOSITORY env var."""
+        monkeypatch.setenv("GITHUB_REPOSITORY", "env/repo")
+        result = dependabot_automerge._resolve_repository(None, None)
+        assert result == "env/repo", "Should fall back to env var"
+
+    def test_missing_repository_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Raises when no repository can be determined."""
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._resolve_repository(None, None)
+
+
+class TestResolvePullRequestNumber:
+    """Tests for _resolve_pull_request_number."""
+
+    def test_explicit_number_used(self) -> None:
+        """Explicit PR number takes precedence."""
+        result = dependabot_automerge._resolve_pull_request_number(
+            42, {"pull_request": {"number": 99}}
+        )
+        assert result == 42, "Explicit number should take precedence"
+
+    def test_event_fallback(self) -> None:
+        """Falls back to event payload when no explicit number."""
+        result = dependabot_automerge._resolve_pull_request_number(
+            None, {"pull_request": {"number": 99}}
+        )
+        assert result == 99, "Should fall back to event number"
+
+    def test_string_number_parsed(self) -> None:
+        """String numbers in event are converted to int."""
+        result = dependabot_automerge._resolve_pull_request_number(
+            None, {"pull_request": {"number": "123"}}
+        )
+        assert result == 123, "String number should be parsed"
+
+    def test_missing_number_raises(self) -> None:
+        """Raises when no PR number can be determined."""
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._resolve_pull_request_number(None, {})
+
+
+# ---------------------------------------------------------------------------
+# GraphQL request tests
+# ---------------------------------------------------------------------------
+
+
+class TestRequestGraphql:
+    """Tests for _request_graphql error handling."""
+
+    def test_http_error_after_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """HTTP errors are retried and then fail."""
+        connect_error = httpx.ConnectError("Connection failed")
+
+        def raise_error(*_args: object, **_kwargs: object) -> typ.NoReturn:
+            raise connect_error
+
+        monkeypatch.setattr(httpx.Client, "post", raise_error)
+        monkeypatch.setattr(dependabot_automerge, "_backoff_sleep", lambda *_: None)
+
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._request_graphql(TEST_TOKEN, "query {}", {})
+
+    def test_client_error_not_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """4xx errors fail immediately without retry."""
+        call_count = 0
+
+        def mock_post(*_args: object, **_kwargs: object) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(400, text="Bad Request")
+
+        monkeypatch.setattr(httpx.Client, "post", mock_post)
+
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._request_graphql(TEST_TOKEN, "query {}", {})
+
+        assert call_count == 1, "4xx errors should not be retried"
+
+    def test_non_json_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-JSON responses cause a failure."""
+
+        def mock_post(*_args: object, **_kwargs: object) -> httpx.Response:
+            return httpx.Response(200, content=b"not json")
+
+        monkeypatch.setattr(httpx.Client, "post", mock_post)
+
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._request_graphql(TEST_TOKEN, "query {}", {})
+
+    def test_graphql_errors_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GraphQL errors in response cause a failure."""
+
+        def mock_post(*_args: object, **_kwargs: object) -> httpx.Response:
+            return httpx.Response(
+                200, json={"errors": [{"message": "Something went wrong"}]}
+            )
+
+        monkeypatch.setattr(httpx.Client, "post", mock_post)
+
+        with pytest.raises(SystemExit, match="1"):
+            dependabot_automerge._request_graphql(TEST_TOKEN, "query {}", {})
+
+
+# ---------------------------------------------------------------------------
+# Dry-run skip tests (parametrised)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("event_data", "expected_reason", "test_id"),
+    [
+        pytest.param(
+            {
+                "pull_request": {
+                    "number": 7,
+                    "draft": False,
+                    "user": {"login": "someone"},
+                    "labels": [{"name": "dependencies"}],
+                },
+                "repository": {"full_name": "acme/example"},
+            },
+            "author-not-dependabot",
+            "non_dependabot_author",
+            id="non_dependabot_author",
+        ),
+        pytest.param(
+            {
+                "pull_request": {
+                    "number": 8,
+                    "draft": True,
+                    "user": {"login": "dependabot[bot]"},
+                    "labels": [{"name": "dependencies"}],
+                },
+                "repository": {"full_name": "acme/example"},
+            },
+            "draft-pr",
+            "draft_pr",
+            id="draft_pr",
+        ),
+        pytest.param(
+            {
+                "pull_request": {
+                    "number": 10,
+                    "draft": False,
+                    "user": {"login": "dependabot[bot]"},
+                    "labels": [{"name": "other-label"}],
+                },
+                "repository": {"full_name": "acme/example"},
+            },
+            "missing-label:dependencies",
+            "missing_label",
+            id="missing_label",
+        ),
+    ],
+)
+def test_dry_run_skips(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    event_data: dict[str, object],
+    expected_reason: str,
+    test_id: str,
 ) -> None:
-    """Non-Dependabot authors are skipped in dry-run mode."""
-    event = {
-        "pull_request": {
-            "number": 7,
-            "draft": False,
-            "user": {"login": "someone"},
-            "labels": [{"name": "dependencies"}],
-        },
-        "repository": {"full_name": "acme/example"},
-    }
-    event_path = _write_event(tmp_path, event)
-
+    """Dry-run mode skips PRs that don't meet eligibility criteria."""
+    event_path = _write_event(tmp_path, event_data)
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
 
     dependabot_automerge.main(
@@ -49,8 +268,17 @@ def test_dry_run_skips_non_dependabot(
     )
 
     captured = capsys.readouterr()
-    assert "automerge_status=skipped" in captured.out
-    assert "automerge_reason=author-not-dependabot" in captured.out
+    assert "automerge_status=skipped" in captured.out, (
+        f"[{test_id}] Expected skipped status"
+    )
+    assert f"automerge_reason={expected_reason}" in captured.out, (
+        f"[{test_id}] Expected reason {expected_reason}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Other integration tests
+# ---------------------------------------------------------------------------
 
 
 def test_dry_run_requires_event_payload(
@@ -60,7 +288,7 @@ def test_dry_run_requires_event_payload(
     monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
     monkeypatch.setenv("GITHUB_REPOSITORY", "acme/example")
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit, match="1"):
         dependabot_automerge.main(
             github_token=TEST_TOKEN,
             options=dependabot_automerge.AutomergeOptions(
@@ -70,8 +298,10 @@ def test_dry_run_requires_event_payload(
         )
 
     captured = capsys.readouterr()
-    assert "automerge_status=error" in captured.err
-    assert "Dry-run mode requires GITHUB_EVENT_PATH" in captured.err
+    assert "automerge_status=error" in captured.err, "Expected error status"
+    assert "Dry-run mode requires GITHUB_EVENT_PATH" in captured.err, (
+        "Expected specific error message"
+    )
 
 
 def test_dry_run_eligible_dependabot(
@@ -102,8 +332,8 @@ def test_dry_run_eligible_dependabot(
     )
 
     captured = capsys.readouterr()
-    assert "automerge_status=dry-run" in captured.out
-    assert "automerge_reason=eligible" in captured.out
+    assert "automerge_status=dry-run" in captured.out, "Expected dry-run status"
+    assert "automerge_reason=eligible" in captured.out, "Expected eligible reason"
 
 
 def test_enables_automerge_when_ready(
@@ -141,72 +371,8 @@ def test_enables_automerge_when_ready(
     )
 
     captured = capsys.readouterr()
-    assert "automerge_status=enabled" in captured.out
-    assert "automerge_reason=enabled" in captured.out
-
-
-def test_dry_run_skips_draft_pr(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Draft pull requests are skipped in dry-run mode."""
-    event = {
-        "pull_request": {
-            "number": 8,
-            "draft": True,
-            "user": {"login": "dependabot[bot]"},
-            "labels": [{"name": "dependencies"}],
-        },
-        "repository": {"full_name": "acme/example"},
-    }
-    event_path = _write_event(tmp_path, event)
-
-    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
-
-    dependabot_automerge.main(
-        github_token=TEST_TOKEN,
-        options=dependabot_automerge.AutomergeOptions(
-            dry_run=True,
-            required_label="dependencies",
-        ),
-    )
-
-    captured = capsys.readouterr()
-    assert "automerge_status=skipped" in captured.out
-    assert "automerge_reason=draft-pr" in captured.out
-
-
-def test_dry_run_skips_missing_label(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Pull requests missing the required label are skipped."""
-    event = {
-        "pull_request": {
-            "number": 10,
-            "draft": False,
-            "user": {"login": "dependabot[bot]"},
-            "labels": [{"name": "other-label"}],
-        },
-        "repository": {"full_name": "acme/example"},
-    }
-    event_path = _write_event(tmp_path, event)
-
-    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
-
-    dependabot_automerge.main(
-        github_token=TEST_TOKEN,
-        options=dependabot_automerge.AutomergeOptions(
-            dry_run=True,
-            required_label="dependencies",
-        ),
-    )
-
-    captured = capsys.readouterr()
-    assert "automerge_status=skipped" in captured.out
-    assert "automerge_reason=missing-label:dependencies" in captured.out
+    assert "automerge_status=enabled" in captured.out, "Expected enabled status"
+    assert "automerge_reason=enabled" in captured.out, "Expected enabled reason"
 
 
 def test_already_enabled_automerge_detected(
@@ -245,5 +411,7 @@ def test_already_enabled_automerge_detected(
     )
 
     captured = capsys.readouterr()
-    assert "automerge_status=enabled" in captured.out
-    assert "automerge_reason=already-enabled" in captured.out
+    assert "automerge_status=enabled" in captured.out, "Expected enabled status"
+    assert "automerge_reason=already-enabled" in captured.out, (
+        "Expected already-enabled reason"
+    )

--- a/workflow_scripts/tests/test_dependabot_automerge.py
+++ b/workflow_scripts/tests/test_dependabot_automerge.py
@@ -18,7 +18,7 @@ if typ.TYPE_CHECKING:
 TEST_TOKEN = "test-token"  # noqa: S105
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, slots=True)
 class DryRunTestCase:
     """Test case parameters for dry-run skip scenarios."""
 
@@ -28,6 +28,20 @@ class DryRunTestCase:
 
 
 def _write_event(tmp_path: Path, payload: dict[str, object]) -> Path:
+    """Write an event payload to a temporary JSON file.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        pytest temporary directory fixture.
+    payload : dict
+        The event payload to serialise.
+
+    Returns
+    -------
+    Path
+        Path to the created event.json file.
+    """
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps(payload), encoding="utf-8")
     return event_path

--- a/workflow_scripts/tests/test_dependabot_automerge.py
+++ b/workflow_scripts/tests/test_dependabot_automerge.py
@@ -1,0 +1,137 @@
+"""Unit tests for the dependabot auto-merge helper script."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+import pytest
+
+from workflow_scripts import dependabot_automerge
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+TEST_TOKEN = "test-token"  # noqa: S105
+
+
+def _write_event(tmp_path: Path, payload: dict[str, object]) -> Path:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(payload), encoding="utf-8")
+    return event_path
+
+
+def test_dry_run_skips_non_dependabot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-Dependabot authors are skipped in dry-run mode."""
+    event = {
+        "pull_request": {
+            "number": 7,
+            "draft": False,
+            "user": {"login": "someone"},
+            "labels": [{"name": "dependencies"}],
+        },
+        "repository": {"full_name": "acme/example"},
+    }
+    event_path = _write_event(tmp_path, event)
+
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+
+    dependabot_automerge.main(
+        github_token=TEST_TOKEN,
+        dry_run=True,
+        required_label="dependencies",
+    )
+
+    captured = capsys.readouterr()
+    assert "automerge_status=skipped" in captured.out
+    assert "automerge_reason=author-not-dependabot" in captured.out
+
+
+def test_dry_run_requires_event_payload(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Dry-run mode errors without a pull_request event payload."""
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "acme/example")
+
+    with pytest.raises(SystemExit):
+        dependabot_automerge.main(
+            github_token=TEST_TOKEN,
+            dry_run=True,
+            required_label="dependencies",
+        )
+
+    captured = capsys.readouterr()
+    assert "automerge_status=error" in captured.err
+    assert "Dry-run mode requires GITHUB_EVENT_PATH" in captured.err
+
+
+def test_dry_run_eligible_dependabot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Eligible Dependabot PRs log dry-run readiness."""
+    event = {
+        "pull_request": {
+            "number": 9,
+            "draft": False,
+            "user": {"login": "dependabot[bot]"},
+            "labels": [{"name": "dependencies"}],
+        },
+        "repository": {"full_name": "acme/example"},
+    }
+    event_path = _write_event(tmp_path, event)
+
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+
+    dependabot_automerge.main(
+        github_token=TEST_TOKEN,
+        dry_run=True,
+        required_label="dependencies",
+    )
+
+    captured = capsys.readouterr()
+    assert "automerge_status=dry-run" in captured.out
+    assert "automerge_reason=eligible" in captured.out
+
+
+def test_enables_automerge_when_ready(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Eligible PRs enable auto-merge via the GitHub API."""
+
+    def fake_request(
+        token: str, query: str, variables: dict[str, object]
+    ) -> dict[str, object]:
+        if "enablePullRequestAutoMerge" in query:
+            return {"enablePullRequestAutoMerge": {"pullRequest": {"number": 12}}}
+        return {
+            "repository": {
+                "pullRequest": {
+                    "id": "PR_12",
+                    "number": 12,
+                    "isDraft": False,
+                    "author": {"login": "dependabot[bot]"},
+                    "labels": {"nodes": [{"name": "dependencies"}]},
+                    "autoMergeRequest": None,
+                }
+            }
+        }
+
+    monkeypatch.setattr(dependabot_automerge, "_request_graphql", fake_request)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    dependabot_automerge.main(
+        github_token=TEST_TOKEN,
+        repository="acme/example",
+        pull_request_number=12,
+    )
+
+    captured = capsys.readouterr()
+    assert "automerge_status=enabled" in captured.out
+    assert "automerge_reason=enabled" in captured.out


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable GitHub Actions workflow and helper script to safely auto‑enable GitHub auto‑merge for eligible Dependabot pull requests, with tests and documentation, and make minor testing and repo‑root detection adjustments.

New Features:
- Add a Dependabot auto-merge reusable workflow callable from other repositories.
- Implement a Python helper script that evaluates Dependabot PR eligibility and enables GitHub auto-merge via the GitHub GraphQL API.
- Provide a dry-run mode for the auto-merge helper to emit decisions without performing API calls.

Enhancements:
- Update pytest configuration to include workflow helper tests in default test discovery.
- Adjust repository root detection in linux-packages tests to work with Git worktree checkouts that expose .git as a file.

Documentation:
- Document the Dependabot auto-merge reusable workflow, its usage, permissions, and local validation flow.
- Extend the README with a table entry listing the new reusable workflow.

Tests:
- Add unit tests for the Dependabot auto-merge helper script.
- Add act-based integration tests and fixtures for the Dependabot auto-merge reusable workflow.