### PR TITLE
Use sccache v0.12.0 for macOS x64 in setup-rust

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -121,12 +121,15 @@ runs:
         key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
-    - name: Run sccache only on non-release runs
-      if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' }}
+    # x86_64-apple-darwin binaries were dropped after sccache v0.12.0
+    - name: Run sccache (x86_64 macOS)
+      if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' && runner.os == 'macOS' && runner.arch == 'X64' }}
       uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad
       with:
-        # x86_64-apple-darwin binaries were dropped after v0.12.0
-        version: ${{ runner.os == 'macOS' && runner.arch == 'X64' && 'v0.12.0' || '' }}
+        version: v0.12.0
+    - name: Run sccache
+      if: ${{ inputs.use-sccache == 'true' && github.event_name != 'release' && !(runner.os == 'macOS' && runner.arch == 'X64') }}
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad
     - name: Install system dependencies
       if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Linux' }}
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev


### PR DESCRIPTION
## Summary
- Split sccache handling in setup-rust: pin v0.12.0 for macOS x64 and keep default behavior on other runners
- Addresses x86_64-apple-darwin binaries dropped after v0.12.0; ensures compatibility on macOS x64

## Changes
### CI Workflow
- Replaced a single Run sccache step with two steps:
  - Run sccache (x86_64 macOS) pinned to v0.12.0
  - Run sccache (default) for non-macOS or non-X64 runners
- Rationale: ensure compatibility with macOS x64 runners where newer binaries are unavailable

### Snippet (for reference)
```yaml
# MacOS X64: x86_64-apple-darwin binaries were dropped after v0.12.0
with:
  version: v0.12.0
```

## Rationale
- The x86_64-apple-darwin binaries were dropped after v0.12.0, so pinning to v0.12.0 on macOS x64 keeps sccache usage compatible on those runners and prevents failures from attempting to download unsupported binaries.

## Test plan
- [x] Trigger CI on a macOS (X64) runner to verify sccache is pinned to v0.12.0
- [x] Validate that non-macOS or non-X64 runners continue with default behavior (no forced v0.12.0 pin)
- [x] Confirm builds on macOS X64 complete successfully with sccache enabled

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5581b3f0-71af-4671-b38a-6331fdd2e034

## Summary by Sourcery

CI:
- Configure the sccache action to use v0.12.0 specifically on macOS X64 runners to avoid missing binary downloads.