### PR TITLE
Pin sccache to v0.12.0 on macOS to fix download error

### DIFF
--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -47,7 +47,7 @@ runs:
       # Update this SHA when setup-rust publishes a new release: run
       # `git ls-remote https://github.com/leynos/shared-actions.git refs/tags/setup-rust-v1`
       # and replace the SHA with the resolved commit (verify compatibility and run CI).
-      uses: leynos/shared-actions/.github/actions/setup-rust@35b0092c30d18ba2669db3e8c7c37412db952437
+      uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       with:
         toolchain: ${{ env.RBR_TOOLCHAIN }}
     - name: Configure gnullvm target on Windows

--- a/.github/actions/setup-rust/CHANGELOG.md
+++ b/.github/actions/setup-rust/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.14 - 2026-01-16
+
+- Pin sccache to v0.12.0 on macOS x86_64 runners (x86_64-apple-darwin binaries
+  were dropped in v0.13.0).
+
 ## v1.0.13 - 2025-07-26
 
 - Add `workspaces` input and forward it to `Swatinem/rust-cache`.


### PR DESCRIPTION
## Summary
- Fix sccache v0.13.0 download error on macOS runners by pinning to v0.12.0.
- Update setup-rust action reference to ensure compatibility with pinned sccache on macOS runners

## Changes

### CI/CD Actions
- .github/actions/rust-build-release/action.yml: Bump setup-rust action SHA from 35b0092c30d18ba2669db3e8c7c37412db952437 to aebb3f5b831102e2a10ef909c83d7d50ea86c332

### Changelog
- .github/actions/setup-rust/CHANGELOG.md: Add v1.0.14 entry:
  - Pin sccache to v0.12.0 on macOS x86_64 runners (x86_64-apple-darwin binaries were dropped in v0.13.0).

## Test plan
- [x] Run CI on macOS runners to confirm sccache download succeeds with v0.12.0
- [x] Ensure the rust-build-release workflow passes with the updated setup-rust action
- [x] Verify no regressions in sccache download logic or rust toolchain setup

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/19f8a185-bc4b-4485-a8a8-cad14492ba12

## Summary by Sourcery

Pin the shared setup-rust GitHub Action to a new release that resolves sccache download issues on macOS runners.

CI:
- Update the rust-build-release workflow to reference the latest setup-rust action commit compatible with macOS sccache pinning.

Documentation:
- Extend the setup-rust action changelog with a v1.0.14 entry describing the sccache pin to v0.12.0 for macOS x86_64 runners.