### PR TITLE
Install cargo-llvm-cov with cargo-binstall (versioned)

### DIFF
--- a/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py
@@ -3,25 +3,43 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
-"""Install the cargo-llvm-cov tool via ``cargo install``."""
+"""Install cargo-llvm-cov via cargo-binstall."""
+
+from __future__ import annotations
 
 import typer
 from cmd_utils_loader import run_cmd
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
+# Keep CARGO_LLVM_COV_VERSION in sync with security audits; update as needed.
+CARGO_LLVM_COV_VERSION = "0.6.24"
 
-def main() -> None:
-    """Install cargo-llvm-cov via cargo install command."""
+
+def install_cargo_llvm_cov() -> None:
+    """Install cargo-llvm-cov using cargo-binstall."""
     try:
-        cmd = cargo["install", "cargo-llvm-cov", "--force"]
+        cmd = cargo[
+            "binstall",
+            "cargo-llvm-cov",
+            "--version",
+            CARGO_LLVM_COV_VERSION,
+            "--no-confirm",
+            "--force",
+        ]
         run_cmd(cmd)
         typer.echo("cargo-llvm-cov installed successfully")
     except ProcessExecutionError as exc:
         typer.echo(
-            f"cargo install failed with code {exc.retcode}: {exc.stderr}", err=True
+            f"cargo binstall failed with code {exc.retcode}: {exc.stderr}",
+            err=True,
         )
         raise typer.Exit(code=exc.retcode or 1) from exc
+
+
+def main() -> None:
+    """Install cargo-llvm-cov via cargo-binstall."""
+    install_cargo_llvm_cov()
 
 
 if __name__ == "__main__":

--- a/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
+++ b/.github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py
@@ -3,7 +3,9 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
-"""Install the cargo-llvm-cov tool via ``cargo install``."""
+"""Install cargo-llvm-cov via cargo-binstall."""
+
+from __future__ import annotations
 
 import typer
 from plumbum.cmd import cargo
@@ -13,18 +15,34 @@ from cmd_utils_importer import import_cmd_utils
 
 run_cmd = import_cmd_utils().run_cmd
 
+# Keep CARGO_LLVM_COV_VERSION in sync with security audits; update as needed.
+CARGO_LLVM_COV_VERSION = "0.6.24"
 
-def main() -> None:
-    """Install cargo-llvm-cov via cargo install command."""
+
+def install_cargo_llvm_cov() -> None:
+    """Install cargo-llvm-cov using cargo-binstall."""
     try:
-        cmd = cargo["install", "cargo-llvm-cov", "--force"]
+        cmd = cargo[
+            "binstall",
+            "cargo-llvm-cov",
+            "--version",
+            CARGO_LLVM_COV_VERSION,
+            "--no-confirm",
+            "--force",
+        ]
         run_cmd(cmd)
         typer.echo("cargo-llvm-cov installed successfully")
     except ProcessExecutionError as exc:
         typer.echo(
-            f"cargo install failed with code {exc.retcode}: {exc.stderr}", err=True
+            f"cargo binstall failed with code {exc.retcode}: {exc.stderr}",
+            err=True,
         )
         raise typer.Exit(code=exc.retcode or 1) from exc
+
+
+def main() -> None:
+    """Install cargo-llvm-cov via cargo-binstall."""
+    install_cargo_llvm_cov()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Install cargo-llvm-cov via cargo-binstall with a pinned version to align audits.
- Pin version using CARGO_LLVM_COV_VERSION to keep audits aligned.
- Update error messaging to reflect cargo binstall failures.
- Apply the same changes to both coverage and ratchet-coverage installation scripts.

## Changes
### Script
- .github/actions/generate-coverage/scripts/install_cargo_llvm_cov.py:
  - Switch to cargo binstall command with flags
  - Add CARGO_LLVM_COV_VERSION = "0.6.24"
  - Rename function to install_cargo_llvm_cov, adjust main
  - Update exception handling to mention cargo binstall
- .github/actions/ratchet-coverage/scripts/install_cargo_llvm_cov.py:
  - Apply identical changes to use cargo-binstall with pinned version and updated error messaging

### Behavior
- Behavior remains the same: prints success, raises on error.

### Why
- Align with security audits and binary distribution practices; using cargo-binstall improves reproducibility.

### Test plan
- [x] Run coverage install script to install and verify cargo-llvm-cov version 0.6.24
- [x] Ensure cargo-llvm-cov available in PATH
- [x] Simulate install failure to validate error message
- [x] Run ratchet-coverage install script similarly to verify parity

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a543703c-6b8c-462f-b51d-e8cfcc28d254

## Summary by Sourcery

Install cargo-llvm-cov via cargo-binstall with a pinned version for reproducible coverage tooling in CI.

Enhancements:
- Refactor the cargo-llvm-cov installation script to use cargo-binstall instead of cargo install with clearer error messaging.

Build:
- Pin the cargo-llvm-cov binary version via CARGO_LLVM_COV_VERSION for consistent coverage tooling across environments.