### PR TITLE
Fix dependabot-automerge workflow: correct workspace handling

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -40,9 +40,10 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           set -euo pipefail
+          workspace="${GITHUB_WORKSPACE:-$PWD}"
           if [[ "${ACT:-}" == "true" ]]; then
             echo "checkout=false" >> "${GITHUB_OUTPUT}"
-            echo "workflow_dir=${GITHUB_WORKSPACE}" >> "${GITHUB_OUTPUT}"
+            echo "workflow_dir=${workspace}" >> "${GITHUB_OUTPUT}"
             echo "repo=${REPO}" >> "${GITHUB_OUTPUT}"
             echo "ref=" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -55,7 +56,7 @@ jobs:
             ref="${REF}"
           fi
           echo "checkout=true" >> "${GITHUB_OUTPUT}"
-          echo "workflow_dir=workflow-src" >> "${GITHUB_OUTPUT}"
+          echo "workflow_dir=${workspace}/workflow-src" >> "${GITHUB_OUTPUT}"
           echo "repo=${repo}" >> "${GITHUB_OUTPUT}"
           echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
       - name: Checkout workflow repository
@@ -102,4 +103,4 @@ jobs:
             export UV_PROJECT_ENVIRONMENT="/tmp/uv-project"
             export UV_CACHE_DIR="/tmp/uv-cache"
           fi
-          uv run "${{ steps.workflow-source.outputs.workflow_dir }}/workflow_scripts/dependabot_automerge.py"
+          uv run --script "${{ steps.workflow-source.outputs.workflow_dir }}/workflow_scripts/dependabot_automerge.py"


### PR DESCRIPTION
## Summary
- Fix incorrect workspace handling and execution path in dependabot-automerge workflow to prevent errors when automerging Dependabot PRs.

## Changes

### Workflow Fixes
- Introduced workspace variable: `workspace="${GITHUB_WORKSPACE:-$PWD}"`
- When `ACT` is true:
  - output `workflow_dir` now uses the workspace variable instead of `GITHUB_WORKSPACE`
  - `repo` and `ref` outputs remain unchanged
- When `ACT` is not true:
  - `workflow_dir` now outputs `${workspace}/workflow-src` instead of `workflow-src`
- Ensure end-of-file newline for YAML consistency

### Execution Command
- Use: `uv run --script "${{ steps.workflow-source.outputs.workflow_dir }}/workflow_scripts/dependabot_automerge.py"` to explicitly execute the script

### Output Path Adjustments
- All references to `workflow_dir` and `workflow-src` corrected to reflect the actual workspace path

## Test plan
- CI validation:
  - Trigger on dependabot PRs to verify automerge; ensure no errors due to workspace path
- Local validation (simulate ACT true/false):
  - ACT=true: verify `workflow_dir` points to the correct workspace path
  - ACT=false: verify `workflow_dir` points to `${workspace}/workflow-src`
  - Confirm the script invocation uses `--script` with the correct path to `dependabot_automerge.py`

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0d36fdad-9032-439c-a51c-d93930fe4ac0

## Summary by Sourcery

CI:
- Adjust dependabot-automerge workflow outputs to derive workflow directory from a resolved workspace path for ACT and non-ACT runs.