### PR TITLE
Fix read-only attribute setting in rust-build-release

### DIFF
--- a/.github/actions/rust-build-release/tests/test_command_wrapper.py
+++ b/.github/actions/rust-build-release/tests/test_command_wrapper.py
@@ -1,0 +1,60 @@
+"""Tests for command wrapper formatting."""
+
+from __future__ import annotations
+
+import shlex
+import typing as typ
+from pathlib import Path
+
+if typ.TYPE_CHECKING:
+    from types import ModuleType
+
+
+class _DummyCommand:
+    def __init__(self, parts: list[object]) -> None:
+        self._parts = parts
+
+    def formulate(self) -> list[object]:
+        return list(self._parts)
+
+
+def test_command_wrapper_str_uses_display_name(main_module: ModuleType) -> None:
+    """__str__ should reflect the display name and the formulated args."""
+    parts: list[object] = [Path("/usr/bin/cross"), "+1.89.0", "build"]
+    wrapper = main_module._CommandWrapper(_DummyCommand(parts), "cross")
+
+    expected = shlex.join(["cross", "+1.89.0", "build"])
+    assert str(wrapper) == expected
+
+
+def test_command_wrapper_str_quotes_special_characters(
+    main_module: ModuleType,
+) -> None:
+    """__str__ should quote parts that include spaces or shell characters."""
+    parts: list[object] = [
+        "/usr/bin/cargo",
+        "arg with space",
+        "semi;colon",
+        "weird$var",
+    ]
+    wrapper = main_module._CommandWrapper(_DummyCommand(parts), "cargo")
+
+    rendered = str(wrapper)
+    expected = shlex.join(["cargo", "arg with space", "semi;colon", "weird$var"])
+    assert rendered == expected
+    assert "'arg with space'" in rendered
+    assert "'semi;colon'" in rendered
+    assert "'weird$var'" in rendered
+
+
+def test_command_wrapper_str_coerces_non_string_parts(
+    main_module: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """__str__ should coerce non-string formulate values using str()."""
+    path = tmp_path / "path with space" / "bin"
+    parts: list[object] = [path, Path("nested dir/file.txt"), 42]
+    wrapper = main_module._CommandWrapper(_DummyCommand(parts), "run")
+
+    expected = shlex.join([str(value) for value in ["run", *parts[1:]]])
+    assert str(wrapper) == expected

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -260,7 +260,7 @@ def test_builds_freebsd_target_with_cross_and_container(
     assert Path(commands[-1][0]).name == "cross"
     captured = capsys.readouterr()
     _assert_no_timeout_trace(captured.err)
-    assert "::warning:: failed to set display override" in captured.err
+    assert "::warning:: failed to set display override" not in captured.err
 
 
 @CMD_MOX_UNSUPPORTED


### PR DESCRIPTION
## Summary
- Remove mutation of a read-only attribute on command objects within the rust-build-release action
- Introduce a clean string representation for commands via __str__ and shlex.join
- Align tests to expect no display override warnings
- Add tests for CommandWrapper.__str__ behavior to ensure proper quoting and coercion of non-string parts

## Changes
- .github/actions/rust-build-release/src/main.py
  - Remove the override logic that attempted to set command.formulate to a display name
  - Add __str__ method to _CommandWrapper to return a properly quoted shell string using shlex.join
- .github/actions/rust-build-release/tests/test_command_wrapper.py
  - New: Tests for CommandWrapper.__str__ formatting
- .github/actions/rust-build-release/tests/test_target_install.py
  - Update test_builds_freebsd_target_with_cross_and_container to assert that the display override warning is not emitted

## Why
- Mutating read-only attributes is brittle and can fail; avoid it
- Provides a reliable string representation of commands without mutating underlying objects
- Adds tests to verify __str__ behavior and absence of warnings

## Testing
- Run the rust-build-release test suite (pytest) to ensure all tests pass
- Verify logs no longer contain the ::warning:: failed to set display override message

## Notes
- No public API changes; the observable behavior of command execution remains unchanged

🌿 Generated by [Terry](https://www.terragonlabs.com)

---
ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/807f2133-6d23-43fb-81ae-81dd23e246ac

## Summary by Sourcery
- Avoid mutating read-only command attributes in the rust-build-release action and provide a stable string representation for wrapped commands.
- Bug Fixes:
  - Stop attempting to override the underlying command's formulate attribute, preventing warnings and potential failures when the attribute is read-only.
- Enhancements:
  - Add a __str__ implementation to the command wrapper that returns a properly quoted shell string using shlex.join.
- Tests:
  - Update rust-build-release target install tests to assert that display override warnings are no longer emitted.