### PR TITLE
Fix Dependabot automerge checkout with SHA ref, debug, and validation

### DIFF
--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import collections.abc as cabc
+import dataclasses
 import importlib
 import importlib.util
 import shutil
 import sys
 import typing as typ
-from dataclasses import dataclass  # noqa: ICN003
 from pathlib import Path
 
 import pytest
@@ -368,7 +368,7 @@ def _get_installed_toolchains(
     return [line.split()[0] for line in stdout.splitlines() if line.strip()]
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class ToolchainSpec:
     """Specification for a Rust toolchain installation."""
 

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -334,10 +334,14 @@ def ensure_toolchain_ready() -> cabc.Callable[[str, str], None]:
         if not Path(rustup_path).is_file():
             pytest.skip(f"rustup missing at resolved path: {rustup_path}")
         rustup_bin = Path(rustup_path).resolve()
+        if len(rustup_bin.parents) < 2:
+            pytest.skip(f"rustup path lacks expected parents: {rustup_bin}")
         cargo_home = rustup_bin.parents[1]
         if not cargo_home.is_dir():
             pytest.skip(f"cargo home missing for rustup: {cargo_home}")
         rustup_home = cargo_home.parent / ".rustup"
+        if not rustup_home.is_dir():
+            pytest.skip(f"rustup home missing for rustup: {rustup_home}")
         rustup_env = {
             "CARGO_HOME": str(cargo_home),
             "RUSTUP_HOME": str(rustup_home),

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -335,19 +335,18 @@ def _validate_rustup_binary(rustup_path: str | None) -> Path:
     return rustup_bin
 
 
-def _setup_rust_environment(rustup_bin: Path) -> tuple[Path, Path, dict[str, str]]:
-    """Return cargo/rustup paths and a runtime environment mapping."""
+def _setup_rust_environment(rustup_bin: Path) -> dict[str, str]:
+    """Return a runtime environment mapping for rustup."""
     cargo_home = rustup_bin.parents[1]
     if not cargo_home.is_dir():
         pytest.skip(f"cargo home missing for rustup: {cargo_home}")
     rustup_home = cargo_home.parent / ".rustup"
     if not rustup_home.is_dir():
         pytest.skip(f"rustup home missing for rustup: {rustup_home}")
-    rustup_env = {
+    return {
         "CARGO_HOME": str(cargo_home),
         "RUSTUP_HOME": str(rustup_home),
     }
-    return cargo_home, rustup_home, rustup_env
 
 
 def _get_installed_toolchains(
@@ -406,7 +405,7 @@ def ensure_toolchain_ready() -> cabc.Callable[[str, str], None]:
     def _ensure(toolchain_version: str, host_target: str) -> None:
         rustup_path = shutil.which("rustup")
         rustup_bin = _validate_rustup_binary(rustup_path)
-        _, _, rustup_env = _setup_rust_environment(rustup_bin)
+        rustup_env = _setup_rust_environment(rustup_bin)
         installed_names = _get_installed_toolchains(rustup_bin.as_posix(), rustup_env)
         _install_toolchain_if_needed(
             rustup_path=rustup_bin.as_posix(),

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -323,63 +323,98 @@ def patch_common_main_deps(
     return harness
 
 
+def _validate_rustup_binary(rustup_path: str | None) -> Path:
+    """Validate and return the resolved rustup binary path."""
+    if rustup_path is None:  # pragma: no cover - guarded by caller checks
+        pytest.skip("rustup not installed")
+    if not Path(rustup_path).is_file():
+        pytest.skip(f"rustup missing at resolved path: {rustup_path}")
+    rustup_bin = Path(rustup_path).resolve()
+    if len(rustup_bin.parents) < 2:
+        pytest.skip(f"rustup path lacks expected parents: {rustup_bin}")
+    return rustup_bin
+
+
+def _setup_rust_environment(rustup_bin: Path) -> tuple[Path, Path, dict[str, str]]:
+    """Return cargo/rustup paths and a runtime environment mapping."""
+    cargo_home = rustup_bin.parents[1]
+    if not cargo_home.is_dir():
+        pytest.skip(f"cargo home missing for rustup: {cargo_home}")
+    rustup_home = cargo_home.parent / ".rustup"
+    if not rustup_home.is_dir():
+        pytest.skip(f"rustup home missing for rustup: {rustup_home}")
+    rustup_env = {
+        "CARGO_HOME": str(cargo_home),
+        "RUSTUP_HOME": str(rustup_home),
+    }
+    return cargo_home, rustup_home, rustup_env
+
+
+def _get_installed_toolchains(
+    rustup_path: str, rustup_env: dict[str, str]
+) -> list[str]:
+    """Return installed toolchain names from rustup."""
+    try:
+        _, stdout, _ = typ.cast(
+            "tuple[int, str, str]",
+            run_cmd(
+                local[rustup_path]["toolchain", "list"],
+                method="run",
+                env=rustup_env,
+            ),
+        )
+    except (OSError, ProcessExecutionError) as exc:  # pragma: no cover - env guard
+        pytest.skip(f"rustup unavailable on runner: {exc}")
+    return [line.split()[0] for line in stdout.splitlines() if line.strip()]
+
+
+def _install_toolchain_if_needed(
+    *,
+    rustup_path: str,
+    rustup_env: dict[str, str],
+    toolchain_version: str,
+    host_target: str,
+    installed_names: cabc.Sequence[str],
+) -> None:
+    """Install the requested toolchain when it is missing."""
+    expected = {
+        toolchain_version,
+        f"{toolchain_version}-{host_target}",
+    }
+    if all(name not in expected for name in installed_names):
+        install_spec = (
+            f"{toolchain_version}-{host_target}"
+            if sys.platform == "win32" and host_target.endswith("-pc-windows-gnu")
+            else toolchain_version
+        )
+        run_cmd(
+            local[rustup_path][
+                "toolchain",
+                "install",
+                install_spec,
+                "--profile",
+                "minimal",
+            ],
+            env=rustup_env,
+        )
+
+
 @pytest.fixture
 def ensure_toolchain_ready() -> cabc.Callable[[str, str], None]:
     """Return a helper that ensures the requested toolchain is installed."""
 
     def _ensure(toolchain_version: str, host_target: str) -> None:
         rustup_path = shutil.which("rustup")
-        if rustup_path is None:  # pragma: no cover - guarded by caller checks
-            pytest.skip("rustup not installed")
-        if not Path(rustup_path).is_file():
-            pytest.skip(f"rustup missing at resolved path: {rustup_path}")
-        rustup_bin = Path(rustup_path).resolve()
-        if len(rustup_bin.parents) < 2:
-            pytest.skip(f"rustup path lacks expected parents: {rustup_bin}")
-        cargo_home = rustup_bin.parents[1]
-        if not cargo_home.is_dir():
-            pytest.skip(f"cargo home missing for rustup: {cargo_home}")
-        rustup_home = cargo_home.parent / ".rustup"
-        if not rustup_home.is_dir():
-            pytest.skip(f"rustup home missing for rustup: {rustup_home}")
-        rustup_env = {
-            "CARGO_HOME": str(cargo_home),
-            "RUSTUP_HOME": str(rustup_home),
-        }
-        try:
-            _, stdout, _ = typ.cast(
-                "tuple[int, str, str]",
-                run_cmd(
-                    local[rustup_path]["toolchain", "list"],
-                    method="run",
-                    env=rustup_env,
-                ),
-            )
-        except (OSError, ProcessExecutionError) as exc:  # pragma: no cover - env guard
-            pytest.skip(f"rustup unavailable on runner: {exc}")
-        installed_names = [
-            line.split()[0] for line in stdout.splitlines() if line.strip()
-        ]
-        expected = {
-            toolchain_version,
-            f"{toolchain_version}-{host_target}",
-        }
-        if all(name not in expected for name in installed_names):
-            install_spec = (
-                f"{toolchain_version}-{host_target}"
-                if sys.platform == "win32" and host_target.endswith("-pc-windows-gnu")
-                else toolchain_version
-            )
-            run_cmd(
-                local[rustup_path][
-                    "toolchain",
-                    "install",
-                    install_spec,
-                    "--profile",
-                    "minimal",
-                ],
-                env=rustup_env,
-            )
+        rustup_bin = _validate_rustup_binary(rustup_path)
+        _, _, rustup_env = _setup_rust_environment(rustup_bin)
+        installed_names = _get_installed_toolchains(rustup_bin.as_posix(), rustup_env)
+        _install_toolchain_if_needed(
+            rustup_path=rustup_bin.as_posix(),
+            rustup_env=rustup_env,
+            toolchain_version=toolchain_version,
+            host_target=host_target,
+            installed_names=installed_names,
+        )
 
     return _ensure
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,6 +36,7 @@ jobs:
         shell: bash
         env:
           WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
           REPO: ${{ github.repository }}
           REF: ${{ github.ref }}
         run: |
@@ -48,7 +49,10 @@ jobs:
             echo "ref=" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          if [[ -n "${WORKFLOW_REF}" ]]; then
+          if [[ -n "${WORKFLOW_SHA}" ]]; then
+            repo="${WORKFLOW_REF%%/.github/workflows/*}"
+            ref="${WORKFLOW_SHA}"
+          elif [[ -n "${WORKFLOW_REF}" ]]; then
             repo="${WORKFLOW_REF%%/.github/workflows/*}"
             ref="${WORKFLOW_REF##*@}"
           else
@@ -59,6 +63,13 @@ jobs:
           echo "workflow_dir=${workspace}/workflow-src" >> "${GITHUB_OUTPUT}"
           echo "repo=${repo}" >> "${GITHUB_OUTPUT}"
           echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+      - name: Debug workflow source
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "workflow repo: ${{ steps.workflow-source.outputs.repo }}"
+          echo "workflow ref: ${{ steps.workflow-source.outputs.ref }}"
+          echo "workflow dir: ${{ steps.workflow-source.outputs.workflow_dir }}"
       - name: Checkout workflow repository
         if: ${{ steps.workflow-source.outputs.checkout == 'true' }}
         # v4
@@ -67,7 +78,19 @@ jobs:
           repository: ${{ steps.workflow-source.outputs.repo }}
           ref: ${{ steps.workflow-source.outputs.ref }}
           path: workflow-src
-          fetch-depth: 1
+          fetch-depth: 0
+      - name: Verify workflow checkout
+        if: ${{ steps.workflow-source.outputs.checkout == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script_path="workflow-src/workflow_scripts/dependabot_automerge.py"
+          if [[ ! -f "${script_path}" ]]; then
+            echo "Missing ${script_path} after checkout."
+            echo "workflow-src contents:"
+            ls -la workflow-src
+            exit 1
+          fi
       - name: Install uv (act)
         if: ${{ env.ACT == 'true' }}
         shell: bash

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -50,7 +50,13 @@ jobs:
             exit 0
           fi
           if [[ -n "${WORKFLOW_SHA}" ]]; then
-            repo="${WORKFLOW_REF%%/.github/workflows/*}"
+            repo="${REPO}"
+            if [[ -n "${WORKFLOW_REF}" && "${WORKFLOW_REF}" == */.github/workflows/*@* ]]; then
+              parsed_repo="${WORKFLOW_REF%%/.github/workflows/*}"
+              if [[ -n "${parsed_repo}" ]]; then
+                repo="${parsed_repo}"
+              fi
+            fi
             ref="${WORKFLOW_SHA}"
           elif [[ -n "${WORKFLOW_REF}" ]]; then
             repo="${WORKFLOW_REF%%/.github/workflows/*}"
@@ -78,7 +84,7 @@ jobs:
           repository: ${{ steps.workflow-source.outputs.repo }}
           ref: ${{ steps.workflow-source.outputs.ref }}
           path: workflow-src
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Verify workflow checkout
         if: ${{ steps.workflow-source.outputs.checkout == 'true' }}
         shell: bash

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -84,11 +84,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          script_path="workflow-src/workflow_scripts/dependabot_automerge.py"
+          workflow_dir="${{ steps.workflow-source.outputs.workflow_dir }}"
+          script_path="${workflow_dir}/workflow_scripts/dependabot_automerge.py"
           if [[ ! -f "${script_path}" ]]; then
             echo "Missing ${script_path} after checkout."
-            echo "workflow-src contents:"
-            ls -la workflow-src
+            echo "Checked-out commit:"
+            git -C "${workflow_dir}" rev-parse HEAD
+            echo "Workflow directory contents:"
+            ls -la "${workflow_dir}"
             exit 1
           fi
       - name: Install uv (act)

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -98,6 +98,11 @@ jobs:
             git -C "${workflow_dir}" rev-parse HEAD
             echo "Workflow directory contents:"
             ls -la "${workflow_dir}"
+            workflow_scripts_dir="${workflow_dir}/workflow_scripts"
+            if [[ -d "${workflow_scripts_dir}" ]]; then
+              echo "Workflow scripts contents:"
+              ls -la "${workflow_scripts_dir}"
+            fi
             exit 1
           fi
       - name: Install uv (act)


### PR DESCRIPTION
## Summary
- Fixes a Dependabot automerge checkout failure by using the workflow SHA-based ref when available and deriving repo/ref accordingly.
- Adds debugging of workflow source and a verification step to ensure the workflow script exists after checkout.
- Updates Rust CI test harness to support rustup-based environment validation in CI.

## Changes
### Workflow changes
- Introduced WORKFLOW_SHA environment variable into the automerge workflow and updated logic to prefer SHA-based ref fetching when available.
- Derive repo and ref from WORKFLOW_SHA or WORKFLOW_REF accordingly.
- Use fetch-depth: 1 for the workflow repository checkout.
- Added a debugging step to print workflow source details (repo, ref, dir).
- Added a verification step to ensure workflow-src/workflow_scripts/dependabot_automerge.py exists after checkout; lists contents on failure.

### Tests changes
- Updated Rust CI test harness in .github/actions/rust-build-release/tests/conftest.py to better validate rustup/toolchain readiness on CI.
- Added helpers to validate rustup binary, set up environment, query installed toolchains, and install missing toolchains as needed.
- Refactored ensure_toolchain_ready fixture to use the new helpers, ensuring the requested toolchain is installed when running tests.

### Why
- Dependabot automerge previously failed to locate the workflow script due to an incomplete checkout or incorrect ref resolution when triggered via workflow ref.
- The tests were extended to ensure CI environments reliably prepare the Rust toolchain, reducing flaky test outcomes due to missing toolchains.

## Validation plan
- [ ] Run Dependabot automerge workflow on a test PR to verify it checks out the correct workflow source using SHA when available.
- [ ] Verify that the script workflow-src/workflow_scripts/dependabot_automerge.py exists after checkout.
- [ ] Check logs show the workflow repo/ref/dir and no missing file errors.
- [ ] Ensure CI Rust toolchains are installed as needed during tests (no missing toolchain errors).

## Notes
- No changes to public API or runtime behavior outside the automerge workflow logic.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/0455885c-4778-4173-a42d-cc72db30cbcd

📝 Closes #241

## Summary by Sourcery
- Improve Dependabot automerge workflow reliability by ensuring the correct workflow repository ref is checked out and the automerge script is present before running.
- Now prefers the workflow SHA-based ref when available and provides debugging output during checkout.