### PR TITLE
Support both Dependabot logins for auto-merge

### DIFF
--- a/docs/dependabot-automerge-workflow.md
+++ b/docs/dependabot-automerge-workflow.md
@@ -8,12 +8,16 @@ uses a Cyclopts-based Python helper that reads `INPUT_*` environment variables.
 
 The helper script only enables auto-merge when all of the following are true:
 
-- The pull request author is `dependabot[bot]`.
+- The pull request author is `dependabot[bot]` or `dependabot`.
 - The pull request is not marked as a draft.
 - The required label (default `dependencies`) is present.
 
 If any rule fails, the workflow logs an `automerge_status=skipped` entry with a
 reason and exits successfully.
+
+Note: The helper reads `DEPENDABOT_LOGINS` (defined in
+`workflow_scripts/dependabot_automerge.py`) to support both author login variants
+across platforms.
 
 ## Required permissions
 
@@ -61,6 +65,8 @@ jobs:
       # pinned commit, rather than accidentally resolving to the caller repo via `github.workflow_*`.
       # The token is not used for any external cloud auth.
       id-token: write
+    # The caller can filter on dependabot[bot] to reduce noise; the reusable
+    # workflow still validates eligibility via DEPENDABOT_LOGINS.
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
     uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@9d4c046f2788decc264847622b830e2a4d35b91f
     with:

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -380,9 +380,6 @@ def _evaluate(pr: PullRequestContext, required_label: str | None) -> Decision:
     :data:`DEPENDABOT_LOGINS` is the canonical source of eligible Dependabot
     author logins used by this evaluation.
 
-    Update checklist
-    ---------------
-    - [x] Document the Dependabot author variants and DEPENDABOT_LOGINS.
     """
     if pr.author not in DEPENDABOT_LOGINS:
         return Decision(status="skipped", reason="author-not-dependabot")

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -78,13 +78,21 @@ else:
 
 
 class DependabotLogin(enum.StrEnum):
-    """Supported Dependabot author login variants."""
+    """Supported Dependabot author login variants.
+
+    Attributes
+    ----------
+    BOT : DependabotLogin
+        The canonical Dependabot bot login (``dependabot[bot]``).
+    LEGACY : DependabotLogin
+        The legacy Dependabot login (``dependabot``).
+    """
 
     BOT = "dependabot[bot]"
     LEGACY = "dependabot"
 
 
-DEPENDABOT_LOGINS = frozenset(login.value for login in DependabotLogin)
+DEPENDABOT_LOGINS: frozenset[str] = frozenset(login.value for login in DependabotLogin)
 
 MERGE_METHODS = {
     "merge": "MERGE",

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -58,6 +58,7 @@ main : The CLI entrypoint function.
 from __future__ import annotations
 
 import dataclasses
+import enum
 import json
 import os
 import typing as typ
@@ -75,7 +76,15 @@ else:
     )
     from output import emit, fail  # type: ignore[import-not-found,no-redef]
 
-DEPENDABOT_LOGINS = {"dependabot[bot]", "dependabot"}
+
+class DependabotLogin(enum.StrEnum):
+    """Supported Dependabot author login variants."""
+
+    BOT = "dependabot[bot]"
+    LEGACY = "dependabot"
+
+
+DEPENDABOT_LOGINS = frozenset(login.value for login in DependabotLogin)
 
 MERGE_METHODS = {
     "merge": "MERGE",
@@ -340,7 +349,14 @@ def _snapshot_from_event(
 
 
 def _evaluate(pr: PullRequestContext, required_label: str | None) -> Decision:
-    """Evaluate a PR against eligibility rules and return a Decision."""
+    """Evaluate a PR against eligibility rules and return a Decision.
+
+    Dependabot eligibility accepts authors ``dependabot[bot]`` and
+    ``dependabot`` as defined by :data:`DEPENDABOT_LOGINS`.
+
+    Update checklist:
+        - [x] Document the Dependabot author variants and DEPENDABOT_LOGINS.
+    """
     if pr.author not in DEPENDABOT_LOGINS:
         return Decision(status="skipped", reason="author-not-dependabot")
     if pr.is_draft:

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -14,7 +14,7 @@ Eligibility Rules
 -----------------
 Auto-merge is enabled only when all conditions are met:
 
-- The PR author is ``dependabot[bot]``
+- The PR author is ``dependabot[bot]`` or ``dependabot``
 - The PR is not a draft
 - The required label (default: ``dependencies``) is present
 
@@ -75,7 +75,7 @@ else:
     )
     from output import emit, fail  # type: ignore[import-not-found,no-redef]
 
-DEPENDABOT_LOGIN = "dependabot[bot]"
+DEPENDABOT_LOGINS = {"dependabot[bot]", "dependabot"}
 
 MERGE_METHODS = {
     "merge": "MERGE",
@@ -341,7 +341,7 @@ def _snapshot_from_event(
 
 def _evaluate(pr: PullRequestContext, required_label: str | None) -> Decision:
     """Evaluate a PR against eligibility rules and return a Decision."""
-    if pr.author != DEPENDABOT_LOGIN:
+    if pr.author not in DEPENDABOT_LOGINS:
         return Decision(status="skipped", reason="author-not-dependabot")
     if pr.is_draft:
         return Decision(status="skipped", reason="draft-pr")

--- a/workflow_scripts/dependabot_automerge.py
+++ b/workflow_scripts/dependabot_automerge.py
@@ -360,10 +360,29 @@ def _evaluate(pr: PullRequestContext, required_label: str | None) -> Decision:
     """Evaluate a PR against eligibility rules and return a Decision.
 
     Dependabot eligibility accepts authors ``dependabot[bot]`` and
-    ``dependabot`` as defined by :data:`DEPENDABOT_LOGINS`.
+    ``dependabot`` as defined by :data:`DEPENDABOT_LOGINS`, which includes both
+    author variants.
 
-    Update checklist:
-        - [x] Document the Dependabot author variants and DEPENDABOT_LOGINS.
+    Parameters
+    ----------
+    pr : PullRequestContext
+        Snapshot of pull request metadata used for eligibility checks.
+    required_label : str or None
+        Label that must be present on the PR, or None to skip label checks.
+
+    Returns
+    -------
+    Decision
+        Outcome indicating whether auto-merge should proceed.
+
+    Notes
+    -----
+    :data:`DEPENDABOT_LOGINS` is the canonical source of eligible Dependabot
+    author logins used by this evaluation.
+
+    Update checklist
+    ---------------
+    - [x] Document the Dependabot author variants and DEPENDABOT_LOGINS.
     """
     if pr.author not in DEPENDABOT_LOGINS:
         return Decision(status="skipped", reason="author-not-dependabot")

--- a/workflow_scripts/tests/test_dependabot_automerge.py
+++ b/workflow_scripts/tests/test_dependabot_automerge.py
@@ -324,17 +324,19 @@ def test_dry_run_requires_event_payload(
     )
 
 
+@pytest.mark.parametrize("login", ["dependabot[bot]", "dependabot"])
 def test_dry_run_eligible_dependabot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    login: str,
 ) -> None:
     """Eligible Dependabot PRs log dry-run readiness."""
     event = {
         "pull_request": {
             "number": 9,
             "draft": False,
-            "user": {"login": "dependabot[bot]"},
+            "user": {"login": login},
             "labels": [{"name": "dependencies"}],
         },
         "repository": {"full_name": "acme/example"},


### PR DESCRIPTION
## Summary
- Extend auto-merge eligibility to recognize Dependabot PRs from both dependabot[bot] and dependabot
- Align tests to cover both login variants

## Changes

### Core logic
- In `workflow_scripts/dependabot_automerge.py`:
  - Introduced `DEPENDABOT_LOGINS = {"dependabot[bot]", "dependabot"}`
  - Updated eligibility check to verify `pr.author` is in `DEPENDABOT_LOGINS` (not a strict single string)

### Tests
- In `workflow_scripts/tests/test_dependabot_automerge.py`:
  - Parametrize `test_dry_run_eligible_dependabot` with login values `["dependabot[bot]", "dependabot"]`
  - PR event now uses login from the parameter

## Why
- Dependabot identities can vary across platforms/versions. Previously only `dependabot[bot]` was recognized, causing some PRs to be skipped. This change ensures both identities are treated as eligible for auto-merge.

## How to test
- Run the workflow script tests:
  - `pytest workflow_scripts/tests/test_dependabot_automerge.py`
- Specifically verify `test_dry_run_eligible_dependabot` passes for both logins
- Confirm dry-run output indicates readiness for eligible Dependabot PRs with either login

## Risk and Compatibility
- Low risk: preserves existing behavior for `dependabot[bot]` and extends support to `dependabot`.
- No breaking changes for non-Dependabot PRs; they remain unaffected by the login union.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/9491d738-6cba-48c7-ab2e-1baba9ea36a0

## Summary by Sourcery

Extend Dependabot auto-merge eligibility to handle multiple possible bot login names.

Bug Fixes:
- Recognize Dependabot PRs authored by either `dependabot[bot]` or `dependabot` so eligible PRs are no longer skipped.

Tests:
- Parametrize Dependabot dry-run eligibility test to cover both supported Dependabot login variants.