### PR TITLE
Add cargo-manifest input and --manifest-path wiring for coverage

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.3.12 (2026-02-18)
+
+- Add optional `cargo-manifest` input for repositories where `Cargo.toml`
+  lives outside the repository root.
+- Detect Rust projects using root `Cargo.toml` first, then fall back to
+  `cargo-manifest` when provided and present.
+- Pass `--manifest-path <selected-manifest>` to `cargo llvm-cov` runs.
+
 ## v1.3.11 (2026-01-12)
 
 - Add `use-cargo-nextest` input (default true) and run Rust coverage via

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -5,7 +5,7 @@ Run coverage for Rust, Python, or mixed Rust+Python projects.
 Run code coverage for Rust projects, Python projects, and mixed Rust + Python
 projects. The action uses `cargo llvm-cov` (with `cargo nextest` by default)
 when a `Cargo.toml` is present and `slipcover` with `pytest` when a
-`pyproject.toml` is present. If your repository root does not contain a Cargo
+`pyproject.toml` is present. If the repository root does not contain a Cargo
 manifest, set `cargo-manifest` to point to a nested `Cargo.toml`. It installs
 `slipcover` and `pytest` automatically via `uv` before running the tests,
 leveraging ``uv run --with`` so no system-level Python installs are required.

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -5,12 +5,14 @@ Run coverage for Rust, Python, or mixed Rust+Python projects.
 Run code coverage for Rust projects, Python projects, and mixed Rust + Python
 projects. The action uses `cargo llvm-cov` (with `cargo nextest` by default)
 when a `Cargo.toml` is present and `slipcover` with `pytest` when a
-`pyproject.toml` is present. It installs `slipcover` and `pytest` automatically
-via `uv` before running the tests, leveraging ``uv run --with`` so no
-system-level Python installs are required. When Rust coverage is required,
-`cargo-llvm-cov` and `cargo-nextest` are installed automatically. If both
-configuration files are present, coverage is run for each language and the
-Cobertura reports are merged using `uvx merge-cobertura`.
+`pyproject.toml` is present. If your repository root does not contain a Cargo
+manifest, set `cargo-manifest` to point to a nested `Cargo.toml`. It installs
+`slipcover` and `pytest` automatically via `uv` before running the tests,
+leveraging ``uv run --with`` so no system-level Python installs are required.
+When Rust coverage is required, `cargo-llvm-cov` and `cargo-nextest` are
+installed automatically. If both configuration files are present, coverage is
+run for each language and the Cobertura reports are merged using
+`uvx merge-cobertura`.
 
 ## Flow
 
@@ -39,6 +41,7 @@ flowchart TD
 | --- | --- | --- | --- |
 | features | Enable Cargo (Rust) features; space- or comma-separated. | no | |
 | with-default-features | Enable default Cargo features (Rust) | no | `true` |
+| cargo-manifest | Optional path to Cargo.toml if root Cargo.toml is missing | no | |
 | use-cargo-nextest | Use cargo-nextest for Rust coverage runs (default); set to `false` to use `cargo llvm-cov` directly | no | `true` |
 | output-path | Output file path | yes | |
 | format | Formats: `lcov`*, `cobertura`, `coveragepy`* | no | `cobertura` |
@@ -126,6 +129,15 @@ Disable cargo-nextest:
   with:
     output-path: coverage.xml
     use-cargo-nextest: false
+```
+
+Use a nested Cargo manifest:
+
+```yaml
+- uses: ./.github/actions/generate-coverage@v1
+  with:
+    output-path: coverage.xml
+    cargo-manifest: rust-toy-app/Cargo.toml
 ```
 
 The action prints the current coverage percentage to the log. When

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: Enable default features
     required: false
     default: "true"
+  cargo-manifest:
+    description: Optional path to Cargo.toml when the repository root has none
+    required: false
   use-cargo-nextest:
     description: Use cargo-nextest for Rust coverage runs
     required: false
@@ -72,6 +75,7 @@ runs:
       run: uv run --script "${{ github.action_path }}/scripts/detect.py"
       env:
         INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_CARGO_MANIFEST: ${{ inputs.cargo-manifest }}
       shell: bash
     - name: Restore baselines
       id: restore-baselines
@@ -162,6 +166,7 @@ runs:
       env:
         DETECTED_LANG: ${{ steps.detect.outputs.lang }}
         DETECTED_FMT: ${{ steps.detect.outputs.fmt }}
+        DETECTED_CARGO_MANIFEST: ${{ steps.detect.outputs.cargo_manifest }}
         INPUT_OUTPUT_PATH: ${{ inputs.output-path }}
         INPUT_FEATURES: ${{ inputs.features }}
         INPUT_WITH_DEFAULT_FEATURES: ${{ inputs.with-default-features }}

--- a/.github/actions/generate-coverage/scripts/detect.py
+++ b/.github/actions/generate-coverage/scripts/detect.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import enum
+import os
 from pathlib import Path
 
 import typer
@@ -37,14 +38,31 @@ FMT_OPT = typer.Option(
 GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 
 
-def get_lang() -> Lang:
-    """Detect whether the project is Rust, Python or mixed."""
-    cargo = Path("Cargo.toml").is_file()
+def _resolve_cargo_manifest(cargo_manifest: str) -> Path | None:
+    """Resolve the selected Cargo manifest with root precedence."""
+    root_manifest = Path("Cargo.toml")
+    if root_manifest.is_file():
+        return root_manifest
+
+    configured_manifest = cargo_manifest.strip()
+    if not configured_manifest:
+        return None
+
+    configured_path = Path(configured_manifest)
+    if configured_path.is_file():
+        return configured_path
+
+    return None
+
+
+def get_lang(cargo_manifest: str = "") -> tuple[Lang, Path | None]:
+    """Detect project language and selected Cargo manifest (if any)."""
+    selected_manifest = _resolve_cargo_manifest(cargo_manifest)
     python = Path("pyproject.toml").is_file()
-    if cargo:
-        return Lang.MIXED if python else Lang.RUST
+    if selected_manifest is not None:
+        return (Lang.MIXED if python else Lang.RUST), selected_manifest
     if python:
-        return Lang.PYTHON
+        return Lang.PYTHON, None
     typer.echo("Neither Cargo.toml nor pyproject.toml found", err=True)
     raise typer.Exit(code=1)
 
@@ -52,9 +70,12 @@ def get_lang() -> Lang:
 def main(
     fmt: str = FMT_OPT,
     github_output: Path = GITHUB_OUTPUT_OPT,
+    cargo_manifest: str = "",
 ) -> None:
     """Detect the project language and write it plus the format to ``GITHUB_OUTPUT``."""
-    lang = get_lang()
+    if not cargo_manifest:
+        cargo_manifest = os.getenv("INPUT_CARGO_MANIFEST", "")
+    lang, selected_manifest = get_lang(cargo_manifest)
     try:
         fmt_enum = CoverageFmt(fmt.lower())
     except ValueError as exc:
@@ -74,6 +95,8 @@ def main(
 
     with github_output.open("a") as fh:
         fh.write(f"lang={lang.value}\nfmt={fmt_enum.value}\n")
+        if selected_manifest is not None:
+            fh.write(f"cargo_manifest={selected_manifest}\n")
 
 
 if __name__ == "__main__":

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -80,6 +80,7 @@ WITH_DEFAULT_OPT = typer.Option(default=True, envvar="INPUT_WITH_DEFAULT_FEATURE
 USE_NEXTEST_OPT = typer.Option(default=True, envvar="INPUT_USE_CARGO_NEXTEST")
 LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
 FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
+MANIFEST_PATH_OPT = typer.Option(Path("Cargo.toml"), envvar="DETECTED_CARGO_MANIFEST")
 GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 CUCUMBER_RS_FEATURES_OPT = typer.Option("", envvar="INPUT_CUCUMBER_RS_FEATURES")
 CUCUMBER_RS_ARGS_OPT = typer.Option("", envvar="INPUT_CUCUMBER_RS_ARGS")
@@ -103,6 +104,7 @@ def get_cargo_coverage_cmd(
     out: Path,
     features: str,
     *,
+    manifest_path: Path,
     with_default: bool,
     use_nextest: bool,
 ) -> list[str]:
@@ -110,7 +112,7 @@ def get_cargo_coverage_cmd(
     args = ["llvm-cov"]
     if use_nextest:
         args.append("nextest")
-    args += ["--workspace", "--summary-only"]
+    args += ["--manifest-path", str(manifest_path), "--workspace", "--summary-only"]
     if not with_default:
         args.append("--no-default-features")
     if features:
@@ -382,6 +384,7 @@ def run_cucumber_rs_coverage(
     fmt: str,
     features: str,
     *,
+    manifest_path: Path,
     with_default: bool,
     use_nextest: bool,
     cucumber_rs_features: str,
@@ -393,6 +396,7 @@ def run_cucumber_rs_coverage(
         fmt,
         cucumber_file,
         features,
+        manifest_path=manifest_path,
         with_default=with_default,
         use_nextest=use_nextest,
     )
@@ -487,6 +491,7 @@ def main(
     use_nextest: bool = USE_NEXTEST_OPT,
     lang: str = LANG_OPT,
     fmt: str = FMT_OPT,
+    manifest_path: Path = MANIFEST_PATH_OPT,
     github_output: Path = GITHUB_OUTPUT_OPT,
     cucumber_rs_features: str = CUCUMBER_RS_FEATURES_OPT,
     cucumber_rs_args: str = CUCUMBER_RS_ARGS_OPT,
@@ -503,6 +508,7 @@ def main(
         fmt,
         out,
         features,
+        manifest_path=manifest_path,
         with_default=with_default,
         use_nextest=use_nextest,
     )
@@ -517,6 +523,7 @@ def main(
                 out,
                 fmt,
                 features,
+                manifest_path=manifest_path,
                 with_default=with_default,
                 use_nextest=use_nextest,
                 cucumber_rs_features=cucumber_rs_features,

--- a/.github/actions/generate-coverage/tests/test_detect.py
+++ b/.github/actions/generate-coverage/tests/test_detect.py
@@ -179,3 +179,33 @@ def test_detect_ignores_missing_input_manifest_for_python_project(
     detect.main("coveragepy", out, "missing/Cargo.toml")
 
     assert out.read_text() == "lang=python\nfmt=coveragepy\n"
+
+
+def test_detect_reads_manifest_from_env(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INPUT_CARGO_MANIFEST is used when no positional manifest is provided."""
+    _project_dir, out = setup_project({"rust-toy-app/Cargo.toml": ""})
+    monkeypatch.setenv("INPUT_CARGO_MANIFEST", "rust-toy-app/Cargo.toml")
+
+    detect.main("lcov", out)
+
+    assert (
+        out.read_text()
+        == "lang=rust\nfmt=lcov\ncargo_manifest=rust-toy-app/Cargo.toml\n"
+    )
+
+
+def test_detect_errors_when_only_missing_manifest_configured(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing configured manifest without Python/Rust roots should fail."""
+    _project_dir, out = setup_project()
+
+    with pytest.raises(detect.typer.Exit) as exc:
+        detect.main("lcov", out, "missing/Cargo.toml")
+
+    assert _exit_code(exc.value) == 1
+    assert "Neither Cargo.toml nor pyproject.toml found" in capsys.readouterr().err

--- a/.github/actions/generate-coverage/tests/test_detect.py
+++ b/.github/actions/generate-coverage/tests/test_detect.py
@@ -102,3 +102,77 @@ def test_detect_appends_to_malformed_output_file(
     detect.main("coveragepy", out)
 
     assert out.read_text() == "garbage\nnot=kv\nlang=python\nfmt=coveragepy\n"
+
+
+def test_detect_prefers_root_manifest_over_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root ``Cargo.toml`` takes precedence over input ``cargo-manifest``."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "Cargo.toml").write_text("")
+    nested_manifest = project_dir / "nested" / "Cargo.toml"
+    nested_manifest.parent.mkdir(parents=True, exist_ok=True)
+    nested_manifest.write_text("")
+    monkeypatch.chdir(project_dir)
+    out = project_dir / "gh.txt"
+
+    detect.main("lcov", out, "nested/Cargo.toml")
+
+    assert out.read_text() == "lang=rust\nfmt=lcov\ncargo_manifest=Cargo.toml\n"
+
+
+def test_detect_uses_input_manifest_when_root_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Configured manifest is used when root manifest is absent."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    nested_manifest = project_dir / "rust-toy-app" / "Cargo.toml"
+    nested_manifest.parent.mkdir(parents=True, exist_ok=True)
+    nested_manifest.write_text("")
+    monkeypatch.chdir(project_dir)
+    out = project_dir / "gh.txt"
+
+    detect.main("lcov", out, "rust-toy-app/Cargo.toml")
+
+    assert (
+        out.read_text()
+        == "lang=rust\nfmt=lcov\ncargo_manifest=rust-toy-app/Cargo.toml\n"
+    )
+
+
+def test_detect_uses_mixed_when_input_manifest_and_pyproject_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Input manifest plus root Python project yields mixed language."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    nested_manifest = project_dir / "crate" / "Cargo.toml"
+    nested_manifest.parent.mkdir(parents=True, exist_ok=True)
+    nested_manifest.write_text("")
+    (project_dir / "pyproject.toml").write_text("")
+    monkeypatch.chdir(project_dir)
+    out = project_dir / "gh.txt"
+
+    detect.main("cobertura", out, "crate/Cargo.toml")
+
+    assert (
+        out.read_text()
+        == "lang=mixed\nfmt=cobertura\ncargo_manifest=crate/Cargo.toml\n"
+    )
+
+
+def test_detect_ignores_missing_input_manifest_for_python_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing ``cargo-manifest`` keeps Python-only behaviour."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text("")
+    monkeypatch.chdir(project_dir)
+    out = project_dir / "gh.txt"
+
+    detect.main("coveragepy", out, "missing/Cargo.toml")
+
+    assert out.read_text() == "lang=python\nfmt=coveragepy\n"

--- a/.github/actions/generate-coverage/tests/test_detect.py
+++ b/.github/actions/generate-coverage/tests/test_detect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import typing as typ
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,36 @@ def _exit_code(exc: BaseException) -> int | None:
     if exit_code is None:
         exit_code = getattr(exc, "code", None)
     return exit_code
+
+
+@pytest.fixture
+def setup_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> typ.Callable[
+    [dict[str, str] | None, str | None],
+    tuple[Path, Path],
+]:
+    """Return a factory that creates a project directory and output file."""
+
+    def factory(
+        files: dict[str, str] | None = None,
+        initial_output: str | None = None,
+    ) -> tuple[Path, Path]:
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        for rel_path, content in (files or {}).items():
+            target = project_dir / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content)
+        monkeypatch.chdir(project_dir)
+        out = project_dir / "gh.txt"
+        if initial_output is None:
+            out.touch()
+        else:
+            out.write_text(initial_output)
+        return project_dir, out
+
+    return factory
 
 
 def test_invalid_format(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -58,14 +89,10 @@ def test_valid_formats(
 
 
 def test_detect_writes_output_for_empty_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Valid format writes language and format to an empty ``GITHUB_OUTPUT`` file."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / "pyproject.toml").write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
+    _project_dir, out = setup_project({"pyproject.toml": ""})
 
     detect.main("coveragepy", out)
 
@@ -73,15 +100,10 @@ def test_detect_writes_output_for_empty_file(
 
 
 def test_detect_appends_to_existing_output_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Existing ``GITHUB_OUTPUT`` contents are preserved when appending results."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / "pyproject.toml").write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
-    out.write_text("prev=1\n")
+    _project_dir, out = setup_project({"pyproject.toml": ""}, "prev=1\n")
 
     detect.main("coveragepy", out)
 
@@ -89,15 +111,10 @@ def test_detect_appends_to_existing_output_file(
 
 
 def test_detect_appends_to_malformed_output_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Pre-existing malformed output lines remain untouched when appending results."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / "pyproject.toml").write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
-    out.write_text("garbage\nnot=kv\n")
+    _project_dir, out = setup_project({"pyproject.toml": ""}, "garbage\nnot=kv\n")
 
     detect.main("coveragepy", out)
 
@@ -105,17 +122,15 @@ def test_detect_appends_to_malformed_output_file(
 
 
 def test_detect_prefers_root_manifest_over_input(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Root ``Cargo.toml`` takes precedence over input ``cargo-manifest``."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / "Cargo.toml").write_text("")
-    nested_manifest = project_dir / "nested" / "Cargo.toml"
-    nested_manifest.parent.mkdir(parents=True, exist_ok=True)
-    nested_manifest.write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
+    _project_dir, out = setup_project(
+        {
+            "Cargo.toml": "",
+            "nested/Cargo.toml": "",
+        }
+    )
 
     detect.main("lcov", out, "nested/Cargo.toml")
 
@@ -123,16 +138,10 @@ def test_detect_prefers_root_manifest_over_input(
 
 
 def test_detect_uses_input_manifest_when_root_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Configured manifest is used when root manifest is absent."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    nested_manifest = project_dir / "rust-toy-app" / "Cargo.toml"
-    nested_manifest.parent.mkdir(parents=True, exist_ok=True)
-    nested_manifest.write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
+    _project_dir, out = setup_project({"rust-toy-app/Cargo.toml": ""})
 
     detect.main("lcov", out, "rust-toy-app/Cargo.toml")
 
@@ -143,17 +152,15 @@ def test_detect_uses_input_manifest_when_root_missing(
 
 
 def test_detect_uses_mixed_when_input_manifest_and_pyproject_exist(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Input manifest plus root Python project yields mixed language."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    nested_manifest = project_dir / "crate" / "Cargo.toml"
-    nested_manifest.parent.mkdir(parents=True, exist_ok=True)
-    nested_manifest.write_text("")
-    (project_dir / "pyproject.toml").write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
+    _project_dir, out = setup_project(
+        {
+            "crate/Cargo.toml": "",
+            "pyproject.toml": "",
+        }
+    )
 
     detect.main("cobertura", out, "crate/Cargo.toml")
 
@@ -164,14 +171,10 @@ def test_detect_uses_mixed_when_input_manifest_and_pyproject_exist(
 
 
 def test_detect_ignores_missing_input_manifest_for_python_project(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
 ) -> None:
     """Missing ``cargo-manifest`` keeps Python-only behaviour."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    (project_dir / "pyproject.toml").write_text("")
-    monkeypatch.chdir(project_dir)
-    out = project_dir / "gh.txt"
+    _project_dir, out = setup_project({"pyproject.toml": ""})
 
     detect.main("coveragepy", out, "missing/Cargo.toml")
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -151,6 +151,14 @@ class RustCoverageConfig:
     manifest_path: str = "Cargo.toml"
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class RustMainConfig:
+    """Configuration for ``_run_rust_main_variant`` test helper."""
+
+    use_nextest: bool
+    manifest_path: Path = Path("Cargo.toml")
+
+
 def _run_rust_coverage_test(
     tmp_path: Path,
     shell_stubs: StubManager,
@@ -327,9 +335,7 @@ def _run_rust_main_variant(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     run_rust_module: ModuleType,
-    *,
-    use_nextest: bool,
-    manifest_path: Path = Path("Cargo.toml"),
+    config: RustMainConfig,
 ) -> tuple[list[str], Path, Path]:
     """Run ``main`` with the provided nextest flag and return captured data."""
     monkeypatch.chdir(tmp_path)
@@ -348,10 +354,10 @@ def _run_rust_main_variant(
         output,
         "",
         with_default=True,
-        use_nextest=use_nextest,
+        use_nextest=config.use_nextest,
         lang="rust",
         fmt="lcov",
-        manifest_path=manifest_path,
+        manifest_path=config.manifest_path,
         github_output=github_output,
         cucumber_rs_features="",
         cucumber_rs_args="",
@@ -374,7 +380,7 @@ def test_run_rust_main_nextest_variants(
         tmp_path,
         monkeypatch,
         run_rust_module,
-        use_nextest=use_nextest,
+        RustMainConfig(use_nextest=use_nextest),
     )
 
     if use_nextest:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -148,6 +148,7 @@ class RustCoverageConfig:
     use_nextest: bool
     features: str = ""
     with_default_features: bool = True
+    manifest_path: str = "Cargo.toml"
 
 
 def _run_rust_coverage_test(
@@ -177,6 +178,7 @@ def _run_rust_coverage_test(
             "true" if config.with_default_features else "false"
         ),
         "INPUT_USE_CARGO_NEXTEST": "true" if config.use_nextest else "false",
+        "DETECTED_CARGO_MANIFEST": config.manifest_path,
         "GITHUB_OUTPUT": str(gh),
     }
 
@@ -207,6 +209,8 @@ def test_run_rust_success(tmp_path: Path, shell_stubs: StubManager) -> None:
     )
     expected_args = [
         "llvm-cov",
+        "--manifest-path",
+        "Cargo.toml",
         "--workspace",
         "--summary-only",
         "--no-default-features",
@@ -238,6 +242,8 @@ def test_run_rust_nextest_command(
     expected_args = [
         "llvm-cov",
         "nextest",
+        "--manifest-path",
+        "Cargo.toml",
         "--workspace",
         "--summary-only",
         "--lcov",
@@ -248,6 +254,18 @@ def test_run_rust_nextest_command(
     assert not (tmp_path / ".config" / "nextest.toml").exists()
 
 
+def test_run_rust_uses_detected_manifest_path(
+    tmp_path: Path, shell_stubs: StubManager
+) -> None:
+    """Detected manifest path is propagated to cargo llvm-cov."""
+    cargo_args, _out, _gh = _run_rust_coverage_test(
+        tmp_path,
+        shell_stubs,
+        RustCoverageConfig(use_nextest=False, manifest_path="rust-toy-app/Cargo.toml"),
+    )
+    assert cargo_args[0:3] == ["llvm-cov", "--manifest-path", "rust-toy-app/Cargo.toml"]
+
+
 @pytest.mark.parametrize(
     "case",
     [
@@ -255,9 +273,12 @@ def test_run_rust_nextest_command(
             True,
             "fast",
             False,
+            "Cargo.toml",
             [
                 "llvm-cov",
                 "nextest",
+                "--manifest-path",
+                "Cargo.toml",
                 "--workspace",
                 "--summary-only",
                 "--no-default-features",
@@ -271,8 +292,11 @@ def test_run_rust_nextest_command(
             False,
             "",
             True,
+            "rust-toy-app/Cargo.toml",
             [
                 "llvm-cov",
+                "--manifest-path",
+                "rust-toy-app/Cargo.toml",
                 "--workspace",
                 "--summary-only",
                 "--lcov",
@@ -283,15 +307,16 @@ def test_run_rust_nextest_command(
 )
 def test_get_cargo_coverage_cmd_variants(
     run_rust_module: ModuleType,
-    case: tuple[bool, str, bool, list[str]],
+    case: tuple[bool, str, bool, str, list[str]],
 ) -> None:
     """``get_cargo_coverage_cmd`` varies arguments based on nextest usage."""
-    use_nextest, features, with_default, expected = case
+    use_nextest, features, with_default, manifest_path, expected = case
     out = Path("cov.lcov")
     args = run_rust_module.get_cargo_coverage_cmd(
         "lcov",
         out,
         features,
+        manifest_path=Path(manifest_path),
         with_default=with_default,
         use_nextest=use_nextest,
     )
@@ -304,6 +329,7 @@ def _run_rust_main_variant(
     run_rust_module: ModuleType,
     *,
     use_nextest: bool,
+    manifest_path: Path = Path("Cargo.toml"),
 ) -> tuple[list[str], Path, Path]:
     """Run ``main`` with the provided nextest flag and return captured data."""
     monkeypatch.chdir(tmp_path)
@@ -325,6 +351,7 @@ def _run_rust_main_variant(
         use_nextest=use_nextest,
         lang="rust",
         fmt="lcov",
+        manifest_path=manifest_path,
         github_output=github_output,
         cucumber_rs_features="",
         cucumber_rs_args="",
@@ -352,12 +379,16 @@ def test_run_rust_main_nextest_variants(
 
     if use_nextest:
         assert args[:2] == ["llvm-cov", "nextest"]
+        assert "--manifest-path" in args
+        assert "Cargo.toml" in args
         data = github_output.read_text().splitlines()
         assert f"file={output}" in data
         assert "percent=100.00" in data
     else:
         assert args[0] == "llvm-cov"
         assert "nextest" not in args
+        assert "--manifest-path" in args
+        assert "Cargo.toml" in args
 
 
 def test_nextest_config_is_temporary(
@@ -619,6 +650,7 @@ def test_run_rust_with_cucumber(tmp_path: Path, shell_stubs: StubManager) -> Non
         "INPUT_OUTPUT_PATH": str(out),
         "DETECTED_LANG": "rust",
         "DETECTED_FMT": "lcov",
+        "DETECTED_CARGO_MANIFEST": "rust-toy-app/Cargo.toml",
         "INPUT_FEATURES": "",
         "INPUT_WITH_DEFAULT_FEATURES": "true",
         "INPUT_USE_CARGO_NEXTEST": "false",
@@ -637,6 +669,8 @@ def test_run_rust_with_cucumber(tmp_path: Path, shell_stubs: StubManager) -> Non
     cuc_file = out.with_name(f"{out.stem}.cucumber{out.suffix}")
     expected_second = [
         "llvm-cov",
+        "--manifest-path",
+        "rust-toy-app/Cargo.toml",
         "--workspace",
         "--summary-only",
         "--lcov",
@@ -680,6 +714,7 @@ def test_run_rust_with_cucumber_nextest(
         "INPUT_OUTPUT_PATH": str(out),
         "DETECTED_LANG": "rust",
         "DETECTED_FMT": "lcov",
+        "DETECTED_CARGO_MANIFEST": "rust-toy-app/Cargo.toml",
         "INPUT_FEATURES": "",
         "INPUT_WITH_DEFAULT_FEATURES": "true",
         "INPUT_USE_CARGO_NEXTEST": "true",
@@ -698,6 +733,8 @@ def test_run_rust_with_cucumber_nextest(
     assert len(calls) == 2
     assert "nextest" in calls[0].argv
     assert "nextest" in calls[1].argv
+    assert calls[0].argv[2:4] == ["--manifest-path", "rust-toy-app/Cargo.toml"]
+    assert calls[1].argv[2:4] == ["--manifest-path", "rust-toy-app/Cargo.toml"]
     assert out.read_text() == "TN:test\nend_of_record\nTN:cuke\nend_of_record\n"
     assert not cuc_file.exists()
     assert not (tmp_path / ".config" / "nextest.toml").exists()
@@ -733,6 +770,7 @@ def test_run_rust_with_cucumber_cobertura(
         "INPUT_OUTPUT_PATH": str(out),
         "DETECTED_LANG": "rust",
         "DETECTED_FMT": "cobertura",
+        "DETECTED_CARGO_MANIFEST": "rust-toy-app/Cargo.toml",
         "INPUT_FEATURES": "",
         "INPUT_WITH_DEFAULT_FEATURES": "true",
         "INPUT_USE_CARGO_NEXTEST": "false",
@@ -784,6 +822,7 @@ def test_run_rust_with_cucumber_cobertura_merge_failure(
         "INPUT_OUTPUT_PATH": str(out),
         "DETECTED_LANG": "rust",
         "DETECTED_FMT": "cobertura",
+        "DETECTED_CARGO_MANIFEST": "rust-toy-app/Cargo.toml",
         "INPUT_FEATURES": "",
         "INPUT_WITH_DEFAULT_FEATURES": "true",
         "INPUT_USE_CARGO_NEXTEST": "false",
@@ -811,6 +850,7 @@ def test_run_rust_failure(tmp_path: Path, shell_stubs: StubManager) -> None:
         "INPUT_OUTPUT_PATH": str(tmp_path / "out"),
         "DETECTED_LANG": "rust",
         "DETECTED_FMT": "lcov",
+        "DETECTED_CARGO_MANIFEST": "rust-toy-app/Cargo.toml",
         "INPUT_USE_CARGO_NEXTEST": "false",
         "GITHUB_OUTPUT": str(tmp_path / "gh.txt"),
     }

--- a/docs/execplans/cargo-manifests-input.md
+++ b/docs/execplans/cargo-manifests-input.md
@@ -1,0 +1,237 @@
+<!-- markdownlint-disable MD013 MD014 -->
+
+# Add cargo-manifests input fallback to generate-coverage
+
+This Execution Plan (ExecPlan) is a living document. The sections `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+`PLANS.md` was not found in this repository when this plan was created.
+
+## Purpose / Big Picture
+
+The `generate-coverage` action should support Rust projects whose `Cargo.toml` is not at repository root by accepting an optional `cargo-manifests` input (comma/space/newline-separated candidate paths). After this change, Rust or mixed-language detection will still prefer root `Cargo.toml`, otherwise select the first existing path from `cargo-manifests`, and pass that selected file to `cargo llvm-cov` via `--manifest-path`. If `cargo-manifests` is unset, behaviour remains exactly as it is today.
+
+Success is observable when the action:
+
+- still behaves exactly as today with no `cargo-manifests` input,
+- detects Rust/mixed projects through the fallback list when root `Cargo.toml` is absent,
+- executes `cargo llvm-cov ... --manifest-path <selected-manifest>` for Rust coverage.
+
+## Constraints
+
+- Follow repository policy in `AGENTS.md`, including Makefile-first execution and required gateways for GitHub Action logic changes: `make check-fmt`, `make typecheck`, `make lint`, `make test`.
+- Use `set -o pipefail` and `tee` for long-running gateway commands so failures are not masked and logs can be reviewed.
+- Keep backward compatibility: when `cargo-manifests` is unset, outputs and behaviour must match current behaviour.
+- Preserve existing action inputs/outputs; only add the new optional input and any internal step output required to wire selected manifest path.
+- Keep paths relative in caller-facing docs and examples, matching the requirement.
+- Keep scope limited to `.github/actions/generate-coverage/` plus this plan document.
+
+## Tolerances (Exception Triggers)
+
+- Scope: if implementation exceeds 7 files or 260 net LOC, stop and escalate.
+- Interface: if preserving exact unset-input behaviour requires changing public outputs/semantics beyond the new input, stop and escalate.
+- Dependencies: if any new package is needed, stop and escalate.
+- Iterations: if required gateways fail after 2 full fix/retest cycles, stop and escalate with logs.
+- Ambiguity: if requirement interpretation changes language detection outcomes for existing users, stop and request clarification.
+
+## Risks
+
+- Risk: fallback list parsing could incorrectly treat malformed separators as paths.
+  Severity: medium
+  Likelihood: medium
+  Mitigation: centralize parsing helper and add table-driven tests for comma/space/newline combinations.
+
+- Risk: adding `--manifest-path` can regress command assembly (including cucumber path).
+  Severity: medium
+  Likelihood: medium
+  Mitigation: update command-argument unit tests for both standard and cucumber flows.
+
+- Risk: detection could classify projects as Rust/mixed unexpectedly when a fallback manifest exists but is not intended.
+  Severity: low
+  Likelihood: medium
+  Mitigation: document precedence clearly (root first, then first existing fallback) and keep opt-in via explicit input.
+
+## Progress
+
+- [x] (2026-02-18 16:20Z) Reviewed current `generate-coverage` action inputs, detection script, Rust runner script, and tests.
+- [x] (2026-02-18 16:27Z) Drafted this ExecPlan with staged implementation and validation details.
+- [ ] Implement detection fallback and selected-manifest output wiring.
+- [ ] Implement Rust runner `--manifest-path` wiring.
+- [ ] Update docs/changelog/tests and run all required gateways.
+
+## Surprises & Discoveries
+
+- Observation: current Rust detection only checks root `Cargo.toml` in `.github/actions/generate-coverage/scripts/detect.py`, and `run_rust.py` currently runs without explicit `--manifest-path`.
+  Evidence: `get_lang()` uses `Path("Cargo.toml").is_file()`, and `get_cargo_coverage_cmd()` does not add manifest-path args.
+  Impact: both detection and runtime command assembly need changes for this feature.
+
+- Observation: no MCP resources/tools for the project memory protocol (`qdrant-find`/`qdrant-store`) are available in this execution environment.
+  Evidence: `list_mcp_resources` and `list_mcp_resource_templates` returned empty sets.
+  Impact: proceeded without project-memory recall/store.
+
+## Decision Log
+
+- Decision: keep coverage execution scalar (one selected manifest), while allowing `cargo-manifests` to be a list of candidate paths for discovery.
+  Rationale: `cargo llvm-cov --workspace` already covers a workspace rooted at the selected manifest. Executing multiple manifests in one action run would duplicate test execution, require multi-report merge semantics, and introduce unclear deduplication/ratchet behaviour.
+  Date/Author: 2026-02-18 (Codex)
+
+- Decision: detect step will emit the selected manifest path as an internal step output (for Rust/mixed paths) consumed by `run_rust.py`.
+  Rationale: keeps selection logic in one place and avoids diverging manifest resolution rules across scripts.
+  Date/Author: 2026-02-18 (Codex)
+
+## Outcomes & Retrospective
+
+Planned, not yet executed. Expected outcome: optional fallback manifest detection with unchanged default behaviour and explicit manifest-path passing in Rust coverage commands.
+
+## Context and Orientation
+
+The relevant implementation lives in `.github/actions/generate-coverage/`:
+
+- `action.yml`: action interface and composite step wiring.
+- `scripts/detect.py`: determines `lang` and `fmt` outputs from repository files.
+- `scripts/run_rust.py`: builds and executes `cargo llvm-cov` commands.
+- `tests/test_detect.py`: unit tests for detection behaviour.
+- `tests/test_scripts.py`: unit/integration-style tests for Rust command construction and script execution.
+- `README.md` and `CHANGELOG.md`: user-facing docs and release notes.
+
+Current baseline behaviour:
+
+- Root `Cargo.toml` present => Rust (or mixed if root `pyproject.toml` also present).
+- No root `Cargo.toml` and root `pyproject.toml` present => Python.
+- Neither present => error.
+- Rust coverage commands currently do not pass `--manifest-path`.
+
+## Plan of Work
+
+Stage A (no behavioural change): add focused tests that describe desired fallback behaviour.
+
+- Extend `tests/test_detect.py` with cases covering:
+  - root `Cargo.toml` precedence over `cargo-manifests` candidates,
+  - first-existing selection from comma/space/newline-separated candidates,
+  - Python-only/error behaviour unchanged when fallback list is empty or has no existing files,
+  - mixed detection when selected manifest exists and root `pyproject.toml` exists.
+- Extend `tests/test_scripts.py` cases that assert cargo argv to include `--manifest-path` in both primary and cucumber coverage invocations.
+
+Go/no-go: new tests should fail before implementation and pass after implementation.
+
+Stage B: implement manifest selection in detection and export selected path.
+
+- In `scripts/detect.py`:
+  - add option/env binding for `INPUT_CARGO_MANIFESTS`.
+  - add parser for comma/space/newline-separated tokens.
+  - add resolver: root `Cargo.toml` first; else first existing candidate; else none.
+  - keep existing Python/error behaviour when no manifest selected.
+  - append selected manifest to detect outputs (internal output such as `cargo_manifest=<path>`).
+- In `action.yml`:
+  - add new input `cargo-manifests` (optional) with clear description.
+  - pass `INPUT_CARGO_MANIFESTS` into detect step.
+  - pass detect output manifest path to Rust step environment (e.g. `DETECTED_CARGO_MANIFEST`).
+
+Go/no-go: detect script tests pass and default path (input unset) remains unchanged.
+
+Stage C: wire selected manifest into Rust command builder.
+
+- In `scripts/run_rust.py`:
+  - add option/env binding for selected manifest path from detect output.
+  - update `get_cargo_coverage_cmd()` to include `--manifest-path <selected-manifest>`.
+  - ensure cucumber command path inherits same manifest argument.
+  - keep defaults compatible for direct test invocation (no env override).
+
+Go/no-go: rust script tests confirm manifest-path in command args for nextest/non-nextest and cucumber flows.
+
+Stage D: update docs/changelog and run full gateways.
+
+- Update `.github/actions/generate-coverage/README.md`:
+  - input table row for `cargo-manifests`.
+  - flow/behaviour text describing precedence rules.
+  - example showing nested manifest fallback.
+- Update `.github/actions/generate-coverage/CHANGELOG.md` with a new release entry.
+- Run all required gateways and capture logs via `tee`.
+
+## Concrete Steps
+
+1. Add failing tests for desired behaviour.
+
+   - Edit `.github/actions/generate-coverage/tests/test_detect.py`.
+   - Edit `.github/actions/generate-coverage/tests/test_scripts.py`.
+   - Run targeted tests first:
+
+        uv run --with pytest pytest .github/actions/generate-coverage/tests/test_detect.py -v
+        uv run --with pytest pytest .github/actions/generate-coverage/tests/test_scripts.py -v
+
+2. Implement detection and wiring.
+
+   - Edit `.github/actions/generate-coverage/scripts/detect.py`.
+   - Edit `.github/actions/generate-coverage/action.yml`.
+
+3. Implement Rust command changes.
+
+   - Edit `.github/actions/generate-coverage/scripts/run_rust.py`.
+
+4. Update docs.
+
+   - Edit `.github/actions/generate-coverage/README.md`.
+   - Edit `.github/actions/generate-coverage/CHANGELOG.md`.
+
+5. Run required gateways from repository root (with logs).
+
+        set -o pipefail; make check-fmt 2>&1 | tee /tmp/shared-actions-check-fmt.log
+        set -o pipefail; make typecheck 2>&1 | tee /tmp/shared-actions-typecheck.log
+        set -o pipefail; make lint 2>&1 | tee /tmp/shared-actions-lint.log
+        set -o pipefail; make test 2>&1 | tee /tmp/shared-actions-test.log
+
+6. If any gateway fails, fix and rerun the failed gateway(s) until green, then rerun full sequence if failures touched shared logic.
+
+## Validation and Acceptance
+
+Acceptance criteria:
+
+- With no `cargo-manifests` input, detection and runtime behaviour match current behaviour.
+- With root `Cargo.toml` present, that manifest is always selected regardless of `cargo-manifests` values.
+- With no root `Cargo.toml`, first existing path from `cargo-manifests` is selected.
+- If no manifest exists after fallback, action keeps current Python-only/error behaviour.
+- Rust command invocation includes `--manifest-path <selected-manifest>`.
+- `make check-fmt`, `make typecheck`, `make lint`, `make test` all pass.
+
+Observable checks:
+
+- Tests assert detect outputs and cargo argv contents.
+- Command logs show `cargo llvm-cov ... --manifest-path <path> ...`.
+
+## Idempotence and Recovery
+
+The edits are text-only and re-runnable. If a test run partially writes coverage outputs in temp paths, remove only test temp artefacts and rerun. If command-order assertions fail due argument position changes, adjust tests to assert stable semantic invariants (presence and value pairing of `--manifest-path`) rather than brittle absolute positions where appropriate.
+
+## Artifacts and Notes
+
+Expected command snippet after implementation:
+
+    $ cargo llvm-cov nextest --manifest-path rust-toy-app/Cargo.toml --workspace --summary-only --lcov --output-path <...>
+
+Expected detect output snippet for fallback case:
+
+    lang=rust
+    fmt=lcov
+    cargo_manifest=rust-toy-app/Cargo.toml
+
+## Interfaces and Dependencies
+
+- New action input:
+  - `cargo-manifests` (optional string): comma/space/newline-separated relative candidate paths.
+- Internal step contract:
+  - detect step emits selected manifest path output (for Rust/mixed detection paths).
+  - rust step consumes selected manifest path via environment variable.
+- No new external dependencies.
+- Files expected to change:
+  - `.github/actions/generate-coverage/action.yml`
+  - `.github/actions/generate-coverage/scripts/detect.py`
+  - `.github/actions/generate-coverage/scripts/run_rust.py`
+  - `.github/actions/generate-coverage/tests/test_detect.py`
+  - `.github/actions/generate-coverage/tests/test_scripts.py`
+  - `.github/actions/generate-coverage/README.md`
+  - `.github/actions/generate-coverage/CHANGELOG.md`
+
+## Revision note
+
+Initial draft created to plan `cargo-manifests` fallback detection and manifest-path wiring for Rust coverage, with a deliberate scalar execution decision and explicit backward-compatibility checks.

--- a/docs/execplans/cargo-manifests-input.md
+++ b/docs/execplans/cargo-manifests-input.md
@@ -4,7 +4,7 @@
 
 This Execution Plan (ExecPlan) is a living document. The sections `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 `PLANS.md` was not found in this repository when this plan was created.
 
@@ -68,9 +68,12 @@ Success is observable when the action:
 - [x] (2026-02-18 16:27Z) Drafted this ExecPlan with staged implementation and validation details.
 - [x] (2026-02-18 16:40Z) Revised plan to use scalar `cargo-manifest` input
   instead of list `cargo-manifests`.
-- [ ] Implement detection fallback and selected-manifest output wiring.
-- [ ] Implement Rust runner `--manifest-path` wiring.
-- [ ] Update docs/changelog/tests and run all required gateways.
+- [x] (2026-02-18 17:10Z) Implemented detection fallback and selected-manifest
+  output wiring in `detect.py` and `action.yml`.
+- [x] (2026-02-18 17:15Z) Implemented Rust runner `--manifest-path` wiring in
+  `run_rust.py`.
+- [x] (2026-02-18 17:30Z) Updated tests, README, and changelog; validated with
+  targeted tests plus full required gateways.
 
 ## Surprises & Discoveries
 
@@ -81,6 +84,14 @@ Success is observable when the action:
 - Observation: no MCP resources/tools for the project memory protocol (`qdrant-find`/`qdrant-store`) are available in this execution environment.
   Evidence: `list_mcp_resources` and `list_mcp_resource_templates` returned empty sets.
   Impact: proceeded without project-memory recall/store.
+
+- Observation: using a Typer `Option(...)` object as a trailing default in
+  `detect.main` broke direct function-call tests by passing `OptionInfo` into
+  `.strip()`.
+  Evidence: `AttributeError: 'OptionInfo' object has no attribute 'strip'` in
+  `test_detect.py`.
+  Impact: switched to a plain string parameter and explicit
+  `os.getenv("INPUT_CARGO_MANIFEST", "")` fallback.
 
 ## Decision Log
 
@@ -94,9 +105,43 @@ Success is observable when the action:
   Rationale: keeps selection logic in one place and avoids diverging manifest resolution rules across scripts.
   Date/Author: 2026-02-18 (Codex)
 
+- Decision: keep `detect.main` callable as a regular Python function for tests,
+  while still reading `INPUT_CARGO_MANIFEST` from the environment in script
+  mode.
+  Rationale: avoids Typer `OptionInfo` default pitfalls and preserves existing
+  unit test invocation style.
+  Date/Author: 2026-02-18 (Codex)
+
 ## Outcomes & Retrospective
 
-Planned, not yet executed. Expected outcome: optional fallback manifest detection with unchanged default behaviour and explicit manifest-path passing in Rust coverage commands.
+Implemented scalar `cargo-manifest` support for `generate-coverage`:
+
+- Added optional `cargo-manifest` input in
+  `.github/actions/generate-coverage/action.yml`.
+- Updated `.github/actions/generate-coverage/scripts/detect.py` to:
+  - prefer root `Cargo.toml`,
+  - fall back to `cargo-manifest` when present and existing,
+  - emit `cargo_manifest` output for Rust and mixed projects.
+- Updated `.github/actions/generate-coverage/scripts/run_rust.py` to pass
+  `--manifest-path <selected-manifest>` for primary and cucumber runs.
+- Updated tests in:
+  - `.github/actions/generate-coverage/tests/test_detect.py`
+  - `.github/actions/generate-coverage/tests/test_scripts.py`
+- Updated docs/changelog:
+  - `.github/actions/generate-coverage/README.md`
+  - `.github/actions/generate-coverage/CHANGELOG.md`
+
+Validation results:
+
+- Targeted:
+  - `uv run --with pytest pytest .github/actions/generate-coverage/tests/test_detect.py -v`
+  - `uv run --with pytest pytest .github/actions/generate-coverage/tests/test_scripts.py -v`
+- Required gateways:
+  - `make check-fmt`
+  - `UV_PYTHON=3.13 make typecheck`
+  - `UV_PYTHON=3.13 make lint`
+  - `UV_PYTHON=3.13 make test`
+    (`640 passed, 86 skipped`)
 
 ## Context and Orientation
 
@@ -254,4 +299,5 @@ Expected detect output snippet for fallback case:
 
 Revised this draft to use scalar `cargo-manifest` instead of list
 `cargo-manifests`, and updated tests, implementation stages, and acceptance
-criteria accordingly.
+criteria accordingly. This revision also records completed implementation and
+validation evidence, and updates status/progress to `COMPLETE`.

--- a/docs/execplans/cargo-manifests-input.md
+++ b/docs/execplans/cargo-manifests-input.md
@@ -1,6 +1,6 @@
-<!-- markdownlint-disable MD013 MD014 -->
-
 # Add cargo-manifest input fallback to generate-coverage
+
+<!-- markdownlint-disable MD013 MD014 -->
 
 This Execution Plan (ExecPlan) is a living document. The sections `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
@@ -37,7 +37,8 @@ Success is observable when the action:
 
 ## Tolerances (Exception Triggers)
 
-- Scope: if implementation exceeds 7 files or 260 net LOC, stop and escalate.
+- Scope: if implementation exceeds 7 files or 260 net lines of code (LOC),
+  stop and escalate.
 - Interface: if preserving exact unset-input behaviour requires changing public outputs/semantics beyond the new input, stop and escalate.
 - Dependencies: if any new package is needed, stop and escalate.
 - Iterations: if required gateways fail after 2 full fix/retest cycles, stop and escalate with logs.
@@ -49,8 +50,9 @@ Success is observable when the action:
   unexpectedly.
   Severity: medium
   Likelihood: medium
-  Mitigation: resolve path relative to workspace/cwd and add tests for unset,
-  relative, non-existent, and absolute path handling.
+  Mitigation: resolve path relative to workspace/current working directory
+  (cwd) and add tests for unset, relative, non-existent, and absolute path
+  handling.
 
 - Risk: adding `--manifest-path` can regress command assembly (including cucumber path).
   Severity: medium
@@ -81,7 +83,9 @@ Success is observable when the action:
   Evidence: `get_lang()` uses `Path("Cargo.toml").is_file()`, and `get_cargo_coverage_cmd()` does not add manifest-path args.
   Impact: both detection and runtime command assembly need changes for this feature.
 
-- Observation: no MCP resources/tools for the project memory protocol (`qdrant-find`/`qdrant-store`) are available in this execution environment.
+- Observation: no Model Context Protocol (MCP) resources/tools for the project
+  memory protocol (`qdrant-find`/`qdrant-store`) are available in this
+  execution environment.
   Evidence: `list_mcp_resources` and `list_mcp_resource_templates` returned empty sets.
   Impact: proceeded without project-memory recall/store.
 
@@ -172,7 +176,9 @@ Stage A (no behavioural change): add focused tests that describe desired fallbac
   - Python-only/error behaviour unchanged when scalar fallback is unset or
     non-existent,
   - mixed detection when selected manifest exists and root `pyproject.toml` exists.
-- Extend `tests/test_scripts.py` cases that assert cargo argv to include `--manifest-path` in both primary and cucumber coverage invocations.
+- Extend `tests/test_scripts.py` cases that assert the cargo argument vector
+  (argv) includes `--manifest-path` in both primary and cucumber coverage
+  invocations.
 
 Go/no-go: new tests should fail before implementation and pass after implementation.
 
@@ -264,7 +270,11 @@ Observable checks:
 
 ## Idempotence and Recovery
 
-The edits are text-only and re-runnable. If a test run partially writes coverage outputs in temp paths, remove only test temp artefacts and rerun. If command-order assertions fail due argument position changes, adjust tests to assert stable semantic invariants (presence and value pairing of `--manifest-path`) rather than brittle absolute positions where appropriate.
+The edits are text-only and re-runnable. If a test run partially writes
+coverage outputs in temp paths, remove only test temp artefacts and rerun. If
+command-order assertions fail due to argument position changes, adjust tests to
+assert stable semantic invariants (presence and value pairing of
+`--manifest-path`) rather than brittle absolute positions where appropriate.
 
 ## Artifacts and Notes
 

--- a/docs/execplans/cargo-manifests-input.md
+++ b/docs/execplans/cargo-manifests-input.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD013 MD014 -->
 
-# Add cargo-manifests input fallback to generate-coverage
+# Add cargo-manifest input fallback to generate-coverage
 
 This Execution Plan (ExecPlan) is a living document. The sections `Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
@@ -10,19 +10,27 @@ Status: DRAFT
 
 ## Purpose / Big Picture
 
-The `generate-coverage` action should support Rust projects whose `Cargo.toml` is not at repository root by accepting an optional `cargo-manifests` input (comma/space/newline-separated candidate paths). After this change, Rust or mixed-language detection will still prefer root `Cargo.toml`, otherwise select the first existing path from `cargo-manifests`, and pass that selected file to `cargo llvm-cov` via `--manifest-path`. If `cargo-manifests` is unset, behaviour remains exactly as it is today.
+The `generate-coverage` action should support Rust projects whose `Cargo.toml`
+is not at repository root by accepting an optional `cargo-manifest` input
+(single relative path). After this change, Rust or mixed-language detection
+will still prefer root `Cargo.toml`, otherwise use `cargo-manifest` if the
+path exists, and pass that selected file to `cargo llvm-cov` via
+`--manifest-path`. If `cargo-manifest` is unset, behaviour remains exactly as
+it is today.
 
 Success is observable when the action:
 
-- still behaves exactly as today with no `cargo-manifests` input,
-- detects Rust/mixed projects through the fallback list when root `Cargo.toml` is absent,
+- still behaves exactly as today with no `cargo-manifest` input,
+- detects Rust/mixed projects through the fallback path when root
+  `Cargo.toml` is absent,
 - executes `cargo llvm-cov ... --manifest-path <selected-manifest>` for Rust coverage.
 
 ## Constraints
 
 - Follow repository policy in `AGENTS.md`, including Makefile-first execution and required gateways for GitHub Action logic changes: `make check-fmt`, `make typecheck`, `make lint`, `make test`.
 - Use `set -o pipefail` and `tee` for long-running gateway commands so failures are not masked and logs can be reviewed.
-- Keep backward compatibility: when `cargo-manifests` is unset, outputs and behaviour must match current behaviour.
+- Keep backward compatibility: when `cargo-manifest` is unset, outputs and
+  behaviour must match current behaviour.
 - Preserve existing action inputs/outputs; only add the new optional input and any internal step output required to wire selected manifest path.
 - Keep paths relative in caller-facing docs and examples, matching the requirement.
 - Keep scope limited to `.github/actions/generate-coverage/` plus this plan document.
@@ -37,10 +45,12 @@ Success is observable when the action:
 
 ## Risks
 
-- Risk: fallback list parsing could incorrectly treat malformed separators as paths.
+- Risk: a configured scalar path may be absolute or escape workspace
+  unexpectedly.
   Severity: medium
   Likelihood: medium
-  Mitigation: centralize parsing helper and add table-driven tests for comma/space/newline combinations.
+  Mitigation: resolve path relative to workspace/cwd and add tests for unset,
+  relative, non-existent, and absolute path handling.
 
 - Risk: adding `--manifest-path` can regress command assembly (including cucumber path).
   Severity: medium
@@ -56,6 +66,8 @@ Success is observable when the action:
 
 - [x] (2026-02-18 16:20Z) Reviewed current `generate-coverage` action inputs, detection script, Rust runner script, and tests.
 - [x] (2026-02-18 16:27Z) Drafted this ExecPlan with staged implementation and validation details.
+- [x] (2026-02-18 16:40Z) Revised plan to use scalar `cargo-manifest` input
+  instead of list `cargo-manifests`.
 - [ ] Implement detection fallback and selected-manifest output wiring.
 - [ ] Implement Rust runner `--manifest-path` wiring.
 - [ ] Update docs/changelog/tests and run all required gateways.
@@ -72,8 +84,10 @@ Success is observable when the action:
 
 ## Decision Log
 
-- Decision: keep coverage execution scalar (one selected manifest), while allowing `cargo-manifests` to be a list of candidate paths for discovery.
-  Rationale: `cargo llvm-cov --workspace` already covers a workspace rooted at the selected manifest. Executing multiple manifests in one action run would duplicate test execution, require multi-report merge semantics, and introduce unclear deduplication/ratchet behaviour.
+- Decision: use scalar `cargo-manifest` input and single-manifest execution.
+  Rationale: `cargo llvm-cov --workspace` already covers a workspace rooted at
+  the selected manifest. Multi-manifest execution in one action run would
+  duplicate test execution and add unclear merge/ratchet semantics.
   Date/Author: 2026-02-18 (Codex)
 
 - Decision: detect step will emit the selected manifest path as an internal step output (for Rust/mixed paths) consumed by `run_rust.py`.
@@ -107,9 +121,11 @@ Current baseline behaviour:
 Stage A (no behavioural change): add focused tests that describe desired fallback behaviour.
 
 - Extend `tests/test_detect.py` with cases covering:
-  - root `Cargo.toml` precedence over `cargo-manifests` candidates,
-  - first-existing selection from comma/space/newline-separated candidates,
-  - Python-only/error behaviour unchanged when fallback list is empty or has no existing files,
+  - root `Cargo.toml` precedence over scalar `cargo-manifest`,
+  - scalar fallback selection when root `Cargo.toml` is absent and
+    `cargo-manifest` exists,
+  - Python-only/error behaviour unchanged when scalar fallback is unset or
+    non-existent,
   - mixed detection when selected manifest exists and root `pyproject.toml` exists.
 - Extend `tests/test_scripts.py` cases that assert cargo argv to include `--manifest-path` in both primary and cucumber coverage invocations.
 
@@ -118,14 +134,14 @@ Go/no-go: new tests should fail before implementation and pass after implementat
 Stage B: implement manifest selection in detection and export selected path.
 
 - In `scripts/detect.py`:
-  - add option/env binding for `INPUT_CARGO_MANIFESTS`.
-  - add parser for comma/space/newline-separated tokens.
-  - add resolver: root `Cargo.toml` first; else first existing candidate; else none.
+  - add option/env binding for `INPUT_CARGO_MANIFEST`.
+  - add resolver: root `Cargo.toml` first; else `cargo-manifest` when existing;
+    else none.
   - keep existing Python/error behaviour when no manifest selected.
   - append selected manifest to detect outputs (internal output such as `cargo_manifest=<path>`).
 - In `action.yml`:
-  - add new input `cargo-manifests` (optional) with clear description.
-  - pass `INPUT_CARGO_MANIFESTS` into detect step.
+  - add new input `cargo-manifest` (optional) with clear description.
+  - pass `INPUT_CARGO_MANIFEST` into detect step.
   - pass detect output manifest path to Rust step environment (e.g. `DETECTED_CARGO_MANIFEST`).
 
 Go/no-go: detect script tests pass and default path (input unset) remains unchanged.
@@ -143,9 +159,9 @@ Go/no-go: rust script tests confirm manifest-path in command args for nextest/no
 Stage D: update docs/changelog and run full gateways.
 
 - Update `.github/actions/generate-coverage/README.md`:
-  - input table row for `cargo-manifests`.
+  - input table row for `cargo-manifest`.
   - flow/behaviour text describing precedence rules.
-  - example showing nested manifest fallback.
+  - example showing scalar manifest fallback.
 - Update `.github/actions/generate-coverage/CHANGELOG.md` with a new release entry.
 - Run all required gateways and capture logs via `tee`.
 
@@ -187,9 +203,11 @@ Stage D: update docs/changelog and run full gateways.
 
 Acceptance criteria:
 
-- With no `cargo-manifests` input, detection and runtime behaviour match current behaviour.
-- With root `Cargo.toml` present, that manifest is always selected regardless of `cargo-manifests` values.
-- With no root `Cargo.toml`, first existing path from `cargo-manifests` is selected.
+- With no `cargo-manifest` input, detection and runtime behaviour match current
+  behaviour.
+- With root `Cargo.toml` present, that manifest is always selected regardless
+  of `cargo-manifest` value.
+- With no root `Cargo.toml`, `cargo-manifest` is selected when it exists.
 - If no manifest exists after fallback, action keeps current Python-only/error behaviour.
 - Rust command invocation includes `--manifest-path <selected-manifest>`.
 - `make check-fmt`, `make typecheck`, `make lint`, `make test` all pass.
@@ -218,7 +236,7 @@ Expected detect output snippet for fallback case:
 ## Interfaces and Dependencies
 
 - New action input:
-  - `cargo-manifests` (optional string): comma/space/newline-separated relative candidate paths.
+  - `cargo-manifest` (optional string): single relative candidate path.
 - Internal step contract:
   - detect step emits selected manifest path output (for Rust/mixed detection paths).
   - rust step consumes selected manifest path via environment variable.
@@ -234,4 +252,6 @@ Expected detect output snippet for fallback case:
 
 ## Revision note
 
-Initial draft created to plan `cargo-manifests` fallback detection and manifest-path wiring for Rust coverage, with a deliberate scalar execution decision and explicit backward-compatibility checks.
+Revised this draft to use scalar `cargo-manifest` instead of list
+`cargo-manifests`, and updated tests, implementation stages, and acceptance
+criteria accordingly.


### PR DESCRIPTION
## Summary
- Implement optional cargo-manifest input and wire the selected manifest to cargo-llvm-cov runs via --manifest-path. If root Cargo.toml exists, it is preferred; otherwise, fall back to the provided cargo-manifest path if it exists. If cargo-manifest is unset or the configured path does not exist, behavior remains unchanged.
- Adds tests to cover root-precedence, fallback behavior, and Python-only scenarios, and updates related docs and changelog.

## Changes
- Added new documentation file: docs/execplans/cargo-manifests-input.md detailing the plan and design for cargo-manifest (scalar) fallback and manifest-path wiring.
- Updated detection and wiring:
  - detect.py now accepts INPUT_CARGO_MANIFEST and resolves the manifest with root-then-input precedence, emitting the selected manifest path for downstream wiring.
  - action.yml: introduced cargo-manifest input and wired it through to detect step; exposed detected manifest to Rust runner via DETECTED_CARGO_MANIFEST.
  - scripts/run_rust.py: updated to accept and propagate the selected manifest path into get_cargo_coverage_cmd via --manifest-path, and to apply the same for cucumber runs.
- Tests:
  - Extended and updated tests in test_detect.py to verify root manifest precedence, input manifest fallback, and Python-only scenarios.
  - Updated test_scripts.py to validate that the cargo arguments include --manifest-path in both standard and cucumber coverage flows.
- Artifacts:
  - CHANGELOG.md and README.md in the generate-coverage action updated.
  - Documentation of the new behavior added to docs/execplans/cargo-manifests-input.md.

## Rationale
- Maintains backward compatibility: if cargo-manifest is unset or invalid, existing behavior remains unchanged.
- Enables robust Rust detection when Cargo.toml is not at repo root by using a deterministic, scalar cargo-manifest input fallback with root Cargo.toml taking precedence.
- Ensures Rust command invocations include --manifest-path for accurate coverage instrumentation.

## Implementation Plan (Phases)
- Stage A: add focused tests describing the desired fallback behavior (root precedence, wiring, and Python-only paths).
- Stage B: implement detection fallback and export the selected manifest path (detect.py and wiring through to outputs).
- Stage C: wire the selected manifest into the Rust command builder to pass --manifest-path (run_rust.py and related tests).
- Stage D: update action docs and changelog, and run required gateways.

## Validation & Acceptance Criteria
- With no cargo-manifest input, behavior matches current implementation.
- If root Cargo.toml exists, that manifest is always selected regardless of cargo-manifest value.
- If no root Cargo.toml, the first existing path from cargo-manifest input is selected.
- If no manifest exists after fallback, behavior remains as current (Python-only/error path).
- Rust command invocation includes --manifest-path <selected-manifest>.
- All gateways pass: make check-fmt, make typecheck, make lint, make test.

## Notes & Risk Mitigation
- The plan uses a single scalar input to simplify validation and testing and minimize risk.
- Stage rollout and tests are designed to prevent regressions in root-path or Python-only flows.

## Artifacts
- docs/execplans/cargo-manifests-input.md will serve as the single source of truth for this feature's design and validation.

## Why now
- Provides a clear, reviewable path for introducing an optional cargo-manifest input without breaking existing users. This docs+code change sets the stage for future wiring and tests.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
Task: https://www.devboxer.com/task/816ca7c2-5ad8-48bd-984e-3c8ea6777e55

## Summary by Sourcery

Add optional cargo-manifest input to the generate-coverage GitHub Action, resolving a preferred Cargo manifest for Rust projects and wiring it through to coverage commands and documentation.

New Features:
- Introduce a cargo-manifest action input to support Rust projects whose Cargo.toml is not at the repository root.
- Expose the selected Cargo manifest from detection to the Rust coverage runner and pass it to cargo-llvm-cov via --manifest-path, including cucumber flows.

Enhancements:
- Refine language detection to choose a Cargo manifest with root precedence and emit the selected manifest as an internal output.
- Extend tests to cover manifest precedence, fallback behavior, mixed-language scenarios, and manifest-path propagation in Rust coverage commands.

Documentation:
- Document the new cargo-manifest input, its precedence rules, and usage examples in the generate-coverage README and a dedicated exec plan document.
- Update the generate-coverage changelog to describe the new cargo-manifest behavior and manifest-path wiring.

Tests:
- Add and refactor tests for detect.py to exercise root vs input manifest selection and Python-only behavior when manifests are missing.
- Update Rust coverage script tests to assert inclusion and propagation of --manifest-path in standard, nextest, and cucumber coverage flows.
