### PR TITLE
Add --locked to cargo-nextest and verify checks

### DIFF
--- a/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
@@ -96,6 +96,7 @@ def install_cargo_nextest() -> None:
             "cargo-nextest",
             "--version",
             CARGO_NEXTEST_VERSION,
+            "--locked",
             "--no-confirm",
             "--force",
         ]

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1047,6 +1047,7 @@ def test_install_nextest_invokes_binstall(
         "cargo-nextest",
         "--version",
         install_nextest_module.CARGO_NEXTEST_VERSION,
+        "--locked",
         "--no-confirm",
         "--force",
     ]


### PR DESCRIPTION
## Summary
- Adds --locked flag to cargo-nextest in the coverage install script to ensure reproducible checks
- Updates tests to expect the new flag and verify the invocation includes --locked

## Changes
### Core functionality
- .github/actions/generate-coverage/scripts/install_cargo_nextest.py now invokes cargo-nextest with `--version`, the version constant, `--locked`, `--no-confirm`, and `--force`

### Tests
- .github/actions/generate-coverage/tests/test_scripts.py updated to include `--locked` in the expected argument list for the install_nextest invocation

## Verification
- [x] Ran generate-coverage tests; updated tests pass with the added `--locked` flag
- [x] Confirmed cargo-nextest is invoked with `--locked` in both the install script and tests

## Notes
- The `--locked` flag enforces a locked Cargo.lock state, improving determinism of coverage checks and avoiding dependency version drift during CI


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/16fc86ab-2d3c-41d9-aecf-419814915ff7

## Summary by Sourcery

Ensure cargo-nextest installation for coverage runs uses a locked dependency state and keep tests in sync with the new invocation.

New Features:
- Invoke cargo-nextest with the --locked flag during coverage tooling installation to enforce use of Cargo.lock.

Tests:
- Update coverage script tests to expect the --locked flag in the cargo-nextest invocation.