### PR TITLE
[codex] Fix cross nightly toolchain resolution

### DIFF
--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -47,6 +47,13 @@ if typ.TYPE_CHECKING:
     import subprocess
 
     from cmd_utils import SupportsFormulate
+
+    class _SupportsEnvFormulate(SupportsFormulate, typ.Protocol):
+        """Protocol for commands that support temporary environment bindings."""
+
+        def with_env(self, *args: object, **kwargs: object) -> _SupportsEnvFormulate:
+            """Return a command wrapper with the provided environment overrides."""
+            ...
 from cmd_utils_importer import import_cmd_utils
 
 run_cmd = import_cmd_utils().run_cmd
@@ -615,7 +622,8 @@ def main(
     """Build the project for *target* using *toolchain*."""
     target_to_build = _resolve_target_argument(target)
     manifest_path = _resolve_manifest_path()
-    requested_toolchain = toolchain.strip() or resolve_requested_toolchain(
+    explicit_toolchain = toolchain.strip()
+    requested_toolchain = explicit_toolchain or resolve_requested_toolchain(
         toolchain,
         project_dir=Path.cwd(),
         manifest_path=manifest_path,
@@ -655,6 +663,10 @@ def main(
         build_cmd = _build_cross_command(
             decision, target_to_build, manifest_argument, features
         )
+        if explicit_toolchain:
+            build_cmd = typ.cast("_SupportsEnvFormulate", build_cmd).with_env(
+                RUSTUP_TOOLCHAIN=explicit_toolchain
+            )
     else:
         build_cmd = _build_cargo_command(
             decision.cargo_toolchain_spec, target_to_build, manifest_argument, features

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -68,31 +68,6 @@ BSD_TARGET_SUFFIXES = (
     "unknown-netbsd",
 )
 
-_TRIPLE_OS_COMPONENTS = {
-    "linux",
-    "windows",
-    "darwin",
-    "freebsd",
-    "netbsd",
-    "openbsd",
-    "dragonfly",
-    "solaris",
-    "android",
-    "ios",
-    "emscripten",
-    "haiku",
-    "hermit",
-    "fuchsia",
-    "wasi",
-    "redox",
-    "illumos",
-    "uefi",
-    "macabi",
-    "rumprun",
-    "vita",
-    "psp",
-}
-
 app = typer.Typer(add_completion=False)
 
 
@@ -102,7 +77,6 @@ class _CrossDecision(typ.NamedTuple):
     cross_path: str | None
     cross_version: str | None
     use_cross: bool
-    cross_toolchain_spec: str
     cargo_toolchain_spec: str
     use_cross_local_backend: bool
     docker_present: bool
@@ -222,26 +196,6 @@ def _resolve_toolchain_name(
         if _matches_toolchain_channel(name, toolchain):
             return name
     return ""
-
-
-def _looks_like_triple(candidate: str) -> bool:
-    """Return ``True`` when *candidate* resembles a target triple."""
-    components = [part for part in candidate.split("-") if part]
-    if len(components) < 3:
-        return False
-    return any(component in _TRIPLE_OS_COMPONENTS for component in components[1:])
-
-
-def _toolchain_channel(toolchain_name: str) -> str:
-    """Strip any target triple suffix from *toolchain_name* for CLI overrides."""
-    for suffix_parts in (4, 3):
-        parts = toolchain_name.rsplit("-", suffix_parts)
-        if len(parts) != suffix_parts + 1:
-            continue
-        candidate = "-".join(parts[-suffix_parts:])
-        if _looks_like_triple(candidate):
-            return parts[0]
-    return toolchain_name
 
 
 def _probe_runtime(name: str) -> bool:
@@ -386,8 +340,8 @@ def _ensure_target_installed(
 
 def _decide_cross_usage(
     toolchain_name: str,
-    installed_names: list[str],
-    rustup_exec: str,
+    _installed_names: list[str],
+    _rustup_exec: str,
     target: str,
     host_target: str,
 ) -> _CrossDecision:
@@ -418,41 +372,11 @@ def _decide_cross_usage(
     use_cross = cross_path is not None and (has_container or use_cross_local_backend)
 
     cargo_toolchain_spec = f"+{toolchain_name}"
-    cross_toolchain_spec = cargo_toolchain_spec
-
-    if use_cross:
-        cross_toolchain_name = _toolchain_channel(toolchain_name)
-        if (
-            cross_toolchain_name != toolchain_name
-            and cross_toolchain_name not in installed_names
-        ):
-            try:
-                run_cmd(
-                    local[rustup_exec][
-                        "toolchain",
-                        "install",
-                        cross_toolchain_name,
-                        "--profile",
-                        "minimal",
-                        "--no-self-update",
-                    ]
-                )
-            except ProcessExecutionError:
-                typer.echo(
-                    "::warning:: failed to install sanitized toolchain; using cargo",
-                    err=True,
-                )
-                use_cross = False
-            else:
-                installed_names = _list_installed_toolchains(rustup_exec)
-        if use_cross:
-            cross_toolchain_spec = f"+{cross_toolchain_name}"
 
     return _CrossDecision(
         cross_path=cross_path,
         cross_version=cross_version,
         use_cross=use_cross,
-        cross_toolchain_spec=cross_toolchain_spec,
         cargo_toolchain_spec=cargo_toolchain_spec,
         use_cross_local_backend=use_cross_local_backend,
         docker_present=docker_present,
@@ -578,7 +502,6 @@ def _build_cross_command(
     cross_executable = decision.cross_path or "cross"
     executor = local[cross_executable]
     build_cmd = executor[
-        decision.cross_toolchain_spec,
         "build",
         "--manifest-path",
         str(manifest_path),

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -340,8 +340,6 @@ def _ensure_target_installed(
 
 def _decide_cross_usage(
     toolchain_name: str,
-    _installed_names: list[str],
-    _rustup_exec: str,
     target: str,
     host_target: str,
 ) -> _CrossDecision:
@@ -624,7 +622,7 @@ def main(
         fallback_toolchain=DEFAULT_TOOLCHAIN,
     )
     rustup_exec = _ensure_rustup_exec()
-    toolchain_name, installed_names = _resolve_toolchain(
+    toolchain_name, _installed_names = _resolve_toolchain(
         rustup_exec, requested_toolchain, target_to_build
     )
     target_installed = _ensure_target_installed(
@@ -634,9 +632,7 @@ def main(
     configure_windows_linkers(toolchain_name, target_to_build, rustup_exec)
 
     host_target = DEFAULT_HOST_TARGET
-    decision = _decide_cross_usage(
-        toolchain_name, installed_names, rustup_exec, target_to_build, host_target
-    )
+    decision = _decide_cross_usage(toolchain_name, target_to_build, host_target)
 
     _validate_cross_requirements(decision, target_to_build, host_target)
 

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -665,7 +665,7 @@ def main(
         )
         if explicit_toolchain:
             build_cmd = typ.cast("_SupportsEnvFormulate", build_cmd).with_env(
-                RUSTUP_TOOLCHAIN=explicit_toolchain
+                RUSTUP_TOOLCHAIN=toolchain_name
             )
     else:
         build_cmd = _build_cargo_command(

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -624,7 +624,7 @@ def main(
     manifest_path = _resolve_manifest_path()
     explicit_toolchain = toolchain.strip()
     requested_toolchain = explicit_toolchain or resolve_requested_toolchain(
-        toolchain,
+        explicit_toolchain,
         project_dir=Path.cwd(),
         manifest_path=manifest_path,
         fallback_toolchain=DEFAULT_TOOLCHAIN,

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -54,6 +54,8 @@ if typ.TYPE_CHECKING:
         def with_env(self, *args: object, **kwargs: object) -> _SupportsEnvFormulate:
             """Return a command wrapper with the provided environment overrides."""
             ...
+
+
 from cmd_utils_importer import import_cmd_utils
 
 run_cmd = import_cmd_utils().run_cmd
@@ -295,24 +297,22 @@ def _install_toolchain_channel(rustup_exec: str, toolchain: str) -> None:
         raise typer.Exit(1) from None
 
 
-def _resolve_toolchain(
-    rustup_exec: str, toolchain: str, target: str
-) -> tuple[str, list[str]]:
+def _resolve_toolchain(rustup_exec: str, toolchain: str, target: str) -> str:
     """Return the installed toolchain to use for the build."""
     installed_names = _list_installed_toolchains(rustup_exec)
     toolchain_name = _resolve_toolchain_name(toolchain, target, installed_names)
     if toolchain_name:
-        return toolchain_name, installed_names
+        return toolchain_name
 
     _install_toolchain_channel(rustup_exec, toolchain)
     installed_names = _list_installed_toolchains(rustup_exec)
     toolchain_name = _resolve_toolchain_name(toolchain, target, installed_names)
     if toolchain_name:
-        return toolchain_name, installed_names
+        return toolchain_name
 
     toolchain_name = _fallback_toolchain_name(toolchain, installed_names)
     if toolchain_name:
-        return toolchain_name, installed_names
+        return toolchain_name
 
     typer.echo(
         f"::error:: requested toolchain '{toolchain}' not installed",
@@ -630,7 +630,7 @@ def main(
         fallback_toolchain=DEFAULT_TOOLCHAIN,
     )
     rustup_exec = _ensure_rustup_exec()
-    toolchain_name, _installed_names = _resolve_toolchain(
+    toolchain_name = _resolve_toolchain(
         rustup_exec, requested_toolchain, target_to_build
     )
     target_installed = _ensure_target_installed(

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -207,9 +207,14 @@ class _DummyCommand:
         return None
 
     def with_env(self, *args: object, **kwargs: str) -> _DummyCommand:
-        _ = args
+        env_from_args: dict[str, str] = {}
+        for arg in args:
+            if not isinstance(arg, cabc.Mapping):
+                msg = "with_env positional arguments must be mappings"
+                raise TypeError(msg)
+            env_from_args.update(arg)
         wrapped = _DummyCommand(self._name)
-        wrapped.env = {**self.env, **kwargs}
+        wrapped.env = {**self.env, **env_from_args, **kwargs}
         return wrapped
 
 

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -198,12 +198,19 @@ HarnessFactory = cabc.Callable[[ModuleType], ModuleHarness]
 class _DummyCommand:
     def __init__(self, name: str = "dummy") -> None:
         self._name = name
+        self.env: dict[str, str] = {}
 
     def formulate(self) -> list[str]:
         return [self._name]
 
     def __call__(self, *_args: object, **_kwargs: object) -> None:
         return None
+
+    def with_env(self, *args: object, **kwargs: str) -> _DummyCommand:
+        _ = args
+        wrapped = _DummyCommand(self._name)
+        wrapped.env = {**self.env, **kwargs}
+        return wrapped
 
 
 def assert_no_toolchain_override(parts: list[str]) -> None:
@@ -320,7 +327,7 @@ def patch_common_main_deps(
     """Provide a harness with the common main() dependencies patched."""
     harness = module_harness(main_module)
     harness.patch_attr("_ensure_rustup_exec", lambda: "/usr/bin/rustup")
-    harness.patch_attr("_resolve_toolchain", lambda *_: ("stable", ["stable"]))
+    harness.patch_attr("_resolve_toolchain", lambda *_: "stable")
     harness.patch_attr("_ensure_target_installed", lambda *_: True)
     harness.patch_attr("configure_windows_linkers", lambda *_, **__: None)
     harness.patch_attr("_configure_cross_container_engine", lambda *_: (None, None))

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -212,7 +212,6 @@ class CrossDecision(typ.Protocol):
     cross_path: str | None
     cross_version: str | None
     use_cross: bool
-    cross_toolchain_spec: str
     cargo_toolchain_spec: str
     use_cross_local_backend: bool
     docker_present: bool
@@ -233,7 +232,6 @@ def _cross_decision(
         cross_path="/usr/bin/cross" if use_cross else None,
         cross_version="0.2.5",
         use_cross=use_cross,
-        cross_toolchain_spec="+stable",
         cargo_toolchain_spec="+stable",
         use_cross_local_backend=False,
         docker_present=True,

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -213,12 +213,6 @@ class _DummyCommand:
         return wrapped
 
 
-def assert_no_toolchain_override(parts: list[str]) -> None:
-    """Assert that a cross command does not inject a +toolchain override."""
-    assert parts[1] == "build"  # noqa: S101
-    assert all(not part.startswith("+") for part in parts[1:])  # noqa: S101
-
-
 class CrossDecision(typ.Protocol):
     """Typed view of the _CrossDecision fields used in tests."""
 

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -206,6 +206,12 @@ class _DummyCommand:
         return None
 
 
+def assert_no_toolchain_override(parts: list[str]) -> None:
+    """Assert that a cross command does not inject a +toolchain override."""
+    assert parts[1] == "build"  # noqa: S101
+    assert all(not part.startswith("+") for part in parts[1:])  # noqa: S101
+
+
 class CrossDecision(typ.Protocol):
     """Typed view of the _CrossDecision fields used in tests."""
 

--- a/.github/actions/rust-build-release/tests/rust_build_release_test_helpers.py
+++ b/.github/actions/rust-build-release/tests/rust_build_release_test_helpers.py
@@ -1,0 +1,9 @@
+"""Shared helpers for rust-build-release tests."""
+
+from __future__ import annotations
+
+
+def assert_no_toolchain_override(parts: list[str]) -> None:
+    """Assert that a cross command does not inject a +toolchain override."""
+    assert parts[1] == "build"  # noqa: S101
+    assert all(not part.startswith("+") for part in parts[1:])  # noqa: S101

--- a/.github/actions/rust-build-release/tests/test_features.py
+++ b/.github/actions/rust-build-release/tests/test_features.py
@@ -256,6 +256,9 @@ class TestBuildCommandFeatures:
             )
 
         parts = list(cmd.formulate())
+        if builder_type == "cross":
+            assert parts[1] == "build"
+            assert all(not part.startswith("+") for part in parts[1:])
 
         _assert_features_in_command_parts(
             parts, test_case.expected_in_parts, test_case.expected_value

--- a/.github/actions/rust-build-release/tests/test_features.py
+++ b/.github/actions/rust-build-release/tests/test_features.py
@@ -7,8 +7,7 @@ import typing as typ
 
 import pytest
 from plumbum.commands.processes import ProcessExecutionError
-
-from conftest import assert_no_toolchain_override
+from rust_build_release_test_helpers import assert_no_toolchain_override
 
 if typ.TYPE_CHECKING:
     from pathlib import Path

--- a/.github/actions/rust-build-release/tests/test_features.py
+++ b/.github/actions/rust-build-release/tests/test_features.py
@@ -8,6 +8,8 @@ import typing as typ
 import pytest
 from plumbum.commands.processes import ProcessExecutionError
 
+from conftest import assert_no_toolchain_override
+
 if typ.TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
@@ -257,8 +259,7 @@ class TestBuildCommandFeatures:
 
         parts = list(cmd.formulate())
         if builder_type == "cross":
-            assert parts[1] == "build"
-            assert all(not part.startswith("+") for part in parts[1:])
+            assert_no_toolchain_override(parts)
 
         _assert_features_in_command_parts(
             parts, test_case.expected_in_parts, test_case.expected_value

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -11,6 +11,8 @@ from types import ModuleType
 import pytest
 from plumbum.commands.processes import ProcessExecutionError
 
+from conftest import assert_no_toolchain_override
+
 if typ.TYPE_CHECKING:
     from .conftest import (
         CrossDecision,
@@ -346,8 +348,7 @@ def test_build_commands_include_manifest_path(
             context.cross_decision, target, context.manifest, ""
         )
         parts = list(cmd.formulate())
-        assert parts[1] == "build"
-        assert all(not part.startswith("+") for part in parts[1:])
+        assert_no_toolchain_override(parts)
     else:
         cmd = context.main_module._build_cargo_command(
             "+stable", target, context.manifest, ""
@@ -371,8 +372,7 @@ def test_cross_command_omits_repo_declared_nightly_override(
     parts = list(cmd.formulate())
 
     assert parts[0] == "cross"
-    assert parts[1] == "build"
-    assert all(not part.startswith("+") for part in parts[1:])
+    assert_no_toolchain_override(parts)
 
 
 def test_handle_cross_container_error_passes_manifest_to_fallback(

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -223,9 +223,7 @@ def test_main_passes_manifest_to_builder(
 
     if config.build_mode == "cross":
         harness.patch_attr("_resolve_target_argument", lambda _value: config.target)
-        harness.patch_attr(
-            "_resolve_toolchain", lambda *_: (config.toolchain, [config.toolchain])
-        )
+        harness.patch_attr("_resolve_toolchain", lambda *_: config.toolchain)
         decision = context.cross_decision_factory(context.main_module, use_cross=True)
 
         def fake_cross(
@@ -304,10 +302,10 @@ def test_main_prefers_repo_declared_toolchain(
 
     def fake_resolve_toolchain(
         _rustup_exec: str, toolchain_arg: str, target_arg: str
-    ) -> tuple[str, list[str]]:
+    ) -> str:
         captured["toolchain"] = toolchain_arg
         captured["target"] = target_arg
-        return toolchain_arg, [toolchain_arg]
+        return toolchain_arg
 
     harness.patch_attr("_resolve_toolchain", fake_resolve_toolchain)
     decision = context.cross_decision_factory(context.main_module, use_cross=False)
@@ -343,7 +341,7 @@ def test_main_exports_explicit_toolchain_to_cross_command(
     )
     harness.patch_attr(
         "_resolve_toolchain",
-        lambda *_: ("nightly-2026-03-26-x86_64-unknown-linux-gnu", []),
+        lambda *_: "nightly-2026-03-26-x86_64-unknown-linux-gnu",
     )
     harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
 
@@ -378,7 +376,7 @@ def test_main_does_not_export_cross_toolchain_without_explicit_override(
         "resolve_requested_toolchain",
         lambda *_args, **_kwargs: "1.89.0",
     )
-    harness.patch_attr("_resolve_toolchain", lambda *_: ("1.89.0", []))
+    harness.patch_attr("_resolve_toolchain", lambda *_: "1.89.0")
     harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
 
     def fake_run(cmd: object) -> None:

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -332,7 +332,7 @@ def test_main_prefers_repo_declared_toolchain(
         pytest.param(
             "nightly-2026-03-26",
             "nightly-2026-03-26-x86_64-unknown-linux-gnu",
-            {"RUSTUP_TOOLCHAIN": "nightly-2026-03-26"},
+            {"RUSTUP_TOOLCHAIN": "nightly-2026-03-26-x86_64-unknown-linux-gnu"},
             id="explicit-override",
         ),
         pytest.param(

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -430,6 +430,45 @@ def test_cross_command_omits_repo_declared_nightly_override(
     assert_no_toolchain_override(parts)
 
 
+def test_main_cross_uses_repo_declared_nightly_without_env_override(
+    build_main_context: BuildMainContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() should let cross inherit a repo-declared nightly manifest."""
+    context = build_main_context
+    harness = context.harness
+    captured: dict[str, object] = {}
+    decision = context.cross_decision_factory(context.main_module, use_cross=True)
+    monkeypatch.delenv("RBR_MANIFEST_PATH", raising=False)
+    monkeypatch.chdir(NIGHTLY_CRANELIFT_PROJECT)
+
+    harness.patch_attr("_resolve_target_argument", lambda value: value)
+
+    def fake_resolve_toolchain(
+        _rustup_exec: str, toolchain_arg: str, target_arg: str
+    ) -> str:
+        captured["toolchain"] = toolchain_arg
+        captured["target"] = target_arg
+        return "nightly-2026-03-26-x86_64-unknown-linux-gnu"
+
+    harness.patch_attr("_resolve_toolchain", fake_resolve_toolchain)
+    harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
+
+    def fake_run(cmd: object) -> None:
+        captured["parts"] = list(cmd.formulate())
+        captured["env"] = getattr(cmd, "env", {})
+
+    harness.patch_attr("run_cmd", fake_run)
+
+    context.main_module.main("aarch64-unknown-linux-gnu")
+
+    parts = typ.cast("list[str]", captured["parts"])
+    assert captured["toolchain"] == "nightly-2026-03-26"
+    assert captured["target"] == "aarch64-unknown-linux-gnu"
+    assert_no_toolchain_override(parts)
+    assert captured["env"] == {}
+
+
 def test_handle_cross_container_error_passes_manifest_to_fallback(
     cross_fallback_context: CrossFallbackContext,
 ) -> None:

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -345,12 +345,34 @@ def test_build_commands_include_manifest_path(
         cmd = context.main_module._build_cross_command(
             context.cross_decision, target, context.manifest, ""
         )
+        parts = list(cmd.formulate())
+        assert parts[1] == "build"
+        assert all(not part.startswith("+") for part in parts[1:])
     else:
         cmd = context.main_module._build_cargo_command(
             "+stable", target, context.manifest, ""
         )
 
     assert_manifest_in_command(cmd, context.manifest)
+
+
+def test_cross_command_omits_repo_declared_nightly_override(
+    build_command_context: BuildCommandContext,
+) -> None:
+    """Cross relies on the repo-declared nightly instead of a CLI override."""
+    context = build_command_context
+    cmd = context.main_module._build_cross_command(
+        context.cross_decision,
+        "aarch64-unknown-linux-gnu",
+        NIGHTLY_CRANELIFT_PROJECT / "Cargo.toml",
+        "",
+    )
+
+    parts = list(cmd.formulate())
+
+    assert parts[0] == "cross"
+    assert parts[1] == "build"
+    assert all(not part.startswith("+") for part in parts[1:])
 
 
 def test_handle_cross_container_error_passes_manifest_to_fallback(

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -329,6 +329,71 @@ def test_main_prefers_repo_declared_toolchain(
     assert captured["manifest"] == Path("Cargo.toml")
 
 
+def test_main_exports_explicit_toolchain_to_cross_command(
+    build_main_context: BuildMainContext,
+) -> None:
+    """Explicit toolchain overrides are passed to cross via RUSTUP_TOOLCHAIN."""
+    context = build_main_context
+    harness = context.harness
+    captured: dict[str, object] = {}
+    decision = context.cross_decision_factory(context.main_module, use_cross=True)
+
+    harness.patch_attr(
+        "_resolve_target_argument", lambda _value: "aarch64-unknown-linux-gnu"
+    )
+    harness.patch_attr(
+        "_resolve_toolchain",
+        lambda *_: ("nightly-2026-03-26-x86_64-unknown-linux-gnu", []),
+    )
+    harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
+
+    def fake_run(cmd: object) -> None:
+        captured["parts"] = list(cmd.formulate())
+        captured["env"] = getattr(cmd, "env", {})
+
+    harness.patch_attr("run_cmd", fake_run)
+
+    context.main_module.main(
+        "aarch64-unknown-linux-gnu", toolchain="nightly-2026-03-26"
+    )
+
+    parts = typ.cast("list[str]", captured["parts"])
+    assert_no_toolchain_override(parts)
+    assert captured["env"] == {"RUSTUP_TOOLCHAIN": "nightly-2026-03-26"}
+
+
+def test_main_does_not_export_cross_toolchain_without_explicit_override(
+    build_main_context: BuildMainContext,
+) -> None:
+    """Cross inherits the ambient toolchain selection when no override is given."""
+    context = build_main_context
+    harness = context.harness
+    captured: dict[str, object] = {}
+    decision = context.cross_decision_factory(context.main_module, use_cross=True)
+
+    harness.patch_attr(
+        "_resolve_target_argument", lambda _value: "aarch64-unknown-linux-gnu"
+    )
+    harness.patch_attr(
+        "resolve_requested_toolchain",
+        lambda *_args, **_kwargs: "1.89.0",
+    )
+    harness.patch_attr("_resolve_toolchain", lambda *_: ("1.89.0", []))
+    harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
+
+    def fake_run(cmd: object) -> None:
+        captured["parts"] = list(cmd.formulate())
+        captured["env"] = getattr(cmd, "env", {})
+
+    harness.patch_attr("run_cmd", fake_run)
+
+    context.main_module.main("aarch64-unknown-linux-gnu")
+
+    parts = typ.cast("list[str]", captured["parts"])
+    assert_no_toolchain_override(parts)
+    assert captured["env"] == {}
+
+
 @pytest.mark.parametrize(
     ("builder", "target"),
     [

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -326,45 +326,31 @@ def test_main_prefers_repo_declared_toolchain(
     assert captured["manifest"] == Path("Cargo.toml")
 
 
-def test_main_exports_explicit_toolchain_to_cross_command(
+@pytest.mark.parametrize(
+    ("explicit_toolchain", "resolved_toolchain", "expected_env"),
+    [
+        pytest.param(
+            "nightly-2026-03-26",
+            "nightly-2026-03-26-x86_64-unknown-linux-gnu",
+            {"RUSTUP_TOOLCHAIN": "nightly-2026-03-26"},
+            id="explicit-override",
+        ),
+        pytest.param(
+            None,
+            "1.89.0",
+            {},
+            id="no-override",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("setup_manifest")
+def test_main_cross_toolchain_environment(
     build_main_context: BuildMainContext,
+    explicit_toolchain: str | None,
+    resolved_toolchain: str,
+    expected_env: dict[str, str],
 ) -> None:
-    """Explicit toolchain overrides are passed to cross via RUSTUP_TOOLCHAIN."""
-    context = build_main_context
-    harness = context.harness
-    captured: dict[str, object] = {}
-    decision = context.cross_decision_factory(context.main_module, use_cross=True)
-
-    harness.patch_attr(
-        "_resolve_target_argument", lambda _value: "aarch64-unknown-linux-gnu"
-    )
-    harness.patch_attr(
-        "_resolve_toolchain",
-        lambda *_: "nightly-2026-03-26-x86_64-unknown-linux-gnu",
-    )
-    harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
-
-    def fake_run(cmd: object) -> None:
-        captured["parts"] = list(cmd.formulate())
-        captured["env"] = getattr(cmd, "env", {})
-
-    harness.patch_attr("run_cmd", fake_run)
-
-    context.main_module.main(
-        "aarch64-unknown-linux-gnu", toolchain="nightly-2026-03-26"
-    )
-
-    parts = typ.cast("list[str]", captured["parts"])
-    assert_no_toolchain_override(parts)
-    assert captured["env"] == {
-        "RUSTUP_TOOLCHAIN": "nightly-2026-03-26-x86_64-unknown-linux-gnu"
-    }
-
-
-def test_main_does_not_export_cross_toolchain_without_explicit_override(
-    build_main_context: BuildMainContext,
-) -> None:
-    """Cross inherits the ambient toolchain selection when no override is given."""
+    """Cross env export depends on whether an explicit toolchain was provided."""
     context = build_main_context
     harness = context.harness
     captured: dict[str, object] = {}
@@ -375,9 +361,9 @@ def test_main_does_not_export_cross_toolchain_without_explicit_override(
     )
     harness.patch_attr(
         "resolve_requested_toolchain",
-        lambda *_args, **_kwargs: "1.89.0",
+        lambda *_args, **_kwargs: resolved_toolchain,
     )
-    harness.patch_attr("_resolve_toolchain", lambda *_: "1.89.0")
+    harness.patch_attr("_resolve_toolchain", lambda *_: resolved_toolchain)
     harness.patch_attr("_decide_cross_usage", lambda *_, **__: decision)
 
     def fake_run(cmd: object) -> None:
@@ -386,11 +372,16 @@ def test_main_does_not_export_cross_toolchain_without_explicit_override(
 
     harness.patch_attr("run_cmd", fake_run)
 
-    context.main_module.main("aarch64-unknown-linux-gnu")
+    if explicit_toolchain is not None:
+        context.main_module.main(
+            "aarch64-unknown-linux-gnu", toolchain=explicit_toolchain
+        )
+    else:
+        context.main_module.main("aarch64-unknown-linux-gnu")
 
     parts = typ.cast("list[str]", captured["parts"])
     assert_no_toolchain_override(parts)
-    assert captured["env"] == {}
+    assert captured["env"] == expected_env
 
 
 @pytest.mark.parametrize(

--- a/.github/actions/rust-build-release/tests/test_manifest_path.py
+++ b/.github/actions/rust-build-release/tests/test_manifest_path.py
@@ -10,8 +10,7 @@ from types import ModuleType
 
 import pytest
 from plumbum.commands.processes import ProcessExecutionError
-
-from conftest import assert_no_toolchain_override
+from rust_build_release_test_helpers import assert_no_toolchain_override
 
 if typ.TYPE_CHECKING:
     from .conftest import (
@@ -357,7 +356,9 @@ def test_main_exports_explicit_toolchain_to_cross_command(
 
     parts = typ.cast("list[str]", captured["parts"])
     assert_no_toolchain_override(parts)
-    assert captured["env"] == {"RUSTUP_TOOLCHAIN": "nightly-2026-03-26"}
+    assert captured["env"] == {
+        "RUSTUP_TOOLCHAIN": "nightly-2026-03-26-x86_64-unknown-linux-gnu"
+    }
 
 
 def test_main_does_not_export_cross_toolchain_without_explicit_override(

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -531,8 +531,6 @@ def test_decide_cross_usage_marks_bsd_targets_for_container(
 
     decision = main_module._decide_cross_usage(
         toolchain_name="stable-x86_64-unknown-linux-gnu",
-        installed_names=["stable-x86_64-unknown-linux-gnu"],
-        rustup_exec="rustup",
         target=target,
         host_target=host_target,
     )

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 from plumbum.commands.processes import ProcessExecutionError
+from rust_build_release_test_helpers import assert_no_toolchain_override
 from shared_actions_conftest import (
     CMD_MOX_UNSUPPORTED,
     _register_cross_version_stub,
@@ -80,8 +81,7 @@ def test_skips_target_install_when_cross_available(
     cmd_mox.verify()
     build_cmd = typ.cast("list[str]", captured["parts"])
     assert Path(build_cmd[0]).name == "cross"
-    assert build_cmd[1] == "build"
-    assert all(not part.startswith("+") for part in build_cmd[1:])
+    assert_no_toolchain_override(build_cmd)
     assert captured["env"] == {"RUSTUP_TOOLCHAIN": default_toolchain}
 
 

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -1165,7 +1165,6 @@ def test_main_propagates_windows_linker_rustup_failure(
             cross_path=None,
             cross_version=None,
             use_cross=False,
-            cross_toolchain_spec=None,
             cargo_toolchain_spec=None,
             use_cross_local_backend=False,
             docker_present=False,

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -45,12 +45,7 @@ def test_skips_target_install_when_cross_available(
     """Continues when target addition fails but cross is available."""
     cross_env = module_harness(cross_module)
     app_env = module_harness(main_module)
-
-    def run_cmd_side_effect(cmd: list[str]) -> None:
-        if Path(cmd[0]).name == "rustup" and cmd[1:3] == ["target", "add"]:
-            raise ProcessExecutionError(cmd, 1, "", "")
-
-    app_env.patch_run_cmd(run_cmd_side_effect)
+    captured: dict[str, object] = {}
 
     default_toolchain = main_module.DEFAULT_TOOLCHAIN
     rustup_stdout = f"{default_toolchain}-x86_64-unknown-linux-gnu\n"
@@ -69,13 +64,25 @@ def test_skips_target_install_when_cross_available(
     cross_env.patch_shutil_which(fake_which)
     app_env.patch_shutil_which(fake_which)
 
+    def fake_run(cmd: object) -> None:
+        parts = list(cmd.formulate())
+        env = getattr(cmd, "env", {})
+        if Path(parts[0]).name == "rustup" and parts[1:3] == ["target", "add"]:
+            raise ProcessExecutionError(parts, 1, "", "")
+        captured["parts"] = parts
+        captured["env"] = env
+
+    app_env.patch_attr("run_cmd", fake_run)
+
     cmd_mox.replay()
 
     main_module.main("aarch64-pc-windows-gnu", default_toolchain)
     cmd_mox.verify()
-    build_cmd = app_env.calls[-1]
+    build_cmd = typ.cast("list[str]", captured["parts"])
     assert Path(build_cmd[0]).name == "cross"
-    assert build_cmd[1] == f"+{default_toolchain}"
+    assert build_cmd[1] == "build"
+    assert all(not part.startswith("+") for part in build_cmd[1:])
+    assert captured["env"] == {"RUSTUP_TOOLCHAIN": default_toolchain}
 
 
 @CMD_MOX_UNSUPPORTED

--- a/.github/actions/rust-build-release/tests/test_target_install.py
+++ b/.github/actions/rust-build-release/tests/test_target_install.py
@@ -1154,7 +1154,7 @@ def test_main_propagates_windows_linker_rustup_failure(
     harness.patch_attr("_ensure_rustup_exec", lambda: rustup_path)
     harness.patch_attr(
         "_resolve_toolchain",
-        lambda *_: (toolchain_name, [toolchain_name]),
+        lambda *_: toolchain_name,
     )
     harness.patch_attr("_ensure_target_installed", lambda *_: True)
     harness.patch_attr(

--- a/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
+++ b/.github/actions/rust-build-release/tests/test_toolchain_sanitize.py
@@ -1,4 +1,4 @@
-"""Verify toolchain triple is sanitized for cross."""
+"""Regression coverage for repo-declared toolchains and cross builds."""
 
 from __future__ import annotations
 
@@ -16,27 +16,11 @@ from cmd_utils_importer import import_cmd_utils
 from test_support.plumbum_helpers import run_plumbum_command
 
 if typ.TYPE_CHECKING:
-    from types import ModuleType
-
     from ._packaging_utils import PackagingProject as _PackagingProject
 
 _cmd_utils = import_cmd_utils()
 RunResult = _cmd_utils.RunResult
 run_cmd = _cmd_utils.run_cmd
-
-
-def test_toolchain_channel_strips_host_triple(main_module: ModuleType) -> None:
-    """The action strips host triples when preparing cross CLI overrides."""
-    channel = main_module._toolchain_channel("1.89.0-x86_64-unknown-linux-gnu")
-    assert channel == "1.89.0"
-
-    nightly = main_module._toolchain_channel(
-        "nightly-2024-08-10-x86_64-unknown-linux-gnu"
-    )
-    assert nightly == "nightly-2024-08-10"
-
-    stable = main_module._toolchain_channel("stable")
-    assert stable == "stable"
 
 
 os.environ.setdefault("CROSS_CONTAINER_ENGINE", "docker")


### PR DESCRIPTION
## Summary
- remove the explicit `+toolchain` override from `cross build` in `rust-build-release`
- drop the cross-only toolchain sanitization/install path that only existed to support that CLI override
- update tests to assert that cross relies on the repo-declared toolchain instead of injecting a `+...` argument

## Why
When a target repository already pins a dated nightly in `rust-toolchain.toml`, rustup exports `RUSTUP_TOOLCHAIN=nightly-YYYY-MM-DD`. Passing `cross +nightly-YYYY-MM-DD build ...` at the same time causes cross/rustup to combine both sources into an invalid toolchain name with the date repeated, which rustup rejects.

## Impact
`cross` now resolves its toolchain solely from `RUSTUP_TOOLCHAIN` or the repository's `rust-toolchain.toml`, while cargo keeps its existing explicit toolchain override behavior.

## Validation
- `make check-fmt`
- `make typecheck`
- `make lint`
- `make test`
- focused `rust-build-release` pytest run covering the command shape regression

## Summary by Sourcery

Rely on the repository’s or rustup’s toolchain resolution for cross builds instead of injecting an explicit toolchain override, and adjust tests accordingly.

Bug Fixes:
- Prevent invalid toolchain names when invoking cross by no longer passing an explicit +toolchain override.

Enhancements:
- Simplify cross decision logic by removing special toolchain sanitization and installation for cross invocations.

Tests:
- Update and extend rust-build-release tests to assert that cross build commands omit +toolchain arguments and rely on the repo-declared toolchain.