### PR TITLE
Run Python coverage tooling in a venv

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.3.14 (2026-04-28)
+
+- Run Python coverage tooling in an isolated, job-local virtual environment
+  (`.venv-coverage`) instead of using `uv run --with`. The venv is created
+  once per process, reused across calls within the same job, and repaired
+  automatically when the Python executable is missing.
+- Project dependencies are synced into the venv via `uv sync --inexact
+  --python`; `slipcover`, `pytest`, and `coverage` are installed via
+  `uv pip install --python` without `--system`.
+- Broken-venv recovery: if `.venv-coverage` exists but its Python executable
+  is absent or a non-directory placeholder occupies its path, the directory is
+  removed and recreated before proceeding.
+
 ## v1.3.13 (2026-04-16)
 
 - Override Cranelift coverage builds via

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -46,6 +46,7 @@ codegen-backend-related variables first, and then merges
 `get_cargo_coverage_env(manifest_path)` on top so workflow-level Cranelift
 exports are not treated as the default coverage behaviour.
 
+<!-- markdownlint-disable MD013 -->
 ```mermaid
 sequenceDiagram
     actor GitHubActions
@@ -79,6 +80,7 @@ sequenceDiagram
         _run_cargo-->>run_rust_py: stdout
     end
 ```
+<!-- markdownlint-enable MD013 -->
 
 ## Cranelift codegen backend support
 
@@ -124,6 +126,7 @@ Known limitations:
 
 ## Inputs
 
+<!-- markdownlint-disable MD013 -->
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
 | features | Enable Cargo (Rust) features; space- or comma-separated. | no | |
@@ -135,11 +138,11 @@ Known limitations:
 | with-ratchet | Fail if coverage drops below baseline | no | `false` |
 | artefact-name-suffix | Additional suffix appended to the uploaded coverage artefact | no | |
 | baseline-rust-file | Rust baseline path | no | `.coverage-baseline.rust` |
-<!-- markdownlint-disable-next-line MD013 -->
 | baseline-python-file | Python baseline path | no | `.coverage-baseline.python` |
 | with-cucumber-rs | Run cucumber-rs scenarios under coverage | no | `false` |
 | cucumber-rs-features | Path to cucumber feature files | no | |
 | cucumber-rs-args | Extra arguments for cucumber | no | |
+<!-- markdownlint-enable MD013 -->
 
 \* `lcov` is only supported for Rust projects, while `coveragepy` is only
 supported for Python projects. Mixed projects must use `cobertura`.

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -7,9 +7,10 @@ projects. The action uses `cargo llvm-cov` (with `cargo nextest` by default)
 when a `Cargo.toml` is present and `slipcover` with `pytest` when a
 `pyproject.toml` is present. If the repository root does not contain a Cargo
 manifest, set `cargo-manifest` to point to a nested `Cargo.toml`. It installs
-`slipcover`, `pytest`, and `coverage` automatically via `uv` into an isolated
-throwaway virtual environment (`.venv-coverage`) before running the tests, so
-no system-level Python installs are required.
+the project dependencies plus `slipcover`, `pytest`, and `coverage`
+automatically via `uv` into an isolated throwaway virtual environment
+(`.venv-coverage`) before running the tests, so no system-level Python installs
+are required.
 When Rust coverage is required, `cargo-llvm-cov` and `cargo-nextest` are
 installed automatically. If both configuration files are present, coverage is
 run for each language and the Cobertura reports are merged using

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -7,8 +7,9 @@ projects. The action uses `cargo llvm-cov` (with `cargo nextest` by default)
 when a `Cargo.toml` is present and `slipcover` with `pytest` when a
 `pyproject.toml` is present. If the repository root does not contain a Cargo
 manifest, set `cargo-manifest` to point to a nested `Cargo.toml`. It installs
-`slipcover` and `pytest` automatically via `uv` before running the tests,
-leveraging ``uv run --with`` so no system-level Python installs are required.
+`slipcover`, `pytest`, and `coverage` automatically via `uv` into an isolated
+throwaway virtual environment (`.venv-coverage`) before running the tests, so
+no system-level Python installs are required.
 When Rust coverage is required, `cargo-llvm-cov` and `cargo-nextest` are
 installed automatically. If both configuration files are present, coverage is
 run for each language and the Cobertura reports are merged using

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -55,10 +55,7 @@ def _find_coverage_python() -> Path | None:
         COVERAGE_VENV / "Scripts" / "python.exe",
         COVERAGE_VENV / "Scripts" / "python",
     )
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
-    return None
+    return next((c for c in candidates if c.is_file()), None)
 
 
 def _remove_coverage_venv() -> None:
@@ -212,6 +209,27 @@ def tmp_coveragepy_xml(out: Path) -> cabc.Generator[Path]:
         xml_tmp.unlink(missing_ok=True)
 
 
+def _resolve_output_path(output_path: Path, lang: str) -> Path:
+    """Return the effective output path, accounting for mixed-language projects.
+
+    Parameters
+    ----------
+    output_path : Path
+        Base output path supplied by the caller.
+    lang : str
+        Detected project language.  When ``"mixed"``, a ``.python`` infix
+        is inserted between the stem and the suffix.
+
+    Returns
+    -------
+    Path
+        Adjusted output path.
+    """
+    if lang == "mixed":
+        return output_path.with_name(f"{output_path.stem}.python{output_path.suffix}")
+    return output_path
+
+
 def main(
     output_path: Path = OUTPUT_PATH_OPT,
     lang: str = LANG_OPT,
@@ -238,9 +256,7 @@ def main(
         Optional path to a previous coverage baseline file.  When present,
         the previous percentage is echoed to the log.
     """
-    out = output_path
-    if lang == "mixed":
-        out = output_path.with_name(f"{output_path.stem}.python{output_path.suffix}")
+    out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)
 
     cmd = coverage_cmd_for_fmt(fmt, out)

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -59,7 +59,7 @@ def _find_coverage_python() -> Path | None:
         COVERAGE_VENV / "Scripts" / "python.exe",
         COVERAGE_VENV / "Scripts" / "python",
     )
-    return next((c for c in candidates if c.is_file()), None)
+    return next((c.resolve() for c in candidates if c.is_file()), None)
 
 
 def _remove_coverage_venv() -> None:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -265,6 +265,67 @@ def _resolve_output_path(output_path: Path, lang: str) -> Path:
     return output_path
 
 
+def _run_slipcover(fmt: str, out: Path) -> None:
+    """Build and execute the slipcover command, converting errors to typer.Exit.
+
+    Parameters
+    ----------
+    fmt : str
+        Coverage format identifier; forwarded to
+        :func:`coverage_cmd_for_fmt`.
+    out : Path
+        Destination path for the coverage output file.
+
+    Raises
+    ------
+    typer.Exit
+        When the slipcover/pytest command exits non-zero (preserving the
+        original return code) or when venv setup raises ``RuntimeError``.
+    """
+    try:
+        cmd = coverage_cmd_for_fmt(fmt, out)
+        run_cmd(cmd, method="run_fg")
+    except ProcessExecutionError as exc:
+        raise typer.Exit(code=exc.retcode or 1) from exc
+    except RuntimeError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _parse_coverage_percent(fmt: str, out: Path) -> str:
+    """Run coverage-format post-processing and return the line-coverage percentage.
+
+    For ``"coveragepy"`` format, invokes ``coverage xml`` via
+    :func:`tmp_coveragepy_xml` to produce a Cobertura XML, parses it,
+    then moves the ``.coverage`` data file into ``out``.  For all other
+    formats, parses ``out`` directly as a Cobertura XML.
+
+    Parameters
+    ----------
+    fmt : str
+        Coverage format identifier.
+    out : Path
+        Path to the coverage output file produced by slipcover.
+
+    Returns
+    -------
+    str
+        Line coverage percentage.
+
+    Raises
+    ------
+    typer.Exit
+        Propagated from :func:`tmp_coveragepy_xml` when ``coverage xml``
+        exits non-zero.
+    """
+    if fmt == "coveragepy":
+        with tmp_coveragepy_xml(out) as xml_tmp:
+            percent = get_line_coverage_percent_from_cobertura(xml_tmp)
+        Path(".coverage").replace(out)
+        return percent
+    return get_line_coverage_percent_from_cobertura(out)
+
+
 def main(
     output_path: Path = OUTPUT_PATH_OPT,
     lang: str = LANG_OPT,
@@ -301,21 +362,8 @@ def main(
     out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    try:
-        cmd = coverage_cmd_for_fmt(fmt, out)
-        run_cmd(cmd, method="run_fg")
-    except ProcessExecutionError as exc:
-        raise typer.Exit(code=exc.retcode or 1) from exc
-    except RuntimeError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1) from exc
-
-    if fmt == "coveragepy":
-        with tmp_coveragepy_xml(out) as xml_tmp:
-            percent = get_line_coverage_percent_from_cobertura(xml_tmp)
-        Path(".coverage").replace(out)
-    else:
-        percent = get_line_coverage_percent_from_cobertura(out)
+    _run_slipcover(fmt, out)
+    percent = _parse_coverage_percent(fmt, out)
 
     typer.echo(f"Current coverage: {percent}%")
     previous = read_previous_coverage(baseline_file)

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -72,7 +72,10 @@ def _ensure_coverage_venv() -> str:
                 "executable; recreating.",
                 err=True,
             )
-            shutil.rmtree(COVERAGE_VENV)
+            if COVERAGE_VENV.is_dir() and not COVERAGE_VENV.is_symlink():
+                shutil.rmtree(COVERAGE_VENV)
+            else:
+                COVERAGE_VENV.unlink(missing_ok=True)
         else:
             typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
         run_cmd(uv["venv", str(COVERAGE_VENV)])

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -301,11 +301,14 @@ def main(
     out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    cmd = coverage_cmd_for_fmt(fmt, out)
     try:
+        cmd = coverage_cmd_for_fmt(fmt, out)
         run_cmd(cmd, method="run_fg")
     except ProcessExecutionError as exc:
         raise typer.Exit(code=exc.retcode or 1) from exc
+    except RuntimeError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
 
     if fmt == "coveragepy":
         with tmp_coveragepy_xml(out) as xml_tmp:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -48,6 +48,8 @@ PYTEST_ARGS: tuple[str, ...] = (
 
 def _find_coverage_python() -> Path | None:
     """Return the coverage venv Python executable path when it exists."""
+    if COVERAGE_VENV.is_symlink() or not COVERAGE_VENV.is_dir():
+        return None
     candidates = (
         COVERAGE_VENV / "bin" / "python",
         COVERAGE_VENV / "Scripts" / "python.exe",

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -105,6 +105,49 @@ def _recreate_coverage_venv() -> Path:
     return python
 
 
+@contextlib.contextmanager
+def _project_env(venv: Path) -> cabc.Iterator[None]:
+    """Temporarily set UV_PROJECT_ENVIRONMENT to the given venv path."""
+    previous = os.environ.get("UV_PROJECT_ENVIRONMENT")
+    os.environ["UV_PROJECT_ENVIRONMENT"] = str(venv.resolve())
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("UV_PROJECT_ENVIRONMENT", None)
+        else:
+            os.environ["UV_PROJECT_ENVIRONMENT"] = previous
+
+
+def _sync_project_deps(python: Path) -> None:
+    """Run `uv sync` for the project into the coverage venv, with logs."""
+    typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
+    try:
+        with _project_env(COVERAGE_VENV):
+            run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
+        typer.echo(f"Project dependencies installed into {COVERAGE_VENV}")
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"uv sync failed with code {exc.retcode}: {exc.stderr}",
+            err=True,
+        )
+        raise
+
+
+def _install_coverage_tooling(python: Path) -> None:
+    """Install slipcover/pytest/coverage into the venv, with logs."""
+    typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
+    try:
+        run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"uv pip install failed with code {exc.retcode}: {exc.stderr}",
+            err=True,
+        )
+        raise
+    typer.echo(f"Coverage tooling installed into {COVERAGE_VENV}")
+
+
 def _ensure_coverage_venv() -> str:
     """Create or repair the coverage venv and install project/test tooling.
 
@@ -133,33 +176,8 @@ def _ensure_coverage_venv() -> str:
         python = _recreate_coverage_venv()
     else:
         typer.echo(f"Reusing existing coverage venv at {COVERAGE_VENV}")
-    typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
-    previous_project_environment = os.environ.get("UV_PROJECT_ENVIRONMENT")
-    os.environ["UV_PROJECT_ENVIRONMENT"] = str(COVERAGE_VENV.resolve())
-    try:
-        run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
-        typer.echo(f"Project dependencies installed into {COVERAGE_VENV}")
-    except ProcessExecutionError as exc:
-        typer.echo(
-            f"uv sync failed with code {exc.retcode}: {exc.stderr}",
-            err=True,
-        )
-        raise
-    finally:
-        if previous_project_environment is None:
-            os.environ.pop("UV_PROJECT_ENVIRONMENT", None)
-        else:
-            os.environ["UV_PROJECT_ENVIRONMENT"] = previous_project_environment
-    typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
-    try:
-        run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])
-    except ProcessExecutionError as exc:
-        typer.echo(
-            f"uv pip install failed with code {exc.retcode}: {exc.stderr}",
-            err=True,
-        )
-        raise
-    typer.echo(f"Coverage tooling installed into {COVERAGE_VENV}")
+    _sync_project_deps(python)
+    _install_coverage_tooling(python)
     return str(python)
 
 

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -31,6 +31,11 @@ GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
 COVERAGE_VENV = Path(".venv-coverage")
 TOOLING_PACKAGES: tuple[str, ...] = ("slipcover", "pytest", "coverage")
+# _COVERAGE_PYTHON_CMD is a module-level lazy singleton.  GitHub Actions
+# runners execute action steps sequentially in a single thread, so no
+# synchronisation is required.  The variable is None until the first call
+# to _coverage_python_cmd(), after which it is reused for the lifetime of
+# the process.
 _COVERAGE_PYTHON_CMD: BoundCommand | None = None
 
 SLIPCOVER_ARGS: tuple[str, ...] = (
@@ -61,32 +66,76 @@ def _coverage_python_path() -> Path:
 
 
 def create_venv() -> str:
-    """Create a throwaway venv for coverage tooling; return python path."""
+    """Create a throwaway venv for coverage tooling.
+
+    If the venv directory already exists but its Python executable cannot be
+    located (broken-cache state), the directory is removed and the venv is
+    recreated before returning the interpreter path.
+
+    Returns
+    -------
+    str
+        Absolute path to the Python executable inside the created venv.
+    """
     if not COVERAGE_VENV.exists():
+        typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
         run_cmd(uv["venv", str(COVERAGE_VENV)])
+    else:
+        typer.echo(f"Reusing existing coverage venv at {COVERAGE_VENV}")
     try:
-        return str(_coverage_python_path())
+        python = str(_coverage_python_path())
     except RuntimeError:
-        if COVERAGE_VENV.is_dir() and not COVERAGE_VENV.is_symlink():
-            shutil.rmtree(COVERAGE_VENV)
-        else:
-            COVERAGE_VENV.unlink(missing_ok=True)
+        typer.echo(
+            f"Coverage venv at {COVERAGE_VENV} is missing its Python "
+            "executable; recreating.",
+            err=True,
+        )
+        shutil.rmtree(COVERAGE_VENV)
         run_cmd(uv["venv", str(COVERAGE_VENV)])
-        return str(_coverage_python_path())
+        python = str(_coverage_python_path())
+    return python
 
 
 def install_coverage_tools(python: str) -> None:
-    """Install coverage tooling into the throwaway venv."""
+    """Install coverage tooling into the throwaway venv.
+
+    Parameters
+    ----------
+    python : str
+        Path to the Python executable inside the target venv, as returned by
+        create_venv().
+
+    Raises
+    ------
+    plumbum.commands.processes.ProcessExecutionError
+        Propagated from run_cmd() when uv pip install fails.
+    """
+    typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
     run_cmd(uv["pip", "install", "--python", python, *TOOLING_PACKAGES])
 
 
 def _coverage_python_cmd() -> BoundCommand:
-    """Return a python command with coverage tooling available."""
+    """Set up the coverage venv on first call and return the cached command.
+
+    Side effects on first call
+    --------------------------
+    * Creates .venv-coverage via create_venv() (recreates on broken cache).
+    * Installs slipcover, pytest, and coverage into the venv.
+    * Caches the resulting BoundCommand in _COVERAGE_PYTHON_CMD.
+
+    Returns
+    -------
+    BoundCommand
+        A plumbum command bound to the venv's Python executable.
+    """
     global _COVERAGE_PYTHON_CMD
-    if _COVERAGE_PYTHON_CMD is None:
-        python = create_venv()
-        install_coverage_tools(python)
-        _COVERAGE_PYTHON_CMD = local[python]
+    if _COVERAGE_PYTHON_CMD is not None:
+        typer.echo("Reusing cached coverage Python command.")
+        return _COVERAGE_PYTHON_CMD
+    typer.echo("Setting up coverage Python environment (first use).")
+    python = create_venv()
+    install_coverage_tools(python)
+    _COVERAGE_PYTHON_CMD = local[python]
     return _COVERAGE_PYTHON_CMD
 
 

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import collections.abc as cabc  # noqa: TC003 - used at runtime
 import contextlib
+import shutil
 import typing as typ
 from pathlib import Path
 
@@ -52,7 +53,7 @@ def _coverage_python_path() -> Path:
         COVERAGE_VENV / "Scripts" / "python",
     )
     for candidate in candidates:
-        if candidate.exists():
+        if candidate.is_file():
             return candidate
     paths = ", ".join(str(candidate) for candidate in candidates)
     msg = f"Coverage venv Python executable not found; checked: {paths}"
@@ -63,7 +64,15 @@ def create_venv() -> str:
     """Create a throwaway venv for coverage tooling; return python path."""
     if not COVERAGE_VENV.exists():
         run_cmd(uv["venv", str(COVERAGE_VENV)])
-    return str(_coverage_python_path())
+    try:
+        return str(_coverage_python_path())
+    except RuntimeError:
+        if COVERAGE_VENV.is_dir() and not COVERAGE_VENV.is_symlink():
+            shutil.rmtree(COVERAGE_VENV)
+        else:
+            COVERAGE_VENV.unlink(missing_ok=True)
+        run_cmd(uv["venv", str(COVERAGE_VENV)])
+        return str(_coverage_python_path())
 
 
 def install_coverage_tools(python: str) -> None:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -31,6 +31,9 @@ LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
 FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
 GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
+# COVERAGE_VENV is a process-scoped constant.  It is consumed by
+# _ensure_coverage_venv() and _coverage_python_cmd(), both of which are
+# called from a single-threaded GitHub Actions step.
 COVERAGE_VENV = Path(".venv-coverage")
 TOOLING_PACKAGES: tuple[str, ...] = ("slipcover", "pytest", "coverage")
 PROJECT_SYNC_ARGS: tuple[str, ...] = ("sync", "--inexact", "--python")
@@ -94,6 +97,7 @@ def _recreate_coverage_venv() -> Path:
     else:
         typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
     run_cmd(uv["venv", str(COVERAGE_VENV)])
+    typer.echo(f"Coverage venv created at {COVERAGE_VENV}")
     python = _find_coverage_python()
     if python is None:
         msg = f"Coverage venv Python executable not found in {COVERAGE_VENV}"
@@ -104,7 +108,25 @@ def _recreate_coverage_venv() -> Path:
 def _ensure_coverage_venv() -> str:
     """Create or repair the coverage venv and install project/test tooling.
 
-    Returns the Python executable path inside the isolated coverage venv.
+    Checks whether ``.venv-coverage`` contains a healthy Python executable.
+    If not, delegates to :func:`_recreate_coverage_venv` to remove any
+    broken state and create a fresh venv.  Then runs ``uv sync`` to install
+    project dependencies, followed by ``uv pip install`` to add
+    ``slipcover``, ``pytest``, and ``coverage``.
+
+    Returns
+    -------
+    str
+        Absolute path to the Python executable inside the coverage venv.
+
+    Raises
+    ------
+    RuntimeError
+        Propagated from :func:`_recreate_coverage_venv` when the Python
+        executable cannot be located after venv creation.
+    plumbum.commands.processes.ProcessExecutionError
+        Propagated from ``uv sync`` or ``uv pip install`` when either
+        command exits with a non-zero return code.
     """
     python = _find_coverage_python()
     if python is None:
@@ -134,9 +156,14 @@ def _ensure_coverage_venv() -> str:
             err=True,
         )
         raise
+    typer.echo(f"Coverage tooling installed into {COVERAGE_VENV}")
     return str(python)
 
 
+# _coverage_python_cmd() is memoised with lru_cache rather than using a
+# mutable global.  GitHub Actions executes action steps sequentially in a
+# single thread, so no synchronisation is required; the cache is safe to
+# use without a lock for the lifetime of this process.
 @lru_cache(maxsize=1)
 def _coverage_python_cmd() -> BoundCommand:
     """Return the coverage venv Python command, creating it on first use."""
@@ -263,6 +290,13 @@ def main(
     baseline_file : Path or None
         Optional path to a previous coverage baseline file.  When present,
         the previous percentage is echoed to the log.
+
+    Raises
+    ------
+    typer.Exit
+        With the subprocess return code when the slipcover/coverage command
+        exits non-zero, or when ``coverage xml`` fails in ``coveragepy``
+        format mode.
     """
     out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -11,6 +11,7 @@ import collections.abc as cabc  # noqa: TC003 - used at runtime
 import contextlib
 import shutil
 import typing as typ
+from functools import lru_cache
 from pathlib import Path
 
 import typer
@@ -31,12 +32,6 @@ GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
 COVERAGE_VENV = Path(".venv-coverage")
 TOOLING_PACKAGES: tuple[str, ...] = ("slipcover", "pytest", "coverage")
-# _COVERAGE_PYTHON_CMD is a module-level lazy singleton.  GitHub Actions
-# runners execute action steps sequentially in a single thread, so no
-# synchronisation is required.  The variable is None until the first call
-# to _coverage_python_cmd(), after which it is reused for the lifetime of
-# the process.
-_COVERAGE_PYTHON_CMD: BoundCommand | None = None
 
 SLIPCOVER_ARGS: tuple[str, ...] = (
     "-m",
@@ -50,8 +45,8 @@ PYTEST_ARGS: tuple[str, ...] = (
 )
 
 
-def _coverage_python_path() -> Path:
-    """Return the Python executable path inside the coverage venv."""
+def _find_coverage_python() -> Path | None:
+    """Return the coverage venv Python executable path when it exists."""
     candidates = (
         COVERAGE_VENV / "bin" / "python",
         COVERAGE_VENV / "Scripts" / "python.exe",
@@ -60,83 +55,40 @@ def _coverage_python_path() -> Path:
     for candidate in candidates:
         if candidate.is_file():
             return candidate
-    paths = ", ".join(str(candidate) for candidate in candidates)
-    msg = f"Coverage venv Python executable not found; checked: {paths}"
-    raise RuntimeError(msg)
+    return None
 
 
-def create_venv() -> str:
-    """Create a throwaway venv for coverage tooling.
+def _ensure_coverage_venv() -> str:
+    """Create or repair the coverage venv and install coverage tooling.
 
-    If the venv directory already exists but its Python executable cannot be
-    located (broken-cache state), the directory is removed and the venv is
-    recreated before returning the interpreter path.
-
-    Returns
-    -------
-    str
-        Absolute path to the Python executable inside the created venv.
+    Returns the Python executable path inside the isolated coverage venv.
     """
-    if not COVERAGE_VENV.exists():
-        typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
+    python = _find_coverage_python()
+    if python is None:
+        if COVERAGE_VENV.exists():
+            typer.echo(
+                f"Coverage venv at {COVERAGE_VENV} is missing its Python "
+                "executable; recreating.",
+                err=True,
+            )
+            shutil.rmtree(COVERAGE_VENV)
+        else:
+            typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
         run_cmd(uv["venv", str(COVERAGE_VENV)])
-    else:
-        typer.echo(f"Reusing existing coverage venv at {COVERAGE_VENV}")
-    try:
-        python = str(_coverage_python_path())
-    except RuntimeError:
-        typer.echo(
-            f"Coverage venv at {COVERAGE_VENV} is missing its Python "
-            "executable; recreating.",
-            err=True,
-        )
-        shutil.rmtree(COVERAGE_VENV)
-        run_cmd(uv["venv", str(COVERAGE_VENV)])
-        python = str(_coverage_python_path())
-    return python
-
-
-def install_coverage_tools(python: str) -> None:
-    """Install coverage tooling into the throwaway venv.
-
-    Parameters
-    ----------
-    python : str
-        Path to the Python executable inside the target venv, as returned by
-        create_venv().
-
-    Raises
-    ------
-    plumbum.commands.processes.ProcessExecutionError
-        Propagated from run_cmd() when uv pip install fails.
-    """
+        python = _find_coverage_python()
+        if python is None:
+            msg = f"Coverage venv Python executable not found in {COVERAGE_VENV}"
+            raise RuntimeError(msg)
     typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
-    run_cmd(uv["pip", "install", "--python", python, *TOOLING_PACKAGES])
+    run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])
+    return str(python)
 
 
+@lru_cache(maxsize=1)
 def _coverage_python_cmd() -> BoundCommand:
-    """Set up the coverage venv on first call and return the cached command.
-
-    Side effects on first call
-    --------------------------
-    * Creates .venv-coverage via create_venv() (recreates on broken cache).
-    * Installs slipcover, pytest, and coverage into the venv.
-    * Caches the resulting BoundCommand in _COVERAGE_PYTHON_CMD.
-
-    Returns
-    -------
-    BoundCommand
-        A plumbum command bound to the venv's Python executable.
-    """
-    global _COVERAGE_PYTHON_CMD
-    if _COVERAGE_PYTHON_CMD is not None:
-        typer.echo("Reusing cached coverage Python command.")
-        return _COVERAGE_PYTHON_CMD
-    typer.echo("Setting up coverage Python environment (first use).")
-    python = create_venv()
-    install_coverage_tools(python)
-    _COVERAGE_PYTHON_CMD = local[python]
-    return _COVERAGE_PYTHON_CMD
+    """Return the coverage venv Python command, creating it on first use."""
+    python = _ensure_coverage_venv()
+    return local[python]
 
 
 def _coverage_args(fmt: str, out: Path) -> list[str]:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -131,11 +131,14 @@ def _ensure_coverage_venv() -> str:
     python = _find_coverage_python()
     if python is None:
         python = _recreate_coverage_venv()
+    else:
+        typer.echo(f"Reusing existing coverage venv at {COVERAGE_VENV}")
     typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
     previous_project_environment = os.environ.get("UV_PROJECT_ENVIRONMENT")
     os.environ["UV_PROJECT_ENVIRONMENT"] = str(COVERAGE_VENV.resolve())
     try:
         run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
+        typer.echo(f"Project dependencies installed into {COVERAGE_VENV}")
     except ProcessExecutionError as exc:
         typer.echo(
             f"uv sync failed with code {exc.retcode}: {exc.stderr}",

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -32,6 +32,7 @@ GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
 COVERAGE_VENV = Path(".venv-coverage")
 TOOLING_PACKAGES: tuple[str, ...] = ("slipcover", "pytest", "coverage")
+PROJECT_SYNC_ARGS: tuple[str, ...] = ("sync", "--inexact", "--python")
 
 SLIPCOVER_ARGS: tuple[str, ...] = (
     "-m",
@@ -59,7 +60,7 @@ def _find_coverage_python() -> Path | None:
 
 
 def _ensure_coverage_venv() -> str:
-    """Create or repair the coverage venv and install coverage tooling.
+    """Create or repair the coverage venv and install project/test tooling.
 
     Returns the Python executable path inside the isolated coverage venv.
     """
@@ -79,6 +80,8 @@ def _ensure_coverage_venv() -> str:
         if python is None:
             msg = f"Coverage venv Python executable not found in {COVERAGE_VENV}"
             raise RuntimeError(msg)
+    typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
+    run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
     typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
     run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])
     return str(python)

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -110,6 +110,7 @@ def _ensure_coverage_venv() -> str:
     if python is None:
         python = _recreate_coverage_venv()
     typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
+    previous_project_environment = os.environ.get("UV_PROJECT_ENVIRONMENT")
     os.environ["UV_PROJECT_ENVIRONMENT"] = str(COVERAGE_VENV.resolve())
     try:
         run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
@@ -119,6 +120,11 @@ def _ensure_coverage_venv() -> str:
             err=True,
         )
         raise
+    finally:
+        if previous_project_environment is None:
+            os.environ.pop("UV_PROJECT_ENVIRONMENT", None)
+        else:
+            os.environ["UV_PROJECT_ENVIRONMENT"] = previous_project_environment
     typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
     try:
         run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -59,6 +59,48 @@ def _find_coverage_python() -> Path | None:
     return None
 
 
+def _remove_coverage_venv() -> None:
+    """Remove the coverage venv directory or non-directory placeholder.
+
+    Uses ``shutil.rmtree`` for directories and ``Path.unlink`` for any
+    other filesystem object (e.g. a symlink or a stale file).
+    """
+    if COVERAGE_VENV.is_dir() and not COVERAGE_VENV.is_symlink():
+        shutil.rmtree(COVERAGE_VENV)
+    else:
+        COVERAGE_VENV.unlink(missing_ok=True)
+
+
+def _recreate_coverage_venv() -> Path:
+    """Remove any existing broken venv, create a fresh one, and return its Python.
+
+    Returns
+    -------
+    Path
+        Absolute path to the Python executable inside the newly created venv.
+
+    Raises
+    ------
+    RuntimeError
+        If the Python executable cannot be located after creation.
+    """
+    if COVERAGE_VENV.exists():
+        typer.echo(
+            f"Coverage venv at {COVERAGE_VENV} is missing its Python "
+            "executable; recreating.",
+            err=True,
+        )
+        _remove_coverage_venv()
+    else:
+        typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
+    run_cmd(uv["venv", str(COVERAGE_VENV)])
+    python = _find_coverage_python()
+    if python is None:
+        msg = f"Coverage venv Python executable not found in {COVERAGE_VENV}"
+        raise RuntimeError(msg)
+    return python
+
+
 def _ensure_coverage_venv() -> str:
     """Create or repair the coverage venv and install project/test tooling.
 
@@ -66,23 +108,7 @@ def _ensure_coverage_venv() -> str:
     """
     python = _find_coverage_python()
     if python is None:
-        if COVERAGE_VENV.exists():
-            typer.echo(
-                f"Coverage venv at {COVERAGE_VENV} is missing its Python "
-                "executable; recreating.",
-                err=True,
-            )
-            if COVERAGE_VENV.is_dir() and not COVERAGE_VENV.is_symlink():
-                shutil.rmtree(COVERAGE_VENV)
-            else:
-                COVERAGE_VENV.unlink(missing_ok=True)
-        else:
-            typer.echo(f"Creating coverage venv at {COVERAGE_VENV}")
-        run_cmd(uv["venv", str(COVERAGE_VENV)])
-        python = _find_coverage_python()
-        if python is None:
-            msg = f"Coverage venv Python executable not found in {COVERAGE_VENV}"
-            raise RuntimeError(msg)
+        python = _recreate_coverage_venv()
     typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
     run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
     typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -86,7 +86,7 @@ def _recreate_coverage_venv() -> Path:
     RuntimeError
         If the Python executable cannot be located after creation.
     """
-    if COVERAGE_VENV.exists():
+    if COVERAGE_VENV.exists() or COVERAGE_VENV.is_symlink():
         typer.echo(
             f"Coverage venv at {COVERAGE_VENV} is missing its Python "
             "executable; recreating.",

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -265,22 +265,27 @@ def _resolve_output_path(output_path: Path, lang: str) -> Path:
     return output_path
 
 
-def _run_slipcover(fmt: str, out: Path) -> None:
-    """Build and execute the slipcover command, converting errors to typer.Exit.
+def _run_coverage(fmt: str, out: Path) -> str:
+    """Run slipcover and return the line coverage percentage.
 
     Parameters
     ----------
     fmt : str
-        Coverage format identifier; forwarded to
-        :func:`coverage_cmd_for_fmt`.
+        Coverage format identifier passed to :func:`coverage_cmd_for_fmt`.
     out : Path
         Destination path for the coverage output file.
+
+    Returns
+    -------
+    str
+        Line coverage percentage parsed from the generated report.
 
     Raises
     ------
     typer.Exit
-        When the slipcover/pytest command exits non-zero (preserving the
-        original return code) or when venv setup raises ``RuntimeError``.
+        With the subprocess return code when the slipcover/coverage
+        command exits non-zero, or when ``coverage xml`` fails in
+        ``coveragepy`` format mode.
     """
     try:
         cmd = coverage_cmd_for_fmt(fmt, out)
@@ -291,33 +296,6 @@ def _run_slipcover(fmt: str, out: Path) -> None:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1) from exc
 
-
-def _parse_coverage_percent(fmt: str, out: Path) -> str:
-    """Run coverage-format post-processing and return the line-coverage percentage.
-
-    For ``"coveragepy"`` format, invokes ``coverage xml`` via
-    :func:`tmp_coveragepy_xml` to produce a Cobertura XML, parses it,
-    then moves the ``.coverage`` data file into ``out``.  For all other
-    formats, parses ``out`` directly as a Cobertura XML.
-
-    Parameters
-    ----------
-    fmt : str
-        Coverage format identifier.
-    out : Path
-        Path to the coverage output file produced by slipcover.
-
-    Returns
-    -------
-    str
-        Line coverage percentage.
-
-    Raises
-    ------
-    typer.Exit
-        Propagated from :func:`tmp_coveragepy_xml` when ``coverage xml``
-        exits non-zero.
-    """
     if fmt == "coveragepy":
         with tmp_coveragepy_xml(out) as xml_tmp:
             percent = get_line_coverage_percent_from_cobertura(xml_tmp)
@@ -361,15 +339,11 @@ def main(
     """
     out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)
-
-    _run_slipcover(fmt, out)
-    percent = _parse_coverage_percent(fmt, out)
-
+    percent = _run_coverage(fmt, out)
     typer.echo(f"Current coverage: {percent}%")
     previous = read_previous_coverage(baseline_file)
     if previous is not None:
         typer.echo(f"Previous coverage: {previous}%")
-
     with github_output.open("a") as fh:
         fh.write(f"file={out}\n")
         fh.write(f"percent={percent}\n")

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import typer
 from cmd_utils_loader import run_cmd
 from coverage_parsers import get_line_coverage_percent_from_cobertura
+from plumbum import local
 from plumbum.cmd import uv
 from plumbum.commands.processes import ProcessExecutionError
 from shared_utils import read_previous_coverage
@@ -27,6 +28,8 @@ LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
 FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
 GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
+COVERAGE_VENV = Path(".venv-coverage")
+TOOLING_PACKAGES: tuple[str, ...] = ("slipcover", "pytest", "coverage")
 
 SLIPCOVER_ARGS: tuple[str, ...] = (
     "-m",
@@ -40,18 +43,15 @@ PYTEST_ARGS: tuple[str, ...] = (
 )
 
 
-def _uv_python_cmd() -> BoundCommand:
-    """Return ``uv run`` configured with the required coverage tools."""
-    return uv[
-        "run",
-        "--with",
-        "slipcover",
-        "--with",
-        "pytest",
-        "--with",
-        "coverage",
-        "python",
-    ]
+def create_venv() -> str:
+    """Create a throwaway venv for coverage tooling; return python path."""
+    run_cmd(uv["venv", str(COVERAGE_VENV)])
+    return str(COVERAGE_VENV / "bin" / "python")
+
+
+def install_coverage_tools(python: str) -> None:
+    """Install coverage tooling into the throwaway venv."""
+    run_cmd(uv["pip", "install", "--python", python, *TOOLING_PACKAGES])
 
 
 def _coverage_args(fmt: str, out: Path) -> list[str]:
@@ -64,18 +64,17 @@ def _coverage_args(fmt: str, out: Path) -> list[str]:
     return args
 
 
-def coverage_cmd_for_fmt(fmt: str, out: Path) -> BoundCommand:
+def coverage_cmd_for_fmt(fmt: str, out: Path, python: str) -> BoundCommand:
     """Return the slipcover command for the requested format."""
-    python_cmd = _uv_python_cmd()
-    return python_cmd[_coverage_args(fmt, out)]
+    return local[python][_coverage_args(fmt, out)]
 
 
 @contextlib.contextmanager
-def tmp_coveragepy_xml(out: Path) -> cabc.Generator[Path]:
+def tmp_coveragepy_xml(out: Path, python: str) -> cabc.Generator[Path]:
     """Generate a cobertura XML from coverage.py and clean up afterwards."""
     xml_tmp = out.with_suffix(".xml")
     try:
-        cmd = _uv_python_cmd()["-m", "coverage", "xml", "-o", str(xml_tmp)]
+        cmd = local[python]["-m", "coverage", "xml", "-o", str(xml_tmp)]
         run_cmd(cmd)
     except ProcessExecutionError as exc:
         typer.echo(
@@ -102,14 +101,17 @@ def main(
         out = output_path.with_name(f"{output_path.stem}.python{output_path.suffix}")
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    cmd = coverage_cmd_for_fmt(fmt, out)
+    python = create_venv()
+    install_coverage_tools(python)
+
+    cmd = coverage_cmd_for_fmt(fmt, out, python)
     try:
         run_cmd(cmd, method="run_fg")
     except ProcessExecutionError as exc:
         raise typer.Exit(code=exc.retcode or 1) from exc
 
     if fmt == "coveragepy":
-        with tmp_coveragepy_xml(out) as xml_tmp:
+        with tmp_coveragepy_xml(out, python) as xml_tmp:
             percent = get_line_coverage_percent_from_cobertura(xml_tmp)
         Path(".coverage").replace(out)
     else:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -30,6 +30,7 @@ GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
 BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
 COVERAGE_VENV = Path(".venv-coverage")
 TOOLING_PACKAGES: tuple[str, ...] = ("slipcover", "pytest", "coverage")
+_COVERAGE_PYTHON_CMD: BoundCommand | None = None
 
 SLIPCOVER_ARGS: tuple[str, ...] = (
     "-m",
@@ -43,15 +44,41 @@ PYTEST_ARGS: tuple[str, ...] = (
 )
 
 
+def _coverage_python_path() -> Path:
+    """Return the Python executable path inside the coverage venv."""
+    candidates = (
+        COVERAGE_VENV / "bin" / "python",
+        COVERAGE_VENV / "Scripts" / "python.exe",
+        COVERAGE_VENV / "Scripts" / "python",
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    paths = ", ".join(str(candidate) for candidate in candidates)
+    msg = f"Coverage venv Python executable not found; checked: {paths}"
+    raise RuntimeError(msg)
+
+
 def create_venv() -> str:
     """Create a throwaway venv for coverage tooling; return python path."""
-    run_cmd(uv["venv", str(COVERAGE_VENV)])
-    return str(COVERAGE_VENV / "bin" / "python")
+    if not COVERAGE_VENV.exists():
+        run_cmd(uv["venv", str(COVERAGE_VENV)])
+    return str(_coverage_python_path())
 
 
 def install_coverage_tools(python: str) -> None:
     """Install coverage tooling into the throwaway venv."""
     run_cmd(uv["pip", "install", "--python", python, *TOOLING_PACKAGES])
+
+
+def _coverage_python_cmd() -> BoundCommand:
+    """Return a python command with coverage tooling available."""
+    global _COVERAGE_PYTHON_CMD
+    if _COVERAGE_PYTHON_CMD is None:
+        python = create_venv()
+        install_coverage_tools(python)
+        _COVERAGE_PYTHON_CMD = local[python]
+    return _COVERAGE_PYTHON_CMD
 
 
 def _coverage_args(fmt: str, out: Path) -> list[str]:
@@ -64,17 +91,19 @@ def _coverage_args(fmt: str, out: Path) -> list[str]:
     return args
 
 
-def coverage_cmd_for_fmt(fmt: str, out: Path, python: str) -> BoundCommand:
+def coverage_cmd_for_fmt(fmt: str, out: Path) -> BoundCommand:
     """Return the slipcover command for the requested format."""
-    return local[python][_coverage_args(fmt, out)]
+    python_cmd = _coverage_python_cmd()
+    return python_cmd[_coverage_args(fmt, out)]
 
 
 @contextlib.contextmanager
-def tmp_coveragepy_xml(out: Path, python: str) -> cabc.Generator[Path]:
+def tmp_coveragepy_xml(out: Path) -> cabc.Generator[Path]:
     """Generate a cobertura XML from coverage.py and clean up afterwards."""
     xml_tmp = out.with_suffix(".xml")
+    python_cmd = _coverage_python_cmd()
     try:
-        cmd = local[python]["-m", "coverage", "xml", "-o", str(xml_tmp)]
+        cmd = python_cmd["-m", "coverage", "xml", "-o", str(xml_tmp)]
         run_cmd(cmd)
     except ProcessExecutionError as exc:
         typer.echo(
@@ -101,17 +130,14 @@ def main(
         out = output_path.with_name(f"{output_path.stem}.python{output_path.suffix}")
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    python = create_venv()
-    install_coverage_tools(python)
-
-    cmd = coverage_cmd_for_fmt(fmt, out, python)
+    cmd = coverage_cmd_for_fmt(fmt, out)
     try:
         run_cmd(cmd, method="run_fg")
     except ProcessExecutionError as exc:
         raise typer.Exit(code=exc.retcode or 1) from exc
 
     if fmt == "coveragepy":
-        with tmp_coveragepy_xml(out, python) as xml_tmp:
+        with tmp_coveragepy_xml(out) as xml_tmp:
             percent = get_line_coverage_percent_from_cobertura(xml_tmp)
         Path(".coverage").replace(out)
     else:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -110,9 +110,23 @@ def _ensure_coverage_venv() -> str:
     if python is None:
         python = _recreate_coverage_venv()
     typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
-    run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
+    try:
+        run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"uv sync failed with code {exc.retcode}: {exc.stderr}",
+            err=True,
+        )
+        raise
     typer.echo(f"Installing coverage tooling {TOOLING_PACKAGES} into {COVERAGE_VENV}")
-    run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])
+    try:
+        run_cmd(uv["pip", "install", "--python", str(python), *TOOLING_PACKAGES])
+    except ProcessExecutionError as exc:
+        typer.echo(
+            f"uv pip install failed with code {exc.retcode}: {exc.stderr}",
+            err=True,
+        )
+        raise
     return str(python)
 
 
@@ -134,14 +148,51 @@ def _coverage_args(fmt: str, out: Path) -> list[str]:
 
 
 def coverage_cmd_for_fmt(fmt: str, out: Path) -> BoundCommand:
-    """Return the slipcover command for the requested format."""
+    """Return the slipcover command for the requested coverage format.
+
+    Parameters
+    ----------
+    fmt : str
+        Coverage format identifier. ``"cobertura"`` adds slipcover's
+        ``--xml`` and ``--out`` flags; all other values produce a bare
+        slipcover/pytest invocation.
+    out : Path
+        Destination path for the coverage output file; passed to slipcover's
+        ``--out`` argument when ``fmt == "cobertura"``.
+
+    Returns
+    -------
+    plumbum.commands.base.BoundCommand
+        A plumbum command that runs slipcover via the coverage venv Python.
+    """
     python_cmd = _coverage_python_cmd()
     return python_cmd[_coverage_args(fmt, out)]
 
 
 @contextlib.contextmanager
 def tmp_coveragepy_xml(out: Path) -> cabc.Generator[Path]:
-    """Generate a cobertura XML from coverage.py and clean up afterwards."""
+    """Generate a Cobertura XML from coverage.py and clean it up afterwards.
+
+    Invokes ``python -m coverage xml -o <xml_tmp>`` using the coverage venv
+    Python, yields the temporary XML path for the caller to consume, and
+    removes the file on exit - whether the body raised or returned normally.
+
+    Parameters
+    ----------
+    out : Path
+        Path to the ``.dat`` (coverage.py data) file.  The temporary XML is
+        written to ``out.with_suffix(".xml")``.
+
+    Yields
+    ------
+    Path
+        Absolute path to the freshly generated temporary Cobertura XML file.
+
+    Raises
+    ------
+    typer.Exit
+        If ``coverage xml`` exits with a non-zero return code.
+    """
     xml_tmp = out.with_suffix(".xml")
     python_cmd = _coverage_python_cmd()
     try:
@@ -166,7 +217,25 @@ def main(
     github_output: Path = GITHUB_OUTPUT_OPT,
     baseline_file: Path | None = BASELINE_OPT,
 ) -> None:
-    """Run slipcover coverage and write the output path to ``GITHUB_OUTPUT``."""
+    """Run slipcover coverage and write the result to ``GITHUB_OUTPUT``.
+
+    Parameters
+    ----------
+    output_path : Path
+        Destination path for the coverage output file.
+    lang : str
+        Detected project language (``"rust"``, ``"python"``, or
+        ``"mixed"``).  When ``"mixed"``, the output file is renamed to
+        include a ``.python`` infix.
+    fmt : str
+        Coverage format identifier passed to :func:`coverage_cmd_for_fmt`.
+    github_output : Path
+        Path to the ``GITHUB_OUTPUT`` append file where ``file=`` and
+        ``percent=`` are written.
+    baseline_file : Path or None
+        Optional path to a previous coverage baseline file.  When present,
+        the previous percentage is echoed to the log.
+    """
     out = output_path
     if lang == "mixed":
         out = output_path.with_name(f"{output_path.stem}.python{output_path.suffix}")

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import collections.abc as cabc  # noqa: TC003 - used at runtime
 import contextlib
+import os
 import shutil
 import typing as typ
 from functools import lru_cache
@@ -109,6 +110,7 @@ def _ensure_coverage_venv() -> str:
     if python is None:
         python = _recreate_coverage_venv()
     typer.echo(f"Installing project dependencies into {COVERAGE_VENV}")
+    os.environ["UV_PROJECT_ENVIRONMENT"] = str(COVERAGE_VENV.resolve())
     try:
         run_cmd(uv[*PROJECT_SYNC_ARGS, str(python)])
     except ProcessExecutionError as exc:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1796,31 +1796,59 @@ def _assert_flag_value_pair(parts: list[str], flag: str, value: str) -> None:
     pytest.fail(message)
 
 
+@dataclasses.dataclass
+class VenvTestSetup:
+    """Scaffolding returned by _setup_create_venv_test for create_venv() tests."""
+
+    coverage_venv: Path
+    recorded: list[list[str]] = dataclasses.field(default_factory=list)
+
+
+def _setup_create_venv_test(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    python_to_create: str | None = "bin/python",
+) -> VenvTestSetup:
+    """Patch COVERAGE_VENV and run_cmd; return shared test scaffolding.
+
+    Parameters
+    ----------
+    python_to_create:
+        Relative POSIX path inside the venv to create when ``uv venv``
+        is recorded. Pass ``None`` to skip creation (reuse scenario).
+    """
+    coverage_venv = tmp_path / ".venv-coverage"
+    setup = VenvTestSetup(coverage_venv=coverage_venv)
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        parts = list(cmd.formulate())  # type: ignore[attr-defined]
+        setup.recorded.append(parts)
+        if python_to_create is not None and parts[1] == "venv":
+            python_path = coverage_venv / python_to_create
+            python_path.parent.mkdir(parents=True, exist_ok=True)
+            python_path.touch()
+
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    return setup
+
+
 def test_create_venv_returns_coverage_python(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper creates the throwaway coverage venv and returns its Python."""
-    recorded: list[list[str]] = []
-    coverage_venv = tmp_path / ".venv-coverage"
-
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
-        python = coverage_venv / "bin" / "python"
-        python.parent.mkdir(parents=True)
-        python.touch()
-
-    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
-    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    setup = _setup_create_venv_test(tmp_path, run_python_module, monkeypatch)
 
     python = run_python_module.create_venv()
 
-    assert python == str(coverage_venv / "bin" / "python")
-    assert len(recorded) == 1
-    parts = recorded[0]
+    assert python == str(setup.coverage_venv / "bin" / "python")
+    assert len(setup.recorded) == 1
+    parts = setup.recorded[0]
     assert Path(parts[0]).name == "uv"
-    assert parts[1:] == ["venv", str(coverage_venv)]
+    assert parts[1:] == ["venv", str(setup.coverage_venv)]
 
 
 def test_create_venv_reuses_existing_coverage_venv(
@@ -1829,20 +1857,15 @@ def test_create_venv_reuses_existing_coverage_venv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper does not recreate an existing coverage venv."""
-    coverage_venv = tmp_path / ".venv-coverage"
-    python_path = coverage_venv / "Scripts" / "python.exe"
+    setup = _setup_create_venv_test(
+        tmp_path, run_python_module, monkeypatch, python_to_create=None
+    )
+    python_path = setup.coverage_venv / "Scripts" / "python.exe"
     python_path.parent.mkdir(parents=True)
     python_path.touch()
-    recorded: list[list[str]] = []
-
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
-
-    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
-    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
 
     assert run_python_module.create_venv() == str(python_path)
-    assert recorded == []
+    assert setup.recorded == []
 
 
 def test_create_venv_recovers_from_broken_cache(
@@ -1897,22 +1920,14 @@ def test_create_venv_recreates_broken_coverage_venv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper repairs an existing venv that has no Python executable."""
-    coverage_venv = tmp_path / ".venv-coverage"
-    coverage_venv.mkdir()
-    recorded: list[list[str]] = []
+    setup = _setup_create_venv_test(tmp_path, run_python_module, monkeypatch)
+    setup.coverage_venv.mkdir()  # broken: directory present, no Python binary
 
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
-        python_path = coverage_venv / "bin" / "python"
-        python_path.parent.mkdir(parents=True)
-        python_path.touch()
-
-    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
-    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
-
-    assert run_python_module.create_venv() == str(coverage_venv / "bin" / "python")
-    assert len(recorded) == 1
-    assert recorded[0][1:] == ["venv", str(coverage_venv)]
+    assert run_python_module.create_venv() == str(
+        setup.coverage_venv / "bin" / "python"
+    )
+    assert len(setup.recorded) == 1
+    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
 
 
 def test_create_venv_recreates_invalid_python_candidate(
@@ -1921,24 +1936,19 @@ def test_create_venv_recreates_invalid_python_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper rejects non-file Python placeholders before reuse."""
-    coverage_venv = tmp_path / ".venv-coverage"
-    (coverage_venv / "bin" / "python").mkdir(parents=True)
-    recorded: list[list[str]] = []
-
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
-        python_path = coverage_venv / "Scripts" / "python.exe"
-        python_path.parent.mkdir(parents=True)
-        python_path.touch()
-
-    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
-    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    setup = _setup_create_venv_test(
+        tmp_path,
+        run_python_module,
+        monkeypatch,
+        python_to_create="Scripts/python.exe",
+    )
+    (setup.coverage_venv / "bin" / "python").mkdir(parents=True)  # dir, not file
 
     assert run_python_module.create_venv() == str(
-        coverage_venv / "Scripts" / "python.exe"
+        setup.coverage_venv / "Scripts" / "python.exe"
     )
-    assert len(recorded) == 1
-    assert recorded[0][1:] == ["venv", str(coverage_venv)]
+    assert len(setup.recorded) == 1
+    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
 
 
 def test_install_coverage_tools_targets_venv_python(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2070,8 +2070,9 @@ def test_coverage_python_cmd_prepares_tools_once(
     recorded: list[list[str]] = []
 
     def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
-        if recorded[-1][1] == "venv":
+        args = list(cmd.formulate())  # type: ignore[attr-defined]
+        recorded.append(args)
+        if len(args) > 1 and args[1] == "venv":
             python_path.parent.mkdir(parents=True)
             python_path.touch()
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2148,28 +2148,17 @@ def test_coverage_cmd_cobertura_uses_venv_python(
     _assert_flag_value_pair(parts, "--out", str(out))
 
 
-def test_coverage_cmd_default_branch_has_shared_args(
+def test_non_cobertura_formats_do_not_emit_cobertura_flags(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Non-Cobertura formats reuse the shared slipcover arguments."""
+    """Non-Cobertura formats do not emit Cobertura output flags."""
     parts, out = _get_coverage_cmd_parts(
         tmp_path, run_python_module, monkeypatch, CoverageFmtSpec("coveragepy", "dat")
     )
     assert "--xml" not in parts
     assert str(out) not in parts
-
-
-def test_non_cobertura_formats_do_not_emit_out_flag(
-    tmp_path: Path,
-    run_python_module: ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Ensure slipcover output targeting stays isolated to Cobertura runs."""
-    parts, _ = _get_coverage_cmd_parts(
-        tmp_path, run_python_module, monkeypatch, CoverageFmtSpec("coveragepy", "dat")
-    )
     assert "--out" not in parts
 
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2083,6 +2083,7 @@ def test_ensure_coverage_venv_sets_uv_project_environment_for_sync(
     assert run_python_module._ensure_coverage_venv() == str(python)
 
     assert sync_environment == [str(setup.coverage_venv.resolve())]
+    assert "UV_PROJECT_ENVIRONMENT" not in os.environ
 
 
 def test_coverage_python_cmd_prepares_tools_once(
@@ -2570,12 +2571,22 @@ def test_run_python_integration_cobertura_success(
     assert "coverage" in pip_args
 
 
+@dataclasses.dataclass(frozen=True)
+class UvFailureSpec:
+    """Pairs a fake-uv exit-code configuration with the expected stderr fragment."""
+
+    write_kwargs: dict[str, int]
+    expected_in_stderr: str | None
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")
 @pytest.mark.parametrize(
-    ("write_kwargs", "expected_in_stderr"),
+    "spec",
     [
-        ({"venv_exit": 1}, None),
-        ({"sync_exit": 2}, "uv sync failed"),
+        UvFailureSpec(write_kwargs={"venv_exit": 1}, expected_in_stderr=None),
+        UvFailureSpec(
+            write_kwargs={"sync_exit": 2}, expected_in_stderr="uv sync failed"
+        ),
     ],
     ids=["uv-venv-fails", "uv-sync-fails"],
 )
@@ -2583,16 +2594,15 @@ def test_run_python_integration_uv_failure_modes(
     tmp_path: Path,
     shell_stubs: StubManager,
     monkeypatch: pytest.MonkeyPatch,
-    write_kwargs: dict[str, int],
-    expected_in_stderr: str | None,
+    spec: UvFailureSpec,
 ) -> None:
     """run_python.py exits non-zero when uv venv or uv sync fails."""
-    bin_dir, _log = _write_fake_uv(tmp_path, **write_kwargs)
+    bin_dir, _log = _write_fake_uv(tmp_path, **spec.write_kwargs)
 
     returncode, _stdout, stderr = _run_integration_script(
         tmp_path, shell_stubs, bin_dir, monkeypatch
     )
 
     assert returncode != 0
-    if expected_in_stderr is not None:
-        assert expected_in_stderr in stderr
+    if spec.expected_in_stderr is not None:
+        assert spec.expected_in_stderr in stderr

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -54,6 +54,12 @@ def run_script(script: Path, env: dict[str, str], *args: str) -> RunResult:
     -------
     RunResult
         A three-tuple of ``(return_code, stdout, stderr)``.
+
+    Raises
+    ------
+    None
+        This helper does not raise for non-zero exits; failures are conveyed
+        via the returned exit code and stderr captured from the child process.
     """
     command = local["uv"]["run", "--script", str(script)]
     if args:
@@ -2366,6 +2372,57 @@ def test_run_python_coveragepy_empty_xml(
     data = github_output.read_text(encoding="utf-8").splitlines()
     assert f"file={output}" in data
     assert "percent=0.00" in data
+
+
+def test_main_echoes_previous_coverage_when_baseline_present(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() logs 'Previous coverage: ...%' when a baseline is provided."""
+    monkeypatch.chdir(tmp_path)
+    coverage_file = tmp_path / ".coverage"
+    coverage_file.write_text("payload", encoding="utf-8")
+
+    def fake_run_cmd(_cmd: object, **_kw: object) -> None:
+        pass
+
+    @contextlib.contextmanager
+    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+        xml = out.with_suffix(".xml")
+        xml.write_text(
+            "<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8"
+        )
+        try:
+            yield xml
+        finally:
+            xml.unlink(missing_ok=True)
+
+    def fake_read_previous_coverage(_baseline: Path | None) -> float | None:
+        return 42.0
+
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    monkeypatch.setattr(
+        run_python_module, "tmp_coveragepy_xml", fake_tmp_coveragepy_xml
+    )
+    monkeypatch.setattr(
+        run_python_module, "read_previous_coverage", fake_read_previous_coverage
+    )
+    _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
+
+    out = tmp_path / "cov.dat"
+    gh = tmp_path / "gh.txt"
+    run_python_module.main(
+        output_path=out,
+        lang="python",
+        fmt="coveragepy",
+        github_output=gh,
+        baseline_file=tmp_path / "baseline.txt",
+    )
+
+    captured = capsys.readouterr()
+    assert "Previous coverage: 42.0%" in captured.out
 
 
 def test_run_python_coveragepy_malformed_xml_exits(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1816,7 +1816,7 @@ def _setup_create_venv_test(
     ----------
     python_to_create:
         Relative POSIX path inside the venv to create when ``uv venv``
-        is called.  Pass ``None`` to skip creation (venv-reuse scenario).
+        is recorded. Pass ``None`` to skip creation (reuse scenario).
     """
     coverage_venv = tmp_path / ".venv-coverage"
     setup = VenvTestSetup(coverage_venv=coverage_venv)
@@ -1824,7 +1824,7 @@ def _setup_create_venv_test(
     def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
         parts = list(cmd.formulate())  # type: ignore[attr-defined]
         setup.recorded.append(parts)
-        if python_to_create is not None and parts[1] == "venv":
+        if python_to_create is not None and len(parts) > 1 and parts[1] == "venv":
             python_path = coverage_venv / python_to_create
             python_path.parent.mkdir(parents=True, exist_ok=True)
             python_path.touch()
@@ -1866,6 +1866,22 @@ def test_create_venv_reuses_existing_coverage_venv(
 
     assert run_python_module.create_venv() == str(python_path)
     assert setup.recorded == []
+
+
+def test_create_venv_recovers_from_broken_cache(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_venv() recreates a venv whose Python executable is absent."""
+    setup = _setup_create_venv_test(tmp_path, run_python_module, monkeypatch)
+    setup.coverage_venv.mkdir(parents=True)  # broken: dir present, no binary
+
+    python = run_python_module.create_venv()
+
+    venv_calls = [r for r in setup.recorded if len(r) > 1 and r[1] == "venv"]
+    assert len(venv_calls) == 1
+    assert python == str(setup.coverage_venv / "bin" / "python")
 
 
 def test_coverage_python_path_raises_when_no_executable(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1925,31 +1925,26 @@ def test_find_coverage_python_returns_none_when_no_executable(
     assert run_python_module._find_coverage_python() is None
 
 
-def test_ensure_coverage_venv_recreates_broken_coverage_venv(
+def test_ensure_coverage_venv_replaces_broken_file_cache(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The helper repairs an existing venv that has no Python executable."""
+    """The helper replaces a non-directory cache placeholder before recreate."""
     setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
-    setup.coverage_venv.mkdir()  # broken: directory present, no Python binary
+    setup.coverage_venv.write_text("not a venv")
 
-    assert run_python_module._ensure_coverage_venv() == str(
-        setup.coverage_venv / "bin" / "python"
-    )
+    python = run_python_module._ensure_coverage_venv()
+
+    assert python == str(setup.coverage_venv / "bin" / "python")
     assert len(setup.recorded) == 3
     assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
-    assert setup.recorded[1][1:] == [
-        "sync",
-        "--inexact",
-        "--python",
-        str(setup.coverage_venv / "bin" / "python"),
-    ]
+    assert setup.recorded[1][1:] == ["sync", "--inexact", "--python", python]
     assert setup.recorded[2][1:5] == [
         "pip",
         "install",
         "--python",
-        str(setup.coverage_venv / "bin" / "python"),
+        python,
     ]
 
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1845,6 +1845,56 @@ def test_create_venv_reuses_existing_coverage_venv(
     assert recorded == []
 
 
+def test_create_venv_recreates_broken_coverage_venv(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper repairs an existing venv that has no Python executable."""
+    coverage_venv = tmp_path / ".venv-coverage"
+    coverage_venv.mkdir()
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+        python_path = coverage_venv / "bin" / "python"
+        python_path.parent.mkdir(parents=True)
+        python_path.touch()
+
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    assert run_python_module.create_venv() == str(coverage_venv / "bin" / "python")
+    assert len(recorded) == 1
+    assert recorded[0][1:] == ["venv", str(coverage_venv)]
+
+
+def test_create_venv_recreates_invalid_python_candidate(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper rejects non-file Python placeholders before reuse."""
+    coverage_venv = tmp_path / ".venv-coverage"
+    (coverage_venv / "bin" / "python").mkdir(parents=True)
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+        python_path = coverage_venv / "Scripts" / "python.exe"
+        python_path.parent.mkdir(parents=True)
+        python_path.touch()
+
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    assert run_python_module.create_venv() == str(
+        coverage_venv / "Scripts" / "python.exe"
+    )
+    assert len(recorded) == 1
+    assert recorded[0][1:] == ["venv", str(coverage_venv)]
+
+
 def test_install_coverage_tools_targets_venv_python(
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1748,6 +1748,20 @@ def _coverage_python(run_python_module: ModuleType) -> str:
     return str(run_python_module.COVERAGE_VENV / "bin" / "python")
 
 
+def _set_fake_coverage_python_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+    run_python_module: ModuleType,
+) -> str:
+    """Patch the coverage Python command helper to avoid creating a venv."""
+    python = _coverage_python(run_python_module)
+    monkeypatch.setattr(
+        run_python_module,
+        "_coverage_python_cmd",
+        lambda: local[python],
+    )
+    return python
+
+
 def _assert_python_command_structure(parts: list[str]) -> None:
     """Verify common venv Python command structure with slipcover and pytest."""
     assert Path(parts[0]).name == "python"
@@ -1783,24 +1797,52 @@ def _assert_flag_value_pair(parts: list[str], flag: str, value: str) -> None:
 
 
 def test_create_venv_returns_coverage_python(
+    tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper creates the throwaway coverage venv and returns its Python."""
     recorded: list[list[str]] = []
+    coverage_venv = tmp_path / ".venv-coverage"
 
     def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
         recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+        python = coverage_venv / "bin" / "python"
+        python.parent.mkdir(parents=True)
+        python.touch()
 
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
 
     python = run_python_module.create_venv()
 
-    assert python == _coverage_python(run_python_module)
+    assert python == str(coverage_venv / "bin" / "python")
     assert len(recorded) == 1
     parts = recorded[0]
     assert Path(parts[0]).name == "uv"
-    assert parts[1:] == ["venv", str(run_python_module.COVERAGE_VENV)]
+    assert parts[1:] == ["venv", str(coverage_venv)]
+
+
+def test_create_venv_reuses_existing_coverage_venv(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper does not recreate an existing coverage venv."""
+    coverage_venv = tmp_path / ".venv-coverage"
+    python_path = coverage_venv / "Scripts" / "python.exe"
+    python_path.parent.mkdir(parents=True)
+    python_path.touch()
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    assert run_python_module.create_venv() == str(python_path)
+    assert recorded == []
 
 
 def test_install_coverage_tools_targets_venv_python(
@@ -1826,12 +1868,48 @@ def test_install_coverage_tools_targets_venv_python(
     assert set(run_python_module.TOOLING_PACKAGES).issubset(parts)
 
 
-def test_coverage_cmd_uses_venv_python(run_python_module: ModuleType) -> None:
+def test_coverage_python_cmd_prepares_tools_once(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The coverage Python command lazily creates and installs tooling once."""
+    coverage_venv = tmp_path / ".venv-coverage"
+    python_path = coverage_venv / "bin" / "python"
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+        if recorded[-1][1] == "venv":
+            python_path.parent.mkdir(parents=True)
+            python_path.touch()
+
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    first = run_python_module._coverage_python_cmd()
+    second = run_python_module._coverage_python_cmd()
+
+    assert first is second
+    parts = list(first.formulate())
+    _assert_coverage_python_path(parts[0], str(python_path))
+    assert len(recorded) == 2
+    assert recorded[0][1:] == ["venv", str(coverage_venv)]
+    assert recorded[1][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(python_path),
+    ]
+
+
+def test_coverage_cmd_uses_venv_python(
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The helper wires slipcover/pytest through the throwaway venv."""
-    python = _coverage_python(run_python_module)
-    cmd = run_python_module.coverage_cmd_for_fmt(
-        "coveragepy", Path("coverage.dat"), python
-    )
+    python = _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
+    cmd = run_python_module.coverage_cmd_for_fmt("coveragepy", Path("coverage.dat"))
     parts = list(cmd.formulate())
     _assert_coverage_python_path(parts[0], python)
     _assert_python_command_structure(parts)
@@ -1840,25 +1918,27 @@ def test_coverage_cmd_uses_venv_python(run_python_module: ModuleType) -> None:
 def _get_coverage_cmd_parts(
     tmp_path: Path,
     run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
     fmt: str,
     suffix: str,
 ) -> tuple[list[str], Path]:
     """Build coverage command for format and return parts and output path."""
     out = tmp_path / f"cov.{suffix}"
-    cmd = run_python_module.coverage_cmd_for_fmt(
-        fmt, out, _coverage_python(run_python_module)
-    )
+    _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
+    cmd = run_python_module.coverage_cmd_for_fmt(fmt, out)
     parts = list(cmd.formulate())
     _assert_python_command_structure(parts)
     return parts, out
 
 
 def test_coverage_cmd_cobertura_uses_venv_python(
-    tmp_path: Path, run_python_module: ModuleType
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cobertura format invokes slipcover with ``--xml`` using the venv Python."""
     parts, out = _get_coverage_cmd_parts(
-        tmp_path, run_python_module, "cobertura", "xml"
+        tmp_path, run_python_module, monkeypatch, "cobertura", "xml"
     )
     assert parts.count("--xml") == 1
     _assert_tokens_in_order(parts, "--xml", "--out")
@@ -1866,26 +1946,34 @@ def test_coverage_cmd_cobertura_uses_venv_python(
 
 
 def test_coverage_cmd_default_branch_has_shared_args(
-    tmp_path: Path, run_python_module: ModuleType
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Non-Cobertura formats reuse the shared slipcover arguments."""
     parts, out = _get_coverage_cmd_parts(
-        tmp_path, run_python_module, "coveragepy", "dat"
+        tmp_path, run_python_module, monkeypatch, "coveragepy", "dat"
     )
     assert "--xml" not in parts
     assert str(out) not in parts
 
 
 def test_non_cobertura_formats_do_not_emit_out_flag(
-    tmp_path: Path, run_python_module: ModuleType
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure slipcover output targeting stays isolated to Cobertura runs."""
-    parts, _ = _get_coverage_cmd_parts(tmp_path, run_python_module, "coveragepy", "dat")
+    parts, _ = _get_coverage_cmd_parts(
+        tmp_path, run_python_module, monkeypatch, "coveragepy", "dat"
+    )
     assert "--out" not in parts
 
 
 def test_tmp_coveragepy_xml_invokes_venv_python(
-    tmp_path: Path, run_python_module: ModuleType
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The coverage.py exporter also reuses the venv Python."""
     out = tmp_path / "coveragepy.dat"
@@ -1898,8 +1986,8 @@ def test_tmp_coveragepy_xml_invokes_venv_python(
 
     run_python_module.run_cmd = fake_run_cmd  # type: ignore[assignment]
 
-    python = _coverage_python(run_python_module)
-    with run_python_module.tmp_coveragepy_xml(out, python) as generated:
+    python = _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
+    with run_python_module.tmp_coveragepy_xml(out) as generated:
         assert generated == xml_path
         assert xml_path.exists()
 
@@ -1929,21 +2017,13 @@ def test_run_python_cobertura_passes_out_flag(
         )  # type: ignore[attr-defined]
 
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
 
     run_python_module.main(output, "python", "cobertura", github_output, None)
 
-    assert len(recorded) == 3
-    assert recorded[0][0][1:] == ["venv", str(run_python_module.COVERAGE_VENV)]
-    install_parts = recorded[1][0]
-    assert install_parts[1:5] == [
-        "pip",
-        "install",
-        "--python",
-        _coverage_python(run_python_module),
-    ]
-    assert "--system" not in install_parts
-    parts = recorded[2][0]
-    assert recorded[2][1] == "run_fg"
+    assert len(recorded) == 1
+    parts = recorded[0][0]
+    assert recorded[0][1] == "run_fg"
     _assert_python_command_structure(parts)
     _assert_tokens_in_order(parts, "--xml", "--out")
     _assert_flag_value_pair(parts, "--out", str(output))
@@ -2019,9 +2099,14 @@ def test_run_python_coveragepy_empty_xml(
         return None
 
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    python = _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
+    captured_python: list[str] = []
 
     @contextlib.contextmanager
-    def fake_tmp_coveragepy_xml(out: Path, _python: str) -> typ.Iterator[Path]:
+    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+        captured_python.append(
+            next(iter(run_python_module._coverage_python_cmd().formulate()))
+        )
         xml_path = tmp_path / "coverage.xml"
         xml_path.write_text(
             "<coverage lines-covered='0' lines-valid='0' />",
@@ -2037,6 +2122,9 @@ def test_run_python_coveragepy_empty_xml(
     )
 
     run_python_module.main(output, "python", "coveragepy", github_output, None)
+
+    assert len(captured_python) == 1
+    _assert_coverage_python_path(captured_python[0], python)
 
     captured = capsys.readouterr()
     assert "Current coverage: 0.00%" in captured.out
@@ -2065,9 +2153,14 @@ def test_run_python_coveragepy_malformed_xml_exits(
         return None
 
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    python = _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
+    captured_python: list[str] = []
 
     @contextlib.contextmanager
-    def fake_tmp_coveragepy_xml(out: Path, _python: str) -> typ.Iterator[Path]:
+    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+        captured_python.append(
+            next(iter(run_python_module._coverage_python_cmd().formulate()))
+        )
         xml_path = tmp_path / "coverage.xml"
         xml_path.write_text("<coverage>", encoding="utf-8")
         try:
@@ -2081,6 +2174,9 @@ def test_run_python_coveragepy_malformed_xml_exits(
 
     with pytest.raises(run_python_module.typer.Exit) as excinfo:
         run_python_module.main(output, "python", "coveragepy", github_output, None)
+
+    assert len(captured_python) == 1
+    _assert_coverage_python_path(captured_python[0], python)
 
     assert _exit_code(excinfo.value) == 1
     assert coverage_file.exists()

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -39,7 +39,22 @@ def _exit_code(exc: BaseException) -> int | None:
 
 
 def run_script(script: Path, env: dict[str, str], *args: str) -> RunResult:
-    """Run ``script`` via ``uv`` with ``env`` and return the run tuple."""
+    """Run ``script`` via ``uv run --script`` with ``env`` and return the result.
+
+    Parameters
+    ----------
+    script : Path
+        Absolute path to the Python script to execute.
+    env : dict[str, str]
+        Environment variables to merge on top of the current environment.
+    *args : str
+        Additional positional arguments appended to the ``uv run`` command.
+
+    Returns
+    -------
+    RunResult
+        A three-tuple of ``(return_code, stdout, stderr)``.
+    """
     command = local["uv"]["run", "--script", str(script)]
     if args:
         command = command[list(args)]
@@ -2548,7 +2563,10 @@ def test_run_python_integration_cobertura_success(
     shell_stubs: StubManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """run_python.py creates the venv, syncs deps, and installs tooling."""
+    """run_python.py creates the venv, syncs deps, installs tooling.
+
+    The script also writes outputs.
+    """
     bin_dir, log = _write_fake_uv(tmp_path)
 
     returncode, _stdout, _stderr = _run_integration_script(
@@ -2569,6 +2587,51 @@ def test_run_python_integration_cobertura_success(
     assert "slipcover" in pip_args
     assert "pytest" in pip_args
     assert "coverage" in pip_args
+    # Verify GITHUB_OUTPUT was written with expected keys
+    gh = tmp_path / "gh.txt"
+    assert gh.exists(), "GITHUB_OUTPUT file must be written"
+    gh_content = gh.read_text(encoding="utf-8")
+    assert "file=" in gh_content, "GITHUB_OUTPUT must contain file= key"
+    assert "percent=" in gh_content, "GITHUB_OUTPUT must contain percent= key"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")
+def test_run_python_integration_mixed_lang_path(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_python.py renames the output file for mixed-lang projects.
+
+    The output path receives a .python infix.
+    """
+    bin_dir, _log = _write_fake_uv(tmp_path)
+    out = tmp_path / "cov.xml"
+    gh = tmp_path / "gh.txt"
+    out.write_text("<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8")
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(out),
+        "DETECTED_LANG": "mixed",
+        "DETECTED_FMT": "cobertura",
+        "BASELINE_PYTHON_FILE": "",
+        "GITHUB_OUTPUT": str(gh),
+    }
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    monkeypatch.chdir(tmp_path)
+    # Provide the expected renamed file so coverage parser can read it
+    mixed_out = tmp_path / "cov.python.xml"
+    mixed_out.write_text(
+        "<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8"
+    )
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
+    returncode, _stdout, _stderr = run_script(script, env)
+
+    assert returncode == 0
+    gh_content = gh.read_text(encoding="utf-8")
+    assert "cov.python.xml" in gh_content, (
+        "mixed-lang output path must include .python infix"
+    )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1764,7 +1764,7 @@ def _set_fake_coverage_python_cmd(
 
 def _assert_python_command_structure(parts: list[str]) -> None:
     """Verify common venv Python command structure with slipcover and pytest."""
-    assert Path(parts[0]).name == "python"
+    assert Path(parts[0]).stem == "python"
     slip_idx = parts.index("-m", 1)
     assert parts[slip_idx : slip_idx + 3] == ["-m", "slipcover", "--branch"]
     assert parts[-3:] == ["-m", "pytest", "-v"]
@@ -1772,7 +1772,10 @@ def _assert_python_command_structure(parts: list[str]) -> None:
 
 def _assert_coverage_python_path(actual: str, expected: str) -> None:
     """Assert that a formulated command points at the coverage venv Python."""
-    assert Path(actual).parts[-3:] == Path(expected).parts[-3:]
+    actual_path = Path(actual)
+    expected_path = Path(expected)
+    assert actual_path.parts[-3:-1] == expected_path.parts[-3:-1]
+    assert actual_path.stem == expected_path.stem
 
 
 def _assert_tokens_in_order(parts: list[str], *tokens: str) -> None:
@@ -1852,7 +1855,7 @@ def test_ensure_coverage_venv_returns_coverage_python(
     assert python == str(setup.coverage_venv / "bin" / "python")
     assert len(setup.recorded) == 3
     venv_parts = setup.recorded[0]
-    assert Path(venv_parts[0]).name == "uv"
+    assert Path(venv_parts[0]).stem == "uv"
     assert venv_parts[1:] == ["venv", str(setup.coverage_venv)]
     sync_parts = setup.recorded[1]
     assert sync_parts[1:] == ["sync", "--inexact", "--python", python]
@@ -1940,7 +1943,7 @@ def test_ensure_coverage_venv_raises_when_created_venv_has_no_python(
 
     assert run_python_module._find_coverage_python() is None
     assert len(setup.recorded) == 1
-    assert Path(setup.recorded[0][0]).name == "uv"
+    assert Path(setup.recorded[0][0]).stem == "uv"
     assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
     assert not [r for r in setup.recorded if len(r) > 1 and r[1] == "sync"]
     assert not [
@@ -2053,7 +2056,7 @@ def test_ensure_coverage_venv_targets_venv_python_for_tooling(
     assert len(setup.recorded) == 2
     assert setup.recorded[0][1:] == ["sync", "--inexact", "--python", str(python)]
     parts = setup.recorded[1]
-    assert Path(parts[0]).name == "uv"
+    assert Path(parts[0]).stem == "uv"
     assert parts[1:5] == ["pip", "install", "--python", str(python)]
     assert "--system" not in parts
     assert set(run_python_module.TOOLING_PACKAGES).issubset(parts)

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1850,11 +1850,13 @@ def test_ensure_coverage_venv_returns_coverage_python(
     python = run_python_module._ensure_coverage_venv()
 
     assert python == str(setup.coverage_venv / "bin" / "python")
-    assert len(setup.recorded) == 2
+    assert len(setup.recorded) == 3
     venv_parts = setup.recorded[0]
     assert Path(venv_parts[0]).name == "uv"
     assert venv_parts[1:] == ["venv", str(setup.coverage_venv)]
-    install_parts = setup.recorded[1]
+    sync_parts = setup.recorded[1]
+    assert sync_parts[1:] == ["sync", "--inexact", "--python", python]
+    install_parts = setup.recorded[2]
     assert install_parts[1:5] == [
         "pip",
         "install",
@@ -1877,8 +1879,9 @@ def test_ensure_coverage_venv_reuses_existing_coverage_venv(
     python_path.touch()
 
     assert run_python_module._ensure_coverage_venv() == str(python_path)
-    assert len(setup.recorded) == 1
-    assert setup.recorded[0][1:5] == [
+    assert len(setup.recorded) == 2
+    assert setup.recorded[0][1:] == ["sync", "--inexact", "--python", str(python_path)]
+    assert setup.recorded[1][1:5] == [
         "pip",
         "install",
         "--python",
@@ -1900,6 +1903,7 @@ def test_ensure_coverage_venv_recovers_from_broken_cache(
     venv_calls = [r for r in setup.recorded if len(r) > 1 and r[1] == "venv"]
     assert len(venv_calls) == 1
     assert python == str(setup.coverage_venv / "bin" / "python")
+    assert setup.recorded[-2][1:] == ["sync", "--inexact", "--python", python]
     assert setup.recorded[-1][1:5] == [
         "pip",
         "install",
@@ -1933,9 +1937,15 @@ def test_ensure_coverage_venv_recreates_broken_coverage_venv(
     assert run_python_module._ensure_coverage_venv() == str(
         setup.coverage_venv / "bin" / "python"
     )
-    assert len(setup.recorded) == 2
+    assert len(setup.recorded) == 3
     assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
-    assert setup.recorded[1][1:5] == [
+    assert setup.recorded[1][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(setup.coverage_venv / "bin" / "python"),
+    ]
+    assert setup.recorded[2][1:5] == [
         "pip",
         "install",
         "--python",
@@ -1960,9 +1970,15 @@ def test_ensure_coverage_venv_recreates_invalid_python_candidate(
     assert run_python_module._ensure_coverage_venv() == str(
         setup.coverage_venv / "Scripts" / "python.exe"
     )
-    assert len(setup.recorded) == 2
+    assert len(setup.recorded) == 3
     assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
-    assert setup.recorded[1][1:5] == [
+    assert setup.recorded[1][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(setup.coverage_venv / "Scripts" / "python.exe"),
+    ]
+    assert setup.recorded[2][1:5] == [
         "pip",
         "install",
         "--python",
@@ -1985,8 +2001,9 @@ def test_ensure_coverage_venv_targets_venv_python_for_tooling(
 
     assert run_python_module._ensure_coverage_venv() == str(python)
 
-    assert len(setup.recorded) == 1
-    parts = setup.recorded[0]
+    assert len(setup.recorded) == 2
+    assert setup.recorded[0][1:] == ["sync", "--inexact", "--python", str(python)]
+    parts = setup.recorded[1]
     assert Path(parts[0]).name == "uv"
     assert parts[1:5] == ["pip", "install", "--python", str(python)]
     assert "--system" not in parts
@@ -2018,9 +2035,10 @@ def test_coverage_python_cmd_prepares_tools_once(
     assert first is second
     parts = list(first.formulate())
     _assert_coverage_python_path(parts[0], str(python_path))
-    assert len(recorded) == 2
+    assert len(recorded) == 3
     assert recorded[0][1:] == ["venv", str(coverage_venv)]
-    assert recorded[1][1:5] == [
+    assert recorded[1][1:] == ["sync", "--inexact", "--python", str(python_path)]
+    assert recorded[2][1:5] == [
         "pip",
         "install",
         "--python",

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1803,13 +1803,13 @@ def _is_uv_venv_invocation(parts: list[str]) -> bool:
 
 @dataclasses.dataclass
 class VenvTestSetup:
-    """Scaffolding returned by _setup_create_venv_test for create_venv() tests."""
+    """Scaffolding returned by _setup_coverage_venv_test for venv tests."""
 
     coverage_venv: Path
     recorded: list[list[str]] = dataclasses.field(default_factory=list)
 
 
-def _setup_create_venv_test(
+def _setup_coverage_venv_test(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
@@ -1839,93 +1839,117 @@ def _setup_create_venv_test(
     return setup
 
 
-def test_create_venv_returns_coverage_python(
+def test_ensure_coverage_venv_returns_coverage_python(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper creates the throwaway coverage venv and returns its Python."""
-    setup = _setup_create_venv_test(tmp_path, run_python_module, monkeypatch)
+    setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
 
-    python = run_python_module.create_venv()
+    python = run_python_module._ensure_coverage_venv()
 
     assert python == str(setup.coverage_venv / "bin" / "python")
-    assert len(setup.recorded) == 1
-    parts = setup.recorded[0]
-    assert Path(parts[0]).name == "uv"
-    assert parts[1:] == ["venv", str(setup.coverage_venv)]
+    assert len(setup.recorded) == 2
+    venv_parts = setup.recorded[0]
+    assert Path(venv_parts[0]).name == "uv"
+    assert venv_parts[1:] == ["venv", str(setup.coverage_venv)]
+    install_parts = setup.recorded[1]
+    assert install_parts[1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(setup.coverage_venv / "bin" / "python"),
+    ]
 
 
-def test_create_venv_reuses_existing_coverage_venv(
+def test_ensure_coverage_venv_reuses_existing_coverage_venv(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper does not recreate an existing coverage venv."""
-    setup = _setup_create_venv_test(
+    setup = _setup_coverage_venv_test(
         tmp_path, run_python_module, monkeypatch, python_to_create=None
     )
     python_path = setup.coverage_venv / "Scripts" / "python.exe"
     python_path.parent.mkdir(parents=True)
     python_path.touch()
 
-    assert run_python_module.create_venv() == str(python_path)
-    assert setup.recorded == []
+    assert run_python_module._ensure_coverage_venv() == str(python_path)
+    assert len(setup.recorded) == 1
+    assert setup.recorded[0][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(python_path),
+    ]
 
 
-def test_create_venv_recovers_from_broken_cache(
+def test_ensure_coverage_venv_recovers_from_broken_cache(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """create_venv() recreates a venv whose Python executable is absent."""
-    setup = _setup_create_venv_test(tmp_path, run_python_module, monkeypatch)
+    """The helper recreates a venv whose Python executable is absent."""
+    setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
     setup.coverage_venv.mkdir(parents=True)  # broken: dir present, no binary
 
-    python = run_python_module.create_venv()
+    python = run_python_module._ensure_coverage_venv()
 
     venv_calls = [r for r in setup.recorded if len(r) > 1 and r[1] == "venv"]
     assert len(venv_calls) == 1
     assert python == str(setup.coverage_venv / "bin" / "python")
+    assert setup.recorded[-1][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        python,
+    ]
 
 
-def test_coverage_python_path_raises_when_no_executable(
+def test_find_coverage_python_returns_none_when_no_executable(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_coverage_python_path() raises RuntimeError when no binary exists."""
+    """_find_coverage_python() returns None when no binary exists."""
     coverage_venv = tmp_path / ".venv-coverage"
     coverage_venv.mkdir(parents=True)
     monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
 
-    with pytest.raises(RuntimeError, match="Coverage venv Python executable not found"):
-        run_python_module._coverage_python_path()
+    assert run_python_module._find_coverage_python() is None
 
 
-def test_create_venv_recreates_broken_coverage_venv(
+def test_ensure_coverage_venv_recreates_broken_coverage_venv(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper repairs an existing venv that has no Python executable."""
-    setup = _setup_create_venv_test(tmp_path, run_python_module, monkeypatch)
+    setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
     setup.coverage_venv.mkdir()  # broken: directory present, no Python binary
 
-    assert run_python_module.create_venv() == str(
+    assert run_python_module._ensure_coverage_venv() == str(
         setup.coverage_venv / "bin" / "python"
     )
-    assert len(setup.recorded) == 1
+    assert len(setup.recorded) == 2
     assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
+    assert setup.recorded[1][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(setup.coverage_venv / "bin" / "python"),
+    ]
 
 
-def test_create_venv_recreates_invalid_python_candidate(
+def test_ensure_coverage_venv_recreates_invalid_python_candidate(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The helper rejects non-file Python placeholders before reuse."""
-    setup = _setup_create_venv_test(
+    setup = _setup_coverage_venv_test(
         tmp_path,
         run_python_module,
         monkeypatch,
@@ -1933,32 +1957,38 @@ def test_create_venv_recreates_invalid_python_candidate(
     )
     (setup.coverage_venv / "bin" / "python").mkdir(parents=True)  # dir, not file
 
-    assert run_python_module.create_venv() == str(
+    assert run_python_module._ensure_coverage_venv() == str(
         setup.coverage_venv / "Scripts" / "python.exe"
     )
-    assert len(setup.recorded) == 1
+    assert len(setup.recorded) == 2
     assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
+    assert setup.recorded[1][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(setup.coverage_venv / "Scripts" / "python.exe"),
+    ]
 
 
-def test_install_coverage_tools_targets_venv_python(
+def test_ensure_coverage_venv_targets_venv_python_for_tooling(
+    tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tooling installs into the throwaway venv instead of the system Python."""
-    recorded: list[list[str]] = []
+    setup = _setup_coverage_venv_test(
+        tmp_path, run_python_module, monkeypatch, python_to_create=None
+    )
+    python = setup.coverage_venv / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.touch()
 
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+    assert run_python_module._ensure_coverage_venv() == str(python)
 
-    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
-
-    python = _coverage_python(run_python_module)
-    run_python_module.install_coverage_tools(python)
-
-    assert len(recorded) == 1
-    parts = recorded[0]
+    assert len(setup.recorded) == 1
+    parts = setup.recorded[0]
     assert Path(parts[0]).name == "uv"
-    assert parts[1:5] == ["pip", "install", "--python", python]
+    assert parts[1:5] == ["pip", "install", "--python", str(python)]
     assert "--system" not in parts
     assert set(run_python_module.TOOLING_PACKAGES).issubset(parts)
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2502,6 +2502,19 @@ def _python_integration_env(
     return env
 
 
+def _run_integration_script(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    bin_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[int, str, str]:
+    """Set up env, chdir, and invoke run_python.py; return (rc, stdout, stderr)."""
+    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
+    monkeypatch.chdir(tmp_path)
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
+    return run_script(script, env)
+
+
 def test_run_python_integration_cobertura_success(
     tmp_path: Path,
     shell_stubs: StubManager,
@@ -2509,11 +2522,11 @@ def test_run_python_integration_cobertura_success(
 ) -> None:
     """run_python.py creates the venv, syncs deps, and installs tooling."""
     bin_dir, log = _write_fake_uv(tmp_path)
-    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
-    monkeypatch.chdir(tmp_path)
 
-    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
-    returncode, _stdout, _stderr = run_script(script, env)
+    returncode, _stdout, _stderr = _run_integration_script(
+        tmp_path, shell_stubs, bin_dir, monkeypatch
+    )
+
     uv_calls = log.read_text(encoding="utf-8").splitlines()
     venv_calls = [c for c in uv_calls if c.startswith("venv ")]
     sync_calls = [c for c in uv_calls if c.startswith("sync ")]
@@ -2537,11 +2550,11 @@ def test_run_python_integration_uv_venv_failure(
 ) -> None:
     """run_python.py exits non-zero when uv venv fails."""
     bin_dir, _log = _write_fake_uv(tmp_path, venv_exit=1)
-    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
-    monkeypatch.chdir(tmp_path)
 
-    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
-    returncode, _stdout, _stderr = run_script(script, env)
+    returncode, _stdout, _stderr = _run_integration_script(
+        tmp_path, shell_stubs, bin_dir, monkeypatch
+    )
+
     assert returncode != 0
 
 
@@ -2552,10 +2565,10 @@ def test_run_python_integration_uv_sync_failure(
 ) -> None:
     """run_python.py exits non-zero and logs a message when uv sync fails."""
     bin_dir, _log = _write_fake_uv(tmp_path, sync_exit=2)
-    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
-    monkeypatch.chdir(tmp_path)
 
-    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
-    returncode, _stdout, stderr = run_script(script, env)
+    returncode, _stdout, stderr = _run_integration_script(
+        tmp_path, shell_stubs, bin_dir, monkeypatch
+    )
+
     assert returncode != 0
     assert "uv sync failed" in stderr

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1970,6 +1970,16 @@ def _assert_venv_rebuild_commands(
     ]
 
 
+def _assert_venv_default_python_rebuild(
+    python: str,
+    setup: VenvTestSetup,
+) -> None:
+    """Assert venv was rebuilt and Python resolved to the default POSIX path."""
+    expected = setup.coverage_venv / "bin" / "python"
+    assert python == str(expected)
+    _assert_venv_rebuild_commands(setup.recorded, setup.coverage_venv, expected)
+
+
 def test_ensure_coverage_venv_replaces_broken_symlink_cache(
     tmp_path: Path,
     run_python_module: ModuleType,
@@ -1984,12 +1994,7 @@ def test_ensure_coverage_venv_replaces_broken_symlink_cache(
     python = run_python_module._ensure_coverage_venv()
 
     assert not setup.coverage_venv.is_symlink()
-    assert python == str(setup.coverage_venv / "bin" / "python")
-    _assert_venv_rebuild_commands(
-        setup.recorded,
-        setup.coverage_venv,
-        setup.coverage_venv / "bin" / "python",
-    )
+    _assert_venv_default_python_rebuild(python, setup)
 
 
 def test_ensure_coverage_venv_replaces_broken_file_cache(
@@ -2003,12 +2008,7 @@ def test_ensure_coverage_venv_replaces_broken_file_cache(
 
     python = run_python_module._ensure_coverage_venv()
 
-    assert python == str(setup.coverage_venv / "bin" / "python")
-    _assert_venv_rebuild_commands(
-        setup.recorded,
-        setup.coverage_venv,
-        setup.coverage_venv / "bin" / "python",
-    )
+    _assert_venv_default_python_rebuild(python, setup)
 
 
 def test_ensure_coverage_venv_recreates_invalid_python_candidate(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2404,3 +2404,158 @@ def test_cobertura_permission_error(
     with pytest.raises(run_python_module.typer.Exit) as excinfo:
         run_python_module.get_line_coverage_percent_from_cobertura(xml)
     assert _exit_code(excinfo.value) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests - run_python.py via run_script()
+# ---------------------------------------------------------------------------
+
+
+def _run_python_script(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    *,
+    fmt: str = "cobertura",
+    extra_env: dict[str, str] | None = None,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> tuple[int, str, str]:
+    """Run run_python.py end-to-end with stub uv and return (rc, stdout, stderr)."""
+    out = tmp_path / "cov.xml"
+    gh = tmp_path / "gh.txt"
+    out.write_text("<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8")
+
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(out),
+        "DETECTED_LANG": "python",
+        "DETECTED_FMT": fmt,
+        "GITHUB_OUTPUT": str(gh),
+    }
+    if extra_env:
+        env.update(extra_env)
+    if monkeypatch is not None:
+        monkeypatch.chdir(tmp_path)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
+    return run_script(script, env)
+
+
+def _write_fake_uv(
+    tmp_path: Path,
+    *,
+    venv_exit: int = 0,
+    sync_exit: int = 0,
+) -> tuple[Path, Path]:
+    """Write a fake uv executable and return its bin directory and log path."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "uv-calls.log"
+    uv = bin_dir / "uv"
+    uv.write_text(
+        f"""#!/usr/bin/env sh
+printf '%s\\n' "$*" >> '{log}'
+if [ "$1" = "venv" ]; then
+    if [ {venv_exit} -ne 0 ]; then
+        echo "uv venv exploded" >&2
+        exit {venv_exit}
+    fi
+    mkdir -p "$2/bin"
+    cat > "$2/bin/python" <<'PY'
+#!/usr/bin/env sh
+exit 0
+PY
+    chmod +x "$2/bin/python"
+    exit 0
+fi
+if [ "$1" = "sync" ]; then
+    if [ {sync_exit} -ne 0 ]; then
+        echo "uv sync exploded" >&2
+        exit {sync_exit}
+    fi
+    exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    return bin_dir, log
+
+
+def _python_integration_env(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    bin_dir: Path,
+) -> dict[str, str]:
+    """Return environment for run_python.py integration tests."""
+    out = tmp_path / "cov.xml"
+    gh = tmp_path / "gh.txt"
+    out.write_text("<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8")
+    env = {
+        **shell_stubs.env,
+        "INPUT_OUTPUT_PATH": str(out),
+        "DETECTED_LANG": "python",
+        "DETECTED_FMT": "cobertura",
+        "GITHUB_OUTPUT": str(gh),
+    }
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    return env
+
+
+def test_run_python_integration_cobertura_success(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_python.py creates the venv, syncs deps, and installs tooling."""
+    bin_dir, log = _write_fake_uv(tmp_path)
+    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
+    monkeypatch.chdir(tmp_path)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
+    returncode, _stdout, _stderr = run_script(script, env)
+    uv_calls = log.read_text(encoding="utf-8").splitlines()
+    venv_calls = [c for c in uv_calls if c.startswith("venv ")]
+    sync_calls = [c for c in uv_calls if c.startswith("sync ")]
+    pip_calls = [c for c in uv_calls if c.startswith("pip install ")]
+    assert returncode == 0
+    assert venv_calls, "uv venv must be called to create the coverage venv"
+    assert sync_calls, "uv sync must be called to install project deps"
+    assert pip_calls, "uv pip install must be called to install tooling"
+    pip_args = pip_calls[0].split()
+    assert "--python" in pip_args
+    assert "--system" not in pip_args
+    assert "slipcover" in pip_args
+    assert "pytest" in pip_args
+    assert "coverage" in pip_args
+
+
+def test_run_python_integration_uv_venv_failure(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_python.py exits non-zero when uv venv fails."""
+    bin_dir, _log = _write_fake_uv(tmp_path, venv_exit=1)
+    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
+    monkeypatch.chdir(tmp_path)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
+    returncode, _stdout, _stderr = run_script(script, env)
+    assert returncode != 0
+
+
+def test_run_python_integration_uv_sync_failure(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_python.py exits non-zero and logs a message when uv sync fails."""
+    bin_dir, _log = _write_fake_uv(tmp_path, sync_exit=2)
+    env = _python_integration_env(tmp_path, shell_stubs, bin_dir)
+    monkeypatch.chdir(tmp_path)
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
+    returncode, _stdout, stderr = run_script(script, env)
+    assert returncode != 0
+    assert "uv sync failed" in stderr

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1743,19 +1743,22 @@ def run_python_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     return _load_module(monkeypatch, "run_python")
 
 
-def _assert_uv_run_base(parts: list[str]) -> None:
-    """Assert that parts starts with 'uv run'."""
-    assert Path(parts[0]).name == "uv"
-    assert parts[1] == "run"
+def _coverage_python(run_python_module: ModuleType) -> str:
+    """Return the expected throwaway venv Python path."""
+    return str(run_python_module.COVERAGE_VENV / "bin" / "python")
 
 
-def _assert_uv_command_structure(parts: list[str]) -> None:
-    """Verify common uv run command structure with slipcover and pytest."""
-    _assert_uv_run_base(parts)
-    python_idx = parts.index("python")
-    slip_idx = parts.index("-m", python_idx + 1)
+def _assert_python_command_structure(parts: list[str]) -> None:
+    """Verify common venv Python command structure with slipcover and pytest."""
+    assert Path(parts[0]).name == "python"
+    slip_idx = parts.index("-m", 1)
     assert parts[slip_idx : slip_idx + 3] == ["-m", "slipcover", "--branch"]
     assert parts[-3:] == ["-m", "pytest", "-v"]
+
+
+def _assert_coverage_python_path(actual: str, expected: str) -> None:
+    """Assert that a formulated command points at the coverage venv Python."""
+    assert Path(actual).parts[-3:] == Path(expected).parts[-3:]
 
 
 def _assert_tokens_in_order(parts: list[str], *tokens: str) -> None:
@@ -1779,13 +1782,59 @@ def _assert_flag_value_pair(parts: list[str], flag: str, value: str) -> None:
     pytest.fail(message)
 
 
-def test_uv_python_cmd_bundles_dependencies(run_python_module: ModuleType) -> None:
-    """The helper wires ``uv run`` with slipcover/pytest/coverage."""
-    cmd = run_python_module._uv_python_cmd()
+def test_create_venv_returns_coverage_python(
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper creates the throwaway coverage venv and returns its Python."""
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    python = run_python_module.create_venv()
+
+    assert python == _coverage_python(run_python_module)
+    assert len(recorded) == 1
+    parts = recorded[0]
+    assert Path(parts[0]).name == "uv"
+    assert parts[1:] == ["venv", str(run_python_module.COVERAGE_VENV)]
+
+
+def test_install_coverage_tools_targets_venv_python(
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tooling installs into the throwaway venv instead of the system Python."""
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        recorded.append(list(cmd.formulate()))  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    python = _coverage_python(run_python_module)
+    run_python_module.install_coverage_tools(python)
+
+    assert len(recorded) == 1
+    parts = recorded[0]
+    assert Path(parts[0]).name == "uv"
+    assert parts[1:5] == ["pip", "install", "--python", python]
+    assert "--system" not in parts
+    assert set(run_python_module.TOOLING_PACKAGES).issubset(parts)
+
+
+def test_coverage_cmd_uses_venv_python(run_python_module: ModuleType) -> None:
+    """The helper wires slipcover/pytest through the throwaway venv."""
+    python = _coverage_python(run_python_module)
+    cmd = run_python_module.coverage_cmd_for_fmt(
+        "coveragepy", Path("coverage.dat"), python
+    )
     parts = list(cmd.formulate())
-    _assert_uv_run_base(parts)
-    assert parts.count("--with") >= 3
-    assert {"slipcover", "pytest", "coverage"}.issubset(parts)
+    _assert_coverage_python_path(parts[0], python)
+    _assert_python_command_structure(parts)
 
 
 def _get_coverage_cmd_parts(
@@ -1796,16 +1845,18 @@ def _get_coverage_cmd_parts(
 ) -> tuple[list[str], Path]:
     """Build coverage command for format and return parts and output path."""
     out = tmp_path / f"cov.{suffix}"
-    cmd = run_python_module.coverage_cmd_for_fmt(fmt, out)
+    cmd = run_python_module.coverage_cmd_for_fmt(
+        fmt, out, _coverage_python(run_python_module)
+    )
     parts = list(cmd.formulate())
-    _assert_uv_command_structure(parts)
+    _assert_python_command_structure(parts)
     return parts, out
 
 
-def test_coverage_cmd_cobertura_uses_uv(
+def test_coverage_cmd_cobertura_uses_venv_python(
     tmp_path: Path, run_python_module: ModuleType
 ) -> None:
-    """Cobertura format invokes slipcover with ``--xml`` using ``uv run``."""
+    """Cobertura format invokes slipcover with ``--xml`` using the venv Python."""
     parts, out = _get_coverage_cmd_parts(
         tmp_path, run_python_module, "cobertura", "xml"
     )
@@ -1833,10 +1884,10 @@ def test_non_cobertura_formats_do_not_emit_out_flag(
     assert "--out" not in parts
 
 
-def test_tmp_coveragepy_xml_invokes_uv(
+def test_tmp_coveragepy_xml_invokes_venv_python(
     tmp_path: Path, run_python_module: ModuleType
 ) -> None:
-    """The coverage.py exporter also reuses the uv helper."""
+    """The coverage.py exporter also reuses the venv Python."""
     out = tmp_path / "coveragepy.dat"
     xml_path = out.with_suffix(".xml")
     recorded: dict[str, list[str]] = {}
@@ -1847,15 +1898,15 @@ def test_tmp_coveragepy_xml_invokes_uv(
 
     run_python_module.run_cmd = fake_run_cmd  # type: ignore[assignment]
 
-    with run_python_module.tmp_coveragepy_xml(out) as generated:
+    python = _coverage_python(run_python_module)
+    with run_python_module.tmp_coveragepy_xml(out, python) as generated:
         assert generated == xml_path
         assert xml_path.exists()
 
     assert not xml_path.exists()
     parts = recorded["cmd"]
-    _assert_uv_run_base(parts)
+    _assert_coverage_python_path(parts[0], python)
     assert parts[-5:] == ["-m", "coverage", "xml", "-o", str(xml_path)]
-    assert {"coverage", "pytest", "slipcover"}.issubset(parts)
 
 
 def test_run_python_cobertura_passes_out_flag(
@@ -1870,17 +1921,30 @@ def test_run_python_cobertura_passes_out_flag(
         encoding="utf-8",
     )
     github_output = tmp_path / "gh.txt"
-    recorded: dict[str, list[str]] = {}
+    recorded: list[tuple[list[str], str | None]] = []
 
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        recorded["cmd"] = list(cmd.formulate())  # type: ignore[attr-defined]
+    def fake_run_cmd(cmd: object, *_args: object, **kwargs: object) -> None:
+        recorded.append(
+            (list(cmd.formulate()), typ.cast("str | None", kwargs.get("method")))
+        )  # type: ignore[attr-defined]
 
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
 
     run_python_module.main(output, "python", "cobertura", github_output, None)
 
-    parts = recorded["cmd"]
-    _assert_uv_command_structure(parts)
+    assert len(recorded) == 3
+    assert recorded[0][0][1:] == ["venv", str(run_python_module.COVERAGE_VENV)]
+    install_parts = recorded[1][0]
+    assert install_parts[1:5] == [
+        "pip",
+        "install",
+        "--python",
+        _coverage_python(run_python_module),
+    ]
+    assert "--system" not in install_parts
+    parts = recorded[2][0]
+    assert recorded[2][1] == "run_fg"
+    _assert_python_command_structure(parts)
     _assert_tokens_in_order(parts, "--xml", "--out")
     _assert_flag_value_pair(parts, "--out", str(output))
     data = github_output.read_text().splitlines()
@@ -1957,7 +2021,7 @@ def test_run_python_coveragepy_empty_xml(
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
 
     @contextlib.contextmanager
-    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+    def fake_tmp_coveragepy_xml(out: Path, _python: str) -> typ.Iterator[Path]:
         xml_path = tmp_path / "coverage.xml"
         xml_path.write_text(
             "<coverage lines-covered='0' lines-valid='0' />",
@@ -2003,7 +2067,7 @@ def test_run_python_coveragepy_malformed_xml_exits(
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
 
     @contextlib.contextmanager
-    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+    def fake_tmp_coveragepy_xml(out: Path, _python: str) -> typ.Iterator[Path]:
         xml_path = tmp_path / "coverage.xml"
         xml_path.write_text("<coverage>", encoding="utf-8")
         try:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2411,35 +2411,6 @@ def test_cobertura_permission_error(
 # ---------------------------------------------------------------------------
 
 
-def _run_python_script(
-    tmp_path: Path,
-    shell_stubs: StubManager,
-    *,
-    fmt: str = "cobertura",
-    extra_env: dict[str, str] | None = None,
-    monkeypatch: pytest.MonkeyPatch | None = None,
-) -> tuple[int, str, str]:
-    """Run run_python.py end-to-end with stub uv and return (rc, stdout, stderr)."""
-    out = tmp_path / "cov.xml"
-    gh = tmp_path / "gh.txt"
-    out.write_text("<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8")
-
-    env = {
-        **shell_stubs.env,
-        "INPUT_OUTPUT_PATH": str(out),
-        "DETECTED_LANG": "python",
-        "DETECTED_FMT": fmt,
-        "GITHUB_OUTPUT": str(gh),
-    }
-    if extra_env:
-        env.update(extra_env)
-    if monkeypatch is not None:
-        monkeypatch.chdir(tmp_path)
-
-    script = Path(__file__).resolve().parents[1] / "scripts" / "run_python.py"
-    return run_script(script, env)
-
-
 def _write_fake_uv(
     tmp_path: Path,
     *,

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1991,7 +1991,6 @@ def test_ensure_coverage_venv_replaces_broken_symlink_cache(
     """The helper unlinks a symlink cache placeholder before recreate."""
     setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
     target = tmp_path / "not-a-venv"
-    target.write_text("not a directory")
     setup.coverage_venv.symlink_to(target)
 
     python = run_python_module._ensure_coverage_venv()

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1965,17 +1965,24 @@ def test_coverage_cmd_uses_venv_python(
     _assert_python_command_structure(parts)
 
 
+@dataclasses.dataclass(frozen=True)
+class CoverageFmtSpec:
+    """Pairs a coverage format name with the corresponding file suffix."""
+
+    fmt: str
+    suffix: str
+
+
 def _get_coverage_cmd_parts(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
-    fmt: str,
-    suffix: str,
+    spec: CoverageFmtSpec,
 ) -> tuple[list[str], Path]:
     """Build coverage command for format and return parts and output path."""
-    out = tmp_path / f"cov.{suffix}"
+    out = tmp_path / f"cov.{spec.suffix}"
     _set_fake_coverage_python_cmd(monkeypatch, run_python_module)
-    cmd = run_python_module.coverage_cmd_for_fmt(fmt, out)
+    cmd = run_python_module.coverage_cmd_for_fmt(spec.fmt, out)
     parts = list(cmd.formulate())
     _assert_python_command_structure(parts)
     return parts, out
@@ -1988,7 +1995,7 @@ def test_coverage_cmd_cobertura_uses_venv_python(
 ) -> None:
     """Cobertura format invokes slipcover with ``--xml`` using the venv Python."""
     parts, out = _get_coverage_cmd_parts(
-        tmp_path, run_python_module, monkeypatch, "cobertura", "xml"
+        tmp_path, run_python_module, monkeypatch, CoverageFmtSpec("cobertura", "xml")
     )
     assert parts.count("--xml") == 1
     _assert_tokens_in_order(parts, "--xml", "--out")
@@ -2002,7 +2009,7 @@ def test_coverage_cmd_default_branch_has_shared_args(
 ) -> None:
     """Non-Cobertura formats reuse the shared slipcover arguments."""
     parts, out = _get_coverage_cmd_parts(
-        tmp_path, run_python_module, monkeypatch, "coveragepy", "dat"
+        tmp_path, run_python_module, monkeypatch, CoverageFmtSpec("coveragepy", "dat")
     )
     assert "--xml" not in parts
     assert str(out) not in parts
@@ -2015,7 +2022,7 @@ def test_non_cobertura_formats_do_not_emit_out_flag(
 ) -> None:
     """Ensure slipcover output targeting stays isolated to Cobertura runs."""
     parts, _ = _get_coverage_cmd_parts(
-        tmp_path, run_python_module, monkeypatch, "coveragepy", "dat"
+        tmp_path, run_python_module, monkeypatch, CoverageFmtSpec("coveragepy", "dat")
     )
     assert "--out" not in parts
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1796,6 +1796,11 @@ def _assert_flag_value_pair(parts: list[str], flag: str, value: str) -> None:
     pytest.fail(message)
 
 
+def _is_uv_venv_invocation(parts: list[str]) -> bool:
+    """Return True when the command parts represent a ``uv venv`` call."""
+    return len(parts) > 1 and parts[1] == "venv"
+
+
 @dataclasses.dataclass
 class VenvTestSetup:
     """Scaffolding returned by _setup_create_venv_test for create_venv() tests."""
@@ -1824,7 +1829,7 @@ def _setup_create_venv_test(
     def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
         parts = list(cmd.formulate())  # type: ignore[attr-defined]
         setup.recorded.append(parts)
-        if python_to_create is not None and len(parts) > 1 and parts[1] == "venv":
+        if python_to_create is not None and _is_uv_venv_invocation(parts):
             python_path = coverage_venv / python_to_create
             python_path.parent.mkdir(parents=True, exist_ok=True)
             python_path.touch()

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1925,29 +1925,21 @@ def test_find_coverage_python_returns_none_when_no_executable(
     assert run_python_module._find_coverage_python() is None
 
 
-def _assert_venv_recreated_with_python(
-    setup: VenvTestSetup,
+def _assert_venv_rebuild_commands(
+    recorded: list[list[str]],
+    coverage_venv: Path,
     python_path: Path,
 ) -> None:
-    """Assert the three run_cmd calls expected after a venv recreation.
-
-    Parameters
-    ----------
-    setup:
-        Shared scaffolding containing the recorded command parts.
-    python_path:
-        Absolute path to the Python executable that the recreation must
-        target for the sync and pip-install commands.
-    """
-    assert len(setup.recorded) == 3
-    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
-    assert setup.recorded[1][1:] == [
+    """Assert the three-command venv rebuild sequence: venv, sync, pip install."""
+    assert len(recorded) == 3
+    assert recorded[0][1:] == ["venv", str(coverage_venv)]
+    assert recorded[1][1:] == [
         "sync",
         "--inexact",
         "--python",
         str(python_path),
     ]
-    assert setup.recorded[2][1:5] == [
+    assert recorded[2][1:5] == [
         "pip",
         "install",
         "--python",
@@ -1967,7 +1959,11 @@ def test_ensure_coverage_venv_replaces_broken_file_cache(
     python = run_python_module._ensure_coverage_venv()
 
     assert python == str(setup.coverage_venv / "bin" / "python")
-    _assert_venv_recreated_with_python(setup, setup.coverage_venv / "bin" / "python")
+    _assert_venv_rebuild_commands(
+        setup.recorded,
+        setup.coverage_venv,
+        setup.coverage_venv / "bin" / "python",
+    )
 
 
 def test_ensure_coverage_venv_recreates_invalid_python_candidate(
@@ -1987,8 +1983,10 @@ def test_ensure_coverage_venv_recreates_invalid_python_candidate(
     assert run_python_module._ensure_coverage_venv() == str(
         setup.coverage_venv / "Scripts" / "python.exe"
     )
-    _assert_venv_recreated_with_python(
-        setup, setup.coverage_venv / "Scripts" / "python.exe"
+    _assert_venv_rebuild_commands(
+        setup.recorded,
+        setup.coverage_venv,
+        setup.coverage_venv / "Scripts" / "python.exe",
     )
 
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1816,7 +1816,7 @@ def _setup_create_venv_test(
     ----------
     python_to_create:
         Relative POSIX path inside the venv to create when ``uv venv``
-        is recorded. Pass ``None`` to skip creation (reuse scenario).
+        is called.  Pass ``None`` to skip creation (venv-reuse scenario).
     """
     coverage_venv = tmp_path / ".venv-coverage"
     setup = VenvTestSetup(coverage_venv=coverage_venv)
@@ -1866,38 +1866,6 @@ def test_create_venv_reuses_existing_coverage_venv(
 
     assert run_python_module.create_venv() == str(python_path)
     assert setup.recorded == []
-
-
-def test_create_venv_recovers_from_broken_cache(
-    tmp_path: Path,
-    run_python_module: ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """create_venv() recreates a venv whose Python executable is absent."""
-    coverage_venv = tmp_path / ".venv-coverage"
-    # Simulate a broken cache: directory exists but no Python binary inside it
-    coverage_venv.mkdir(parents=True)
-    recorded: list[list[str]] = []
-
-    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
-        parts = list(cmd.formulate())  # type: ignore[attr-defined]
-        recorded.append(parts)
-        if parts[1] == "venv":
-            # After the recreate call, place the binary so the second
-            # _coverage_python_path() call succeeds.
-            python = coverage_venv / "bin" / "python"
-            python.parent.mkdir(parents=True, exist_ok=True)
-            python.touch()
-
-    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
-    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
-
-    python = run_python_module.create_venv()
-
-    # One uv venv call (the recreate) must have been recorded.
-    venv_calls = [r for r in recorded if r[1] == "venv"]
-    assert len(venv_calls) == 1
-    assert python == str(coverage_venv / "bin" / "python")
 
 
 def test_coverage_python_path_raises_when_no_executable(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1873,8 +1873,9 @@ def test_ensure_coverage_venv_returns_coverage_python(
     setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
 
     python = run_python_module._ensure_coverage_venv()
+    expected_python = (setup.coverage_venv / "bin" / "python").resolve()
 
-    assert python == str(setup.coverage_venv / "bin" / "python")
+    assert python == str(expected_python)
     assert len(setup.recorded) == 3
     venv_parts = setup.recorded[0]
     assert Path(venv_parts[0]).stem == "uv"
@@ -1886,7 +1887,7 @@ def test_ensure_coverage_venv_returns_coverage_python(
         "pip",
         "install",
         "--python",
-        str(setup.coverage_venv / "bin" / "python"),
+        str(expected_python),
     ]
 
 
@@ -1903,14 +1904,19 @@ def test_ensure_coverage_venv_reuses_existing_coverage_venv(
     python_path.parent.mkdir(parents=True)
     python_path.touch()
 
-    assert run_python_module._ensure_coverage_venv() == str(python_path)
+    assert run_python_module._ensure_coverage_venv() == str(python_path.resolve())
     assert len(setup.recorded) == 2
-    assert setup.recorded[0][1:] == ["sync", "--inexact", "--python", str(python_path)]
+    assert setup.recorded[0][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(python_path.resolve()),
+    ]
     assert setup.recorded[1][1:5] == [
         "pip",
         "install",
         "--python",
-        str(python_path),
+        str(python_path.resolve()),
     ]
 
 
@@ -1927,7 +1933,7 @@ def test_ensure_coverage_venv_recovers_from_broken_cache(
 
     venv_calls = [r for r in setup.recorded if len(r) > 1 and r[1] == "venv"]
     assert len(venv_calls) == 1
-    assert python == str(setup.coverage_venv / "bin" / "python")
+    assert python == str((setup.coverage_venv / "bin" / "python").resolve())
     assert setup.recorded[-2][1:] == ["sync", "--inexact", "--python", python]
     assert setup.recorded[-1][1:5] == [
         "pip",
@@ -1948,6 +1954,26 @@ def test_find_coverage_python_returns_none_when_no_executable(
     monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
 
     assert run_python_module._find_coverage_python() is None
+
+
+def test_find_coverage_python_returns_absolute_path(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_find_coverage_python() resolves relative venv paths before returning."""
+    monkeypatch.chdir(tmp_path)
+    coverage_venv = Path(".venv-coverage")
+    python = coverage_venv / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.touch()
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+
+    found = run_python_module._find_coverage_python()
+
+    assert found is not None
+    assert found == python.resolve()
+    assert found.is_absolute()
 
 
 def test_ensure_coverage_venv_raises_when_created_venv_has_no_python(
@@ -1985,13 +2011,13 @@ def _assert_venv_rebuild_commands(
         "sync",
         "--inexact",
         "--python",
-        str(python_path),
+        str(python_path.resolve()),
     ]
     assert recorded[2][1:5] == [
         "pip",
         "install",
         "--python",
-        str(python_path),
+        str(python_path.resolve()),
     ]
 
 
@@ -2001,7 +2027,7 @@ def _assert_venv_default_python_rebuild(
 ) -> None:
     """Assert venv was rebuilt and Python resolved to the default POSIX path."""
     expected = setup.coverage_venv / "bin" / "python"
-    assert python == str(expected)
+    assert python == str(expected.resolve())
     _assert_venv_rebuild_commands(setup.recorded, setup.coverage_venv, expected)
 
 
@@ -2045,7 +2071,7 @@ def test_ensure_coverage_venv_recreates_invalid_python_candidate(
     (setup.coverage_venv / "bin" / "python").mkdir(parents=True)  # dir, not file
 
     assert run_python_module._ensure_coverage_venv() == str(
-        setup.coverage_venv / "Scripts" / "python.exe"
+        (setup.coverage_venv / "Scripts" / "python.exe").resolve()
     )
     _assert_venv_rebuild_commands(
         setup.recorded,
@@ -2067,13 +2093,18 @@ def test_ensure_coverage_venv_targets_venv_python_for_tooling(
     python.parent.mkdir(parents=True)
     python.touch()
 
-    assert run_python_module._ensure_coverage_venv() == str(python)
+    assert run_python_module._ensure_coverage_venv() == str(python.resolve())
 
     assert len(setup.recorded) == 2
-    assert setup.recorded[0][1:] == ["sync", "--inexact", "--python", str(python)]
+    assert setup.recorded[0][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(python.resolve()),
+    ]
     parts = setup.recorded[1]
     assert Path(parts[0]).stem == "uv"
-    assert parts[1:5] == ["pip", "install", "--python", str(python)]
+    assert parts[1:5] == ["pip", "install", "--python", str(python.resolve())]
     assert "--system" not in parts
     assert set(run_python_module.TOOLING_PACKAGES).issubset(parts)
 
@@ -2101,7 +2132,7 @@ def test_ensure_coverage_venv_sets_uv_project_environment_for_sync(
     monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
     monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
 
-    assert run_python_module._ensure_coverage_venv() == str(python)
+    assert run_python_module._ensure_coverage_venv() == str(python.resolve())
 
     assert sync_environment == [str(setup.coverage_venv.resolve())]
     assert "UV_PROJECT_ENVIRONMENT" not in os.environ
@@ -2132,15 +2163,20 @@ def test_coverage_python_cmd_prepares_tools_once(
 
     assert first is second
     parts = list(first.formulate())
-    _assert_coverage_python_path(parts[0], str(python_path))
+    _assert_coverage_python_path(parts[0], str(python_path.resolve()))
     assert len(recorded) == 3
     assert recorded[0][1:] == ["venv", str(coverage_venv)]
-    assert recorded[1][1:] == ["sync", "--inexact", "--python", str(python_path)]
+    assert recorded[1][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(python_path.resolve()),
+    ]
     assert recorded[2][1:5] == [
         "pip",
         "install",
         "--python",
-        str(python_path),
+        str(python_path.resolve()),
     ]
 
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2056,6 +2056,34 @@ def test_ensure_coverage_venv_targets_venv_python_for_tooling(
     assert set(run_python_module.TOOLING_PACKAGES).issubset(parts)
 
 
+def test_ensure_coverage_venv_sets_uv_project_environment_for_sync(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uv sync targets the coverage venv via UV_PROJECT_ENVIRONMENT."""
+    setup = _setup_coverage_venv_test(
+        tmp_path, run_python_module, monkeypatch, python_to_create=None
+    )
+    python = setup.coverage_venv / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.touch()
+    sync_environment: list[str | None] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        parts = list(cmd.formulate())  # type: ignore[attr-defined]
+        setup.recorded.append(parts)
+        if len(parts) > 1 and parts[1] == "sync":
+            sync_environment.append(os.environ.get("UV_PROJECT_ENVIRONMENT"))
+
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+    monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+
+    assert run_python_module._ensure_coverage_venv() == str(python)
+
+    assert sync_environment == [str(setup.coverage_venv.resolve())]
+
+
 def test_coverage_python_cmd_prepares_tools_once(
     tmp_path: Path,
     run_python_module: ModuleType,

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1925,6 +1925,29 @@ def test_find_coverage_python_returns_none_when_no_executable(
     assert run_python_module._find_coverage_python() is None
 
 
+def test_ensure_coverage_venv_raises_when_created_venv_has_no_python(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_ensure_coverage_venv() fails before sync/install if uv creates no Python."""
+    setup = _setup_coverage_venv_test(
+        tmp_path, run_python_module, monkeypatch, python_to_create=None
+    )
+
+    with pytest.raises(RuntimeError, match="Coverage venv Python executable not found"):
+        run_python_module._ensure_coverage_venv()
+
+    assert run_python_module._find_coverage_python() is None
+    assert len(setup.recorded) == 1
+    assert Path(setup.recorded[0][0]).name == "uv"
+    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
+    assert not [r for r in setup.recorded if len(r) > 1 and r[1] == "sync"]
+    assert not [
+        r for r in setup.recorded if len(r) > 2 and r[1:3] == ["pip", "install"]
+    ]
+
+
 def _assert_venv_rebuild_commands(
     recorded: list[list[str]],
     coverage_venv: Path,
@@ -1945,6 +1968,28 @@ def _assert_venv_rebuild_commands(
         "--python",
         str(python_path),
     ]
+
+
+def test_ensure_coverage_venv_replaces_broken_symlink_cache(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper unlinks a symlink cache placeholder before recreate."""
+    setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
+    target = tmp_path / "not-a-venv"
+    target.write_text("not a directory")
+    setup.coverage_venv.symlink_to(target)
+
+    python = run_python_module._ensure_coverage_venv()
+
+    assert not setup.coverage_venv.is_symlink()
+    assert python == str(setup.coverage_venv / "bin" / "python")
+    _assert_venv_rebuild_commands(
+        setup.recorded,
+        setup.coverage_venv,
+        setup.coverage_venv / "bin" / "python",
+    )
 
 
 def test_ensure_coverage_venv_replaces_broken_file_cache(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1767,6 +1767,8 @@ def run_python_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 
 def _coverage_python(run_python_module: ModuleType) -> str:
     """Return the expected throwaway venv Python path."""
+    if sys.platform == "win32":
+        return str(run_python_module.COVERAGE_VENV / "Scripts" / "python.exe")
     return str(run_python_module.COVERAGE_VENV / "bin" / "python")
 
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -14,6 +14,7 @@ import typing as typ
 from pathlib import Path
 
 import pytest
+import yaml
 from plumbum import local
 
 from cmd_utils_importer import import_cmd_utils
@@ -2433,6 +2434,32 @@ def test_cobertura_permission_error(
 # ---------------------------------------------------------------------------
 
 
+def _generate_coverage_action() -> dict[str, object]:
+    """Return the generate-coverage action contract."""
+    action = Path(__file__).resolve().parents[1] / "action.yml"
+    with action.open(encoding="utf-8") as stream:
+        loaded = yaml.safe_load(stream)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _python_step_env_contract() -> dict[str, str]:
+    """Return the env contract for the Python coverage step."""
+    action = _generate_coverage_action()
+    runs = action.get("runs")
+    assert isinstance(runs, dict)
+    steps = runs.get("steps")
+    assert isinstance(steps, list)
+    python_step = next(
+        step for step in steps if isinstance(step, dict) and step.get("id") == "python"
+    )
+    env = python_step.get("env")
+    assert isinstance(env, dict)
+    assert all(isinstance(key, str) for key in env)
+    assert all(isinstance(value, str) for value in env.values())
+    return typ.cast("dict[str, str]", env)
+
+
 def _write_fake_uv(
     tmp_path: Path,
     *,
@@ -2481,6 +2508,11 @@ def _python_integration_env(
     bin_dir: Path,
 ) -> dict[str, str]:
     """Return environment for run_python.py integration tests."""
+    python_env = _python_step_env_contract()
+    assert python_env["INPUT_OUTPUT_PATH"] == "${{ inputs.output-path }}"
+    assert python_env["DETECTED_LANG"] == "${{ steps.detect.outputs.lang }}"
+    assert python_env["DETECTED_FMT"] == "${{ steps.detect.outputs.fmt }}"
+    assert python_env["BASELINE_PYTHON_FILE"] == "${{ inputs.baseline-python-file }}"
     out = tmp_path / "cov.xml"
     gh = tmp_path / "gh.txt"
     out.write_text("<coverage lines-covered='1' lines-valid='1'/>", encoding="utf-8")
@@ -2489,6 +2521,7 @@ def _python_integration_env(
         "INPUT_OUTPUT_PATH": str(out),
         "DETECTED_LANG": "python",
         "DETECTED_FMT": "cobertura",
+        "BASELINE_PYTHON_FILE": str(tmp_path / "baseline-python.txt"),
         "GITHUB_OUTPUT": str(gh),
     }
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
@@ -2508,6 +2541,7 @@ def _run_integration_script(
     return run_script(script, env)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")
 def test_run_python_integration_cobertura_success(
     tmp_path: Path,
     shell_stubs: StubManager,
@@ -2536,6 +2570,7 @@ def test_run_python_integration_cobertura_success(
     assert "coverage" in pip_args
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")
 @pytest.mark.parametrize(
     ("write_kwargs", "expected_in_stderr"),
     [

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1983,33 +1983,28 @@ def _assert_venv_default_python_rebuild(
     _assert_venv_rebuild_commands(setup.recorded, setup.coverage_venv, expected)
 
 
-def test_ensure_coverage_venv_replaces_broken_symlink_cache(
+@pytest.mark.parametrize(
+    "broken_state_kind",
+    ["file", "symlink"],
+    ids=["file-placeholder", "symlink-placeholder"],
+)
+def test_ensure_coverage_venv_replaces_broken_placeholder(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
+    broken_state_kind: str,
 ) -> None:
-    """The helper unlinks a symlink cache placeholder before recreate."""
+    """The helper removes file and symlink placeholders before recreating the venv."""
     setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
-    target = tmp_path / "not-a-venv"
-    setup.coverage_venv.symlink_to(target)
+    if broken_state_kind == "symlink":
+        setup.coverage_venv.symlink_to(tmp_path / "not-a-venv")
+    else:
+        setup.coverage_venv.write_text("not a venv")
 
     python = run_python_module._ensure_coverage_venv()
 
-    assert not setup.coverage_venv.is_symlink()
-    _assert_venv_default_python_rebuild(python, setup)
-
-
-def test_ensure_coverage_venv_replaces_broken_file_cache(
-    tmp_path: Path,
-    run_python_module: ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The helper replaces a non-directory cache placeholder before recreate."""
-    setup = _setup_coverage_venv_test(tmp_path, run_python_module, monkeypatch)
-    setup.coverage_venv.write_text("not a venv")
-
-    python = run_python_module._ensure_coverage_venv()
-
+    if broken_state_kind == "symlink":
+        assert not setup.coverage_venv.is_symlink()
     _assert_venv_default_python_rebuild(python, setup)
 
 
@@ -2513,32 +2508,28 @@ def test_run_python_integration_cobertura_success(
     assert "coverage" in pip_args
 
 
-def test_run_python_integration_uv_venv_failure(
+@pytest.mark.parametrize(
+    ("write_kwargs", "expected_in_stderr"),
+    [
+        ({"venv_exit": 1}, None),
+        ({"sync_exit": 2}, "uv sync failed"),
+    ],
+    ids=["uv-venv-fails", "uv-sync-fails"],
+)
+def test_run_python_integration_uv_failure_modes(
     tmp_path: Path,
     shell_stubs: StubManager,
     monkeypatch: pytest.MonkeyPatch,
+    write_kwargs: dict[str, int],
+    expected_in_stderr: str | None,
 ) -> None:
-    """run_python.py exits non-zero when uv venv fails."""
-    bin_dir, _log = _write_fake_uv(tmp_path, venv_exit=1)
-
-    returncode, _stdout, _stderr = _run_integration_script(
-        tmp_path, shell_stubs, bin_dir, monkeypatch
-    )
-
-    assert returncode != 0
-
-
-def test_run_python_integration_uv_sync_failure(
-    tmp_path: Path,
-    shell_stubs: StubManager,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """run_python.py exits non-zero and logs a message when uv sync fails."""
-    bin_dir, _log = _write_fake_uv(tmp_path, sync_exit=2)
+    """run_python.py exits non-zero when uv venv or uv sync fails."""
+    bin_dir, _log = _write_fake_uv(tmp_path, **write_kwargs)
 
     returncode, _stdout, stderr = _run_integration_script(
         tmp_path, shell_stubs, bin_dir, monkeypatch
     )
 
     assert returncode != 0
-    assert "uv sync failed" in stderr
+    if expected_in_stderr is not None:
+        assert expected_in_stderr in stderr

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -2160,7 +2160,7 @@ def test_run_python_coveragepy_empty_xml(
     captured_python: list[str] = []
 
     @contextlib.contextmanager
-    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+    def fake_tmp_coveragepy_xml(_out: Path) -> typ.Iterator[Path]:
         captured_python.append(
             next(iter(run_python_module._coverage_python_cmd().formulate()))
         )
@@ -2214,7 +2214,7 @@ def test_run_python_coveragepy_malformed_xml_exits(
     captured_python: list[str] = []
 
     @contextlib.contextmanager
-    def fake_tmp_coveragepy_xml(out: Path) -> typ.Iterator[Path]:
+    def fake_tmp_coveragepy_xml(_out: Path) -> typ.Iterator[Path]:
         captured_python.append(
             next(iter(run_python_module._coverage_python_cmd().formulate()))
         )

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1845,6 +1845,52 @@ def test_create_venv_reuses_existing_coverage_venv(
     assert recorded == []
 
 
+def test_create_venv_recovers_from_broken_cache(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_venv() recreates a venv whose Python executable is absent."""
+    coverage_venv = tmp_path / ".venv-coverage"
+    # Simulate a broken cache: directory exists but no Python binary inside it
+    coverage_venv.mkdir(parents=True)
+    recorded: list[list[str]] = []
+
+    def fake_run_cmd(cmd: object, *_args: object, **_kwargs: object) -> None:
+        parts = list(cmd.formulate())  # type: ignore[attr-defined]
+        recorded.append(parts)
+        if parts[1] == "venv":
+            # After the recreate call, place the binary so the second
+            # _coverage_python_path() call succeeds.
+            python = coverage_venv / "bin" / "python"
+            python.parent.mkdir(parents=True, exist_ok=True)
+            python.touch()
+
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+    monkeypatch.setattr(run_python_module, "run_cmd", fake_run_cmd)
+
+    python = run_python_module.create_venv()
+
+    # One uv venv call (the recreate) must have been recorded.
+    venv_calls = [r for r in recorded if r[1] == "venv"]
+    assert len(venv_calls) == 1
+    assert python == str(coverage_venv / "bin" / "python")
+
+
+def test_coverage_python_path_raises_when_no_executable(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_coverage_python_path() raises RuntimeError when no binary exists."""
+    coverage_venv = tmp_path / ".venv-coverage"
+    coverage_venv.mkdir(parents=True)
+    monkeypatch.setattr(run_python_module, "COVERAGE_VENV", coverage_venv)
+
+    with pytest.raises(RuntimeError, match="Coverage venv Python executable not found"):
+        run_python_module._coverage_python_path()
+
+
 def test_create_venv_recreates_broken_coverage_venv(
     tmp_path: Path,
     run_python_module: ModuleType,

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1925,6 +1925,36 @@ def test_find_coverage_python_returns_none_when_no_executable(
     assert run_python_module._find_coverage_python() is None
 
 
+def _assert_venv_recreated_with_python(
+    setup: VenvTestSetup,
+    python_path: Path,
+) -> None:
+    """Assert the three run_cmd calls expected after a venv recreation.
+
+    Parameters
+    ----------
+    setup:
+        Shared scaffolding containing the recorded command parts.
+    python_path:
+        Absolute path to the Python executable that the recreation must
+        target for the sync and pip-install commands.
+    """
+    assert len(setup.recorded) == 3
+    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
+    assert setup.recorded[1][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(python_path),
+    ]
+    assert setup.recorded[2][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(python_path),
+    ]
+
+
 def test_ensure_coverage_venv_replaces_broken_file_cache(
     tmp_path: Path,
     run_python_module: ModuleType,
@@ -1937,15 +1967,7 @@ def test_ensure_coverage_venv_replaces_broken_file_cache(
     python = run_python_module._ensure_coverage_venv()
 
     assert python == str(setup.coverage_venv / "bin" / "python")
-    assert len(setup.recorded) == 3
-    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
-    assert setup.recorded[1][1:] == ["sync", "--inexact", "--python", python]
-    assert setup.recorded[2][1:5] == [
-        "pip",
-        "install",
-        "--python",
-        python,
-    ]
+    _assert_venv_recreated_with_python(setup, setup.coverage_venv / "bin" / "python")
 
 
 def test_ensure_coverage_venv_recreates_invalid_python_candidate(
@@ -1965,20 +1987,9 @@ def test_ensure_coverage_venv_recreates_invalid_python_candidate(
     assert run_python_module._ensure_coverage_venv() == str(
         setup.coverage_venv / "Scripts" / "python.exe"
     )
-    assert len(setup.recorded) == 3
-    assert setup.recorded[0][1:] == ["venv", str(setup.coverage_venv)]
-    assert setup.recorded[1][1:] == [
-        "sync",
-        "--inexact",
-        "--python",
-        str(setup.coverage_venv / "Scripts" / "python.exe"),
-    ]
-    assert setup.recorded[2][1:5] == [
-        "pip",
-        "install",
-        "--python",
-        str(setup.coverage_venv / "Scripts" / "python.exe"),
-    ]
+    _assert_venv_recreated_with_python(
+        setup, setup.coverage_venv / "Scripts" / "python.exe"
+    )
 
 
 def test_ensure_coverage_venv_targets_venv_python_for_tooling(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,18 +112,18 @@ The `Makefile` resolves optional local tool installations before falling back
 to bare names on `PATH`. The following variables are set at the top of
 `Makefile` and may be overridden on the command line:
 
-| Variable            | Default resolution order                     |
-| ------------------- | -------------------------------------------- |
-| `UV`                | `~/.local/bin/uv`, otherwise `uv`            |
-| `ACTION_VALIDATOR`  | Bun install, then Cargo install, then `PATH` |
-| `MDLINT`            | `~/.bun/bin/markdownlint`, then `PATH`       |
-| `MARKDOWNLINT_BASE` | `origin/main` for the markdownlint diff base |
+| Variable            | Default resolution order                                                                                   |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `UV`                | `~/.local/bin/uv`, otherwise `uv`                                                                          |
+| `ACTION_VALIDATOR`  | `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then `action-validator` (on `PATH`)   |
+| `MDLINT`            | `~/.bun/bin/markdownlint`, then `PATH`                                                                     |
+| `MARKDOWNLINT_BASE` | `origin/main` for the markdownlint diff base                                                               |
 
 For `ACTION_VALIDATOR`, the concrete lookup order is
 `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then
 `action-validator`.
 
-Example - use a system `uv` and a custom markdownlint base:
+Example — use a system `uv` and a custom markdownlint base:
 
 ```bash
 make lint UV=uv MARKDOWNLINT_BASE=origin/develop
@@ -145,7 +145,7 @@ make lint UV=uv MARKDOWNLINT_BASE=origin/develop
 
 ## 6  Documentation Standards
 
-- Each action [**README.md**](http://README.md) must contain:
+- Each action `README.md` must contain:
 
   - **One‑liner summary**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,12 +112,16 @@ The `Makefile` resolves optional local tool installations before falling back
 to bare names on `PATH`. The following variables are set at the top of
 `Makefile` and may be overridden on the command line:
 
-| Variable             | Default resolution order                                                                 |
-|----------------------|------------------------------------------------------------------------------------------|
-| `UV`                 | `~/.local/bin/uv` if present, otherwise `uv`                                            |
-| `ACTION_VALIDATOR`   | `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then `action-validator` |
-| `MDLINT`             | `~/.bun/bin/markdownlint` if present, otherwise `markdownlint`                          |
-| `MARKDOWNLINT_BASE`  | `origin/main` (used as the base ref for `git diff` in the `markdownlint` target)        |
+| Variable            | Default resolution order                     |
+| ------------------- | -------------------------------------------- |
+| `UV`                | `~/.local/bin/uv`, otherwise `uv`            |
+| `ACTION_VALIDATOR`  | Bun install, then Cargo install, then `PATH` |
+| `MDLINT`            | `~/.bun/bin/markdownlint`, then `PATH`       |
+| `MARKDOWNLINT_BASE` | `origin/main` for the markdownlint diff base |
+
+For `ACTION_VALIDATOR`, the concrete lookup order is
+`~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then
+`action-validator`.
 
 Example - use a system `uv` and a custom markdownlint base:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,25 @@ auto‑increments patch unless `release‑type` input overrides (`minor`, `major
 CI workflow lives at `.github/workflows/ci.yml` and runs on PR and nightly via
 schedule.
 
+### Makefile tool resolution
+
+The `Makefile` resolves optional local tool installations before falling back
+to bare names on `PATH`. The following variables are set at the top of
+`Makefile` and may be overridden on the command line:
+
+| Variable             | Default resolution order                                                                 |
+|----------------------|------------------------------------------------------------------------------------------|
+| `UV`                 | `~/.local/bin/uv` if present, otherwise `uv`                                            |
+| `ACTION_VALIDATOR`   | `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then `action-validator` |
+| `MDLINT`             | `~/.bun/bin/markdownlint` if present, otherwise `markdownlint`                          |
+| `MARKDOWNLINT_BASE`  | `origin/main` (used as the base ref for `git diff` in the `markdownlint` target)        |
+
+Example - use a system `uv` and a custom markdownlint base:
+
+```bash
+make lint UV=uv MARKDOWNLINT_BASE=origin/develop
+```
+
 ## 5  Security Hardening
 
 1. **Pin third‑party actions** to a full commit SHA (not just `@v1`).

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ endif
 
 lint: ## Check test scripts and actions
 	$(UV) tool run ruff check
-	find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) -print0 \
-	| xargs -r -0 -n1 $(ACTION_VALIDATOR)
+	find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) \
+		-exec $(ACTION_VALIDATOR) {} +
 
 typecheck: .venv ## Run static type checking with Ty
 	./.venv/bin/ty check \
@@ -71,12 +71,13 @@ check-fmt: ## Check Python formatting without modifying files
 markdownlint: ## Lint Markdown files
 	@if files=$$(git diff --name-only --diff-filter=ACMRT $(MARKDOWNLINT_BASE)...HEAD -- '*.md' 2>/dev/null); then \
 		if [ -n "$$files" ]; then \
-			printf '%s\n' "$$files" | xargs -r -- $(MDLINT); \
+			printf '%s\n' "$$files" | while IFS= read -r file; do $(MDLINT) "$$file"; done; \
 		else \
-			find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT); \
+			find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
 		fi; \
 	else \
-		find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT); \
+		printf 'Warning: git diff using MARKDOWNLINT_BASE=%s failed; running full markdown lint\n' '$(MARKDOWNLINT_BASE)' >&2; \
+		find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
 	fi
 
 nixie: ## Validate Mermaid diagrams

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,12 @@ check-fmt: ## Check Python formatting without modifying files
 	$(UV) tool run ruff check --select $(RUFF_FIX_RULES)
 
 markdownlint: ## Lint Markdown files
-	@files=$$(git diff --name-only --diff-filter=ACMRT $(MARKDOWNLINT_BASE)...HEAD -- '*.md' 2>/dev/null); \
-	if [ -n "$$files" ]; then \
-		printf '%s\n' "$$files" | xargs -r -- $(MDLINT); \
+	@if files=$$(git diff --name-only --diff-filter=ACMRT $(MARKDOWNLINT_BASE)...HEAD -- '*.md' 2>/dev/null); then \
+		if [ -n "$$files" ]; then \
+			printf '%s\n' "$$files" | xargs -r -- $(MDLINT); \
+		else \
+			find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT); \
+		fi; \
 	else \
 		find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ clean: ## Remove transient artefacts
 
 BUILD_JOBS ?=
 ACTION_VALIDATOR ?= $(if $(wildcard $(HOME)/.cargo/bin/action-validator),$(HOME)/.cargo/bin/action-validator,action-validator)
-MDLINT ?= markdownlint
+MDLINT ?= $(if $(wildcard $(HOME)/.bun/bin/markdownlint),$(HOME)/.bun/bin/markdownlint,markdownlint)
+MARKDOWNLINT_BASE ?= origin/main
 NIXIE ?= nixie
 RUFF_FIX_RULES ?= D202,I001
 UV ?= $(if $(wildcard $(HOME)/.local/bin/uv),$(HOME)/.local/bin/uv,uv)
@@ -68,7 +69,12 @@ check-fmt: ## Check Python formatting without modifying files
 	$(UV) tool run ruff check --select $(RUFF_FIX_RULES)
 
 markdownlint: ## Lint Markdown files
-	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)
+	@files=$$(git diff --name-only --diff-filter=ACMRT $(MARKDOWNLINT_BASE)...HEAD -- '*.md' 2>/dev/null); \
+	if [ -n "$$files" ]; then \
+		printf '%s\n' "$$files" | xargs -r -- $(MDLINT); \
+	else \
+		find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT); \
+	fi
 
 nixie: ## Validate Mermaid diagrams
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(NIXIE)

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ check-fmt: ## Check Python formatting without modifying files
 markdownlint: ## Lint Markdown files
 	@if files=$$(git diff --name-only --diff-filter=ACMRT $(MARKDOWNLINT_BASE)...HEAD -- '*.md' 2>/dev/null); then \
 		if [ -n "$$files" ]; then \
-			printf '%s\n' "$$files" | while IFS= read -r file; do $(MDLINT) "$$file"; done; \
+			printf '%s\n' "$$files" | { status=0; while IFS= read -r file; do $(MDLINT) "$$file" || status=1; done; exit $$status; }; \
 		else \
 			find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ endif
 lint: ## Check test scripts and actions
 	$(UV) tool run ruff check
 	find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) \
-		-exec $(ACTION_VALIDATOR) {} +
+		-exec $(ACTION_VALIDATOR) {} \;
 
 typecheck: .venv ## Run static type checking with Ty
 	./.venv/bin/ty check \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean: ## Remove transient artefacts
 	rm -rf .venv .pytest_cache .ruff_cache workspace/.ruff_cache
 
 BUILD_JOBS ?=
-ACTION_VALIDATOR ?= $(if $(wildcard $(HOME)/.cargo/bin/action-validator),$(HOME)/.cargo/bin/action-validator,action-validator)
+ACTION_VALIDATOR ?= $(or $(firstword $(wildcard $(HOME)/.bun/bin/action-validator) $(wildcard $(HOME)/.cargo/bin/action-validator)),action-validator)
 MDLINT ?= $(if $(wildcard $(HOME)/.bun/bin/markdownlint),$(HOME)/.bun/bin/markdownlint,markdownlint)
 MARKDOWNLINT_BASE ?= origin/main
 NIXIE ?= nixie

--- a/Makefile
+++ b/Makefile
@@ -69,16 +69,7 @@ check-fmt: ## Check Python formatting without modifying files
 	$(UV) tool run ruff check --select $(RUFF_FIX_RULES)
 
 markdownlint: ## Lint Markdown files
-	@if files=$$(git diff --name-only --diff-filter=ACMRT $(MARKDOWNLINT_BASE)...HEAD -- '*.md' 2>/dev/null); then \
-		if [ -n "$$files" ]; then \
-			printf '%s\n' "$$files" | { status=0; while IFS= read -r file; do $(MDLINT) "$$file" || status=1; done; exit $$status; }; \
-		else \
-			find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
-		fi; \
-	else \
-		echo "markdownlint: git diff failed or base '$(MARKDOWNLINT_BASE)' not found; linting all .md files" >&2; \
-		find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
-	fi
+	MARKDOWNLINT_BASE='$(MARKDOWNLINT_BASE)' MDLINT='$(MDLINT)' ./workflow_scripts/markdownlint-check.sh
 
 nixie: ## Validate Mermaid diagrams
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(NIXIE)

--- a/Makefile
+++ b/Makefile
@@ -14,25 +14,27 @@ clean: ## Remove transient artefacts
 	rm -rf .venv .pytest_cache .ruff_cache workspace/.ruff_cache
 
 BUILD_JOBS ?=
+ACTION_VALIDATOR ?= $(if $(wildcard $(HOME)/.cargo/bin/action-validator),$(HOME)/.cargo/bin/action-validator,action-validator)
 MDLINT ?= markdownlint
 NIXIE ?= nixie
 RUFF_FIX_RULES ?= D202,I001
+UV ?= $(if $(wildcard $(HOME)/.local/bin/uv),$(HOME)/.local/bin/uv,uv)
 
 test: .venv ## Run tests
-	uv run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist pytest -n auto --dist worksteal -v
+	$(UV) run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist pytest -n auto --dist worksteal -v
 # Truthy values: 1, true, TRUE, True, yes, YES, Yes, on, ON, On
 ifneq ($(strip $(filter 1 true TRUE True yes YES Yes on ON On,$(ACT_WORKFLOW_TESTS))),)
-	ACT_WORKFLOW_TESTS=1 uv run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist pytest tests/workflows -v
+	ACT_WORKFLOW_TESTS=1 $(UV) run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist pytest tests/workflows -v
 endif
 
 .venv:
-	uv venv
-	uv sync --group dev
+	$(UV) venv
+	$(UV) sync --group dev
 
 lint: ## Check test scripts and actions
-	uv tool run ruff check
+	$(UV) tool run ruff check
 	find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) -print0 \
-	| xargs -r -0 -n1 action-validator
+	| xargs -r -0 -n1 $(ACTION_VALIDATOR)
 
 typecheck: .venv ## Run static type checking with Ty
 	./.venv/bin/ty check \
@@ -58,12 +60,12 @@ typecheck: .venv ## Run static type checking with Ty
 		--extra-search-path .github/actions/macos-package/scripts \
 		.github/actions/macos-package/scripts
 fmt: ## Format Python files and auto-fix selected lint rules
-	uv tool run ruff format
-	uv tool run ruff check --select $(RUFF_FIX_RULES) --fix
+	$(UV) tool run ruff format
+	$(UV) tool run ruff check --select $(RUFF_FIX_RULES) --fix
 
 check-fmt: ## Check Python formatting without modifying files
-	uv tool run ruff format --check
-	uv tool run ruff check --select $(RUFF_FIX_RULES)
+	$(UV) tool run ruff format --check
+	$(UV) tool run ruff check --select $(RUFF_FIX_RULES)
 
 markdownlint: ## Lint Markdown files
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 	uv sync --group dev
 
 lint: ## Check test scripts and actions
-	uvx ruff check
+	uv tool run ruff check
 	find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) -print0 \
 	| xargs -r -0 -n1 action-validator
 
@@ -58,12 +58,12 @@ typecheck: .venv ## Run static type checking with Ty
 		--extra-search-path .github/actions/macos-package/scripts \
 		.github/actions/macos-package/scripts
 fmt: ## Format Python files and auto-fix selected lint rules
-	uvx ruff format
-	uvx ruff check --select $(RUFF_FIX_RULES) --fix
+	uv tool run ruff format
+	uv tool run ruff check --select $(RUFF_FIX_RULES) --fix
 
 check-fmt: ## Check Python formatting without modifying files
-	uvx ruff format --check
-	uvx ruff check --select $(RUFF_FIX_RULES)
+	uv tool run ruff format --check
+	uv tool run ruff check --select $(RUFF_FIX_RULES)
 
 markdownlint: ## Lint Markdown files
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ markdownlint: ## Lint Markdown files
 			find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
 		fi; \
 	else \
-		printf 'Warning: git diff using MARKDOWNLINT_BASE=%s failed; running full markdown lint\n' '$(MARKDOWNLINT_BASE)' >&2; \
+		echo "markdownlint: git diff failed or base '$(MARKDOWNLINT_BASE)' not found; linting all .md files" >&2; \
 		find . -type f -name '*.md' -not -path './target/*' -exec $(MDLINT) {} +; \
 	fi
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -19,20 +19,33 @@ interpreter reference within the same process.
 `.venv-coverage` in the working directory.
 
 | Step | Function | Description |
-|---|---|---|
-| 1 | `_find_coverage_python()` | Locate the Python executable within `.venv-coverage`; returns `None` if absent or if the venv directory is a symlink or non-directory. |
-| 2 | `_remove_coverage_venv()` | Remove the venv directory (via `shutil.rmtree`) or any non-directory placeholder (via `Path.unlink`). |
-| 3 | `_recreate_coverage_venv()` | Remove any broken venv state, create a fresh venv via `uv venv`, and return the new Python path. Raises `RuntimeError` if the executable is still absent after creation. |
-| 4 | `_ensure_coverage_venv()` | Orchestrates steps 1-3, then runs `uv sync --inexact --python` and `uv pip install --python slipcover pytest coverage`. Returns the Python path as a string. |
-| 5 | `_coverage_python_cmd()` | Calls `_ensure_coverage_venv()` on first use via `@lru_cache(maxsize=1)`; returns a cached `plumbum.BoundCommand` thereafter. |
+| --- | --- | --- |
+| 1 | `_find_coverage_python()` | Locate the Python executable. |
+| 2 | `_remove_coverage_venv()` | Remove the venv or placeholder path. |
+| 3 | `_recreate_coverage_venv()` | Recreate the venv. |
+| 4 | `_ensure_coverage_venv()` | Sync project deps and install tooling. |
+| 5 | `_coverage_python_cmd()` | Return the cached `plumbum.BoundCommand`. |
+
+`_find_coverage_python()` returns `None` when `.venv-coverage` is absent, is a
+symlink, is a non-directory, or lacks a Python executable. `_remove_coverage_venv()`
+uses `shutil.rmtree` for directories and `Path.unlink` for files or symlinks.
+`_recreate_coverage_venv()` raises `RuntimeError` if the executable is still
+absent after creation. `_ensure_coverage_venv()` runs
+`uv sync --inexact --python` and
+`uv pip install --python slipcover pytest coverage`. `_coverage_python_cmd()`
+uses `@lru_cache(maxsize=1)` and returns the cached command thereafter.
 
 ### Public API
 
 | Symbol | Signature | Role |
-|---|---|---|
-| `coverage_cmd_for_fmt` | `(fmt: str, out: Path) -> BoundCommand` | Build the slipcover command for a given format. |
-| `tmp_coveragepy_xml` | `(out: Path) -> Generator[Path]` | Context manager: generate Cobertura XML via coverage.py, yield the path, clean up on exit. |
-| `main` | `(output_path, lang, fmt, github_output, baseline_file)` | Entry point: run slipcover, parse coverage, write `GITHUB_OUTPUT`. |
+| --- | --- | --- |
+| `coverage_cmd_for_fmt` | `(fmt, out)` | Build a slipcover command. |
+| `tmp_coveragepy_xml` | `(out)` | Generate temporary Cobertura XML. |
+| `main` | `(output_path, lang, fmt, github_output, baseline)` | Entry point. |
+
+`coverage_cmd_for_fmt` returns a `BoundCommand` for the requested format.
+`tmp_coveragepy_xml` yields a temporary XML path and removes it on exit.
+`main` runs slipcover, parses coverage, and writes `GITHUB_OUTPUT`.
 
 ### Concurrency Model
 
@@ -61,11 +74,15 @@ The `Makefile` resolves optional local tool installations before falling back
 to bare names on `PATH`.
 
 | Variable | Default resolution order |
-|---|---|
+| --- | --- |
 | `UV` | `~/.local/bin/uv` if present, otherwise `uv` |
-| `ACTION_VALIDATOR` | `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then `action-validator` |
+| `ACTION_VALIDATOR` | Bun install, then Cargo install, then `PATH` |
 | `MDLINT` | `~/.bun/bin/markdownlint` if present, otherwise `markdownlint` |
-| `MARKDOWNLINT_BASE` | `origin/main` (base ref for `git diff` in the `markdownlint` target) |
+| `MARKDOWNLINT_BASE` | `origin/main` |
+
+`ACTION_VALIDATOR` resolves to `~/.bun/bin/action-validator`, then
+`~/.cargo/bin/action-validator`, then `action-validator`. `MARKDOWNLINT_BASE`
+is the base ref for `git diff` in the `markdownlint` target.
 
 Override example:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,83 @@
+# Developer's Guide
+
+This document describes the internal architecture of the `generate-coverage`
+action, its public API, concurrency model, and Makefile tool-resolution
+strategy.
+
+## Python Coverage Venv Architecture
+
+### Motivation
+
+Earlier revisions of `run_python.py` invoked slipcover and coverage.py via
+`uv run --with slipcover --with pytest --with coverage python ...`, which
+re-resolved and reinstalled tooling on every invocation and could not cache the
+interpreter reference within the same process.
+
+### Lifecycle
+
+`run_python.py` manages a dedicated throwaway virtual environment at
+`.venv-coverage` in the working directory.
+
+| Step | Function | Description |
+|---|---|---|
+| 1 | `_find_coverage_python()` | Locate the Python executable within `.venv-coverage`; returns `None` if absent or if the venv directory is a symlink or non-directory. |
+| 2 | `_remove_coverage_venv()` | Remove the venv directory (via `shutil.rmtree`) or any non-directory placeholder (via `Path.unlink`). |
+| 3 | `_recreate_coverage_venv()` | Remove any broken venv state, create a fresh venv via `uv venv`, and return the new Python path. Raises `RuntimeError` if the executable is still absent after creation. |
+| 4 | `_ensure_coverage_venv()` | Orchestrates steps 1-3, then runs `uv sync --inexact --python` and `uv pip install --python slipcover pytest coverage`. Returns the Python path as a string. |
+| 5 | `_coverage_python_cmd()` | Calls `_ensure_coverage_venv()` on first use via `@lru_cache(maxsize=1)`; returns a cached `plumbum.BoundCommand` thereafter. |
+
+### Public API
+
+| Symbol | Signature | Role |
+|---|---|---|
+| `coverage_cmd_for_fmt` | `(fmt: str, out: Path) -> BoundCommand` | Build the slipcover command for a given format. |
+| `tmp_coveragepy_xml` | `(out: Path) -> Generator[Path]` | Context manager: generate Cobertura XML via coverage.py, yield the path, clean up on exit. |
+| `main` | `(output_path, lang, fmt, github_output, baseline_file)` | Entry point: run slipcover, parse coverage, write `GITHUB_OUTPUT`. |
+
+### Concurrency Model
+
+`run_python.py` runs as a single-threaded GitHub Actions step. The
+`@lru_cache(maxsize=1)` on `_coverage_python_cmd()` therefore requires no
+explicit synchronisation; the cache is safe for the lifetime of the process.
+
+### Broken-Venv Recovery
+
+If `.venv-coverage` is present but its Python executable is absent (or a
+non-directory placeholder occupies its path), `_recreate_coverage_venv()`
+removes the directory and recreates it from scratch. The case is detected by
+`_find_coverage_python()` returning `None` when the directory already exists.
+
+### POSIX and Windows Layouts
+
+`_find_coverage_python()` checks three candidate paths in order:
+
+- `COVERAGE_VENV/bin/python` (POSIX)
+- `COVERAGE_VENV/Scripts/python.exe` (Windows)
+- `COVERAGE_VENV/Scripts/python` (Windows without extension)
+
+## Makefile Tool Resolution
+
+The `Makefile` resolves optional local tool installations before falling back
+to bare names on `PATH`.
+
+| Variable | Default resolution order |
+|---|---|
+| `UV` | `~/.local/bin/uv` if present, otherwise `uv` |
+| `ACTION_VALIDATOR` | `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then `action-validator` |
+| `MDLINT` | `~/.bun/bin/markdownlint` if present, otherwise `markdownlint` |
+| `MARKDOWNLINT_BASE` | `origin/main` (base ref for `git diff` in the `markdownlint` target) |
+
+Override example:
+
+```bash
+make lint UV=uv MARKDOWNLINT_BASE=origin/develop
+```
+
+## Running the Test Suite
+
+```bash
+make test          # full suite
+make check-fmt     # Ruff formatting check
+make typecheck     # mypy
+make lint          # Ruff lint + action-validator + markdownlint
+```

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -31,9 +31,10 @@ symlink, is a non-directory, or lacks a Python executable. `_remove_coverage_ven
 uses `shutil.rmtree` for directories and `Path.unlink` for files or symlinks.
 `_recreate_coverage_venv()` raises `RuntimeError` if the executable is still
 absent after creation. `_ensure_coverage_venv()` runs
-`uv sync --inexact --python` and
-`uv pip install --python slipcover pytest coverage`. `_coverage_python_cmd()`
-uses `@lru_cache(maxsize=1)` and returns the cached command thereafter.
+`uv sync --inexact --python <venv_python>` and
+`uv pip install --python <venv_python> slipcover pytest coverage`.
+`_coverage_python_cmd()` uses `@lru_cache(maxsize=1)` and returns the cached
+command for `<venv_python>` thereafter.
 
 ### Public API
 
@@ -41,7 +42,7 @@ uses `@lru_cache(maxsize=1)` and returns the cached command thereafter.
 | --- | --- | --- |
 | `coverage_cmd_for_fmt` | `(fmt, out)` | Build a slipcover command. |
 | `tmp_coveragepy_xml` | `(out)` | Generate temporary Cobertura XML. |
-| `main` | `(output_path, lang, fmt, github_output, baseline)` | Entry point. |
+| `main` | `(output_path, lang, fmt, github_output, baseline_file)` | Run. |
 
 `coverage_cmd_for_fmt` returns a `BoundCommand` for the requested format.
 `tmp_coveragepy_xml` yields a temporary XML path and removes it on exit.
@@ -51,7 +52,7 @@ uses `@lru_cache(maxsize=1)` and returns the cached command thereafter.
 
 `run_python.py` runs as a single-threaded GitHub Actions step. The
 `@lru_cache(maxsize=1)` on `_coverage_python_cmd()` therefore requires no
-explicit synchronisation; the cache is safe for the lifetime of the process.
+explicit synchronization; the cache is safe for the lifetime of the process.
 
 ### Broken-Venv Recovery
 

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -16,6 +16,14 @@ action and the evolution of its supporting scripts.
   configures the Cranelift backend. This keeps the action compatible with
   `cargo-llvm-cov`, which spawns nested Cargo commands that inherit environment
   variables but do not inherit the wrapper process's ad hoc `--config` flags.
+- *2026-04-27* — Python coverage runs now execute inside an isolated,
+  short-lived virtual environment (`.venv-coverage`) rather than relying on
+  `uv run --with` or the system interpreter. The venv is created on first use
+  by `create_venv()`, which also handles broken-cache recovery by detecting a
+  missing Python executable and recreating the directory. Tooling (`slipcover`,
+  `pytest`, `coverage`) is installed via `uv pip install --python` into that
+  venv and the resulting interpreter path is cached for the lifetime of the
+  process.
 
 ## Rust Coverage Environment Overrides
 
@@ -169,3 +177,38 @@ stops short of that complexity.
   suffixes.
 - [x] Document the Rust coverage environment-override design for
   Cranelift-configured repositories.
+
+## Python Coverage Venv Architecture
+
+### Motivation
+
+Running `uv run --with slipcover ...` on each invocation re-resolves
+dependencies and creates a temporary environment on every call. A named venv
+(`.venv-coverage`) is created once per job, reused on subsequent calls within
+the same job, and discarded when the runner workspace is cleaned up.
+
+### Lifecycle
+
+1. `create_venv()` checks whether `.venv-coverage` exists.
+   - If absent, it creates the venv via `uv venv .venv-coverage`.
+   - If present but broken (Python binary missing), it removes the directory
+     and recreates it.
+2. `install_coverage_tools(python)` installs `slipcover`, `pytest`, and
+   `coverage` into the venv using `uv pip install --python <venv-python>`. The
+   `--system` flag is deliberately excluded to keep the install isolated.
+3. `_coverage_python_cmd()` calls steps 1-2 on first use, caches the resulting
+   `plumbum` command, and returns the cached value on all subsequent calls
+   within the same process.
+
+### Concurrency Model
+
+GitHub Actions executes action steps sequentially in a single thread. The
+module-level `_COVERAGE_PYTHON_CMD` singleton therefore requires no explicit
+synchronisation.
+
+### Public API
+
+| Symbol | Role |
+|---|---|
+| `create_venv() -> str` | Create or recover the venv; return Python path. |
+| `install_coverage_tools(python: str) -> None` | Install tooling into the venv. |

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -195,8 +195,9 @@ the same job, and discarded when the runner workspace is cleaned up.
 1. `_ensure_coverage_venv()` checks whether `.venv-coverage` contains a Python
    executable.
    - If absent, it creates the venv via `uv venv .venv-coverage`.
-   - If present but broken (Python binary missing), it removes the directory
-     and recreates it.
+   - If present but broken (Python binary missing), it removes the existing
+     path - unlinking files and symlinks and removing directories - and then
+     recreates it.
 2. `_ensure_coverage_venv()` syncs the current project into the venv with
    `uv sync --inexact --python <venv-python>` so tests can import project
    dependencies.

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -208,7 +208,9 @@ synchronisation.
 
 ### Public API
 
+<!-- markdownlint-disable MD013 MD060 -->
 | Symbol | Role |
 |---|---|
 | `create_venv() -> str` | Create or recover the venv; return Python path. |
 | `install_coverage_tools(python: str) -> None` | Install tooling into the venv. |
+<!-- markdownlint-enable MD013 MD060 -->

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -204,7 +204,7 @@ the same job, and discarded when the runner workspace is cleaned up.
 3. `_ensure_coverage_venv()` performs installation of `slipcover`, `pytest`,
    and `coverage` into the venv using
    `uv pip install --python <venv-python>`. The `--system` flag is deliberately
-   excluded to keep the install isolated.
+   excluded to keep the installation isolated.
 4. `_coverage_python_cmd()` calls `_ensure_coverage_venv()` on first use, caches
    the resulting `plumbum` command via `functools.lru_cache`, and returns the
    cached value on all subsequent calls within the same process.

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -19,7 +19,8 @@ action and the evolution of its supporting scripts.
 - *2026-04-27* — Python coverage runs now execute inside an isolated,
   short-lived virtual environment (`.venv-coverage`) rather than relying on
   `uv run --with` or the system interpreter. `_ensure_coverage_venv()` creates
-  or repairs the venv on first use, installs tooling (`slipcover`, `pytest`,
+  or repairs the venv on first use, syncs the project dependencies into it via
+  `uv sync --inexact --python`, installs tooling (`slipcover`, `pytest`,
   `coverage`) via `uv pip install --python`, and `_coverage_python_cmd()` caches
   the resulting interpreter command for the lifetime of the process.
 
@@ -192,10 +193,13 @@ the same job, and discarded when the runner workspace is cleaned up.
    - If absent, it creates the venv via `uv venv .venv-coverage`.
    - If present but broken (Python binary missing), it removes the directory
      and recreates it.
-2. `_ensure_coverage_venv()` installs `slipcover`, `pytest`, and `coverage`
+2. `_ensure_coverage_venv()` syncs the current project into the venv with
+   `uv sync --inexact --python <venv-python>` so tests can import project
+   dependencies.
+3. `_ensure_coverage_venv()` installs `slipcover`, `pytest`, and `coverage`
    into the venv using `uv pip install --python <venv-python>`. The `--system`
    flag is deliberately excluded to keep the install isolated.
-3. `_coverage_python_cmd()` calls `_ensure_coverage_venv()` on first use, caches
+4. `_coverage_python_cmd()` calls `_ensure_coverage_venv()` on first use, caches
    the resulting `plumbum` command via `functools.lru_cache`, and returns the
    cached value on all subsequent calls within the same process.
 
@@ -210,6 +214,6 @@ requires no explicit synchronisation.
 <!-- markdownlint-disable MD013 MD060 -->
 | Symbol | Role |
 |---|---|
-| `_ensure_coverage_venv() -> str` | Create or recover the venv, install tooling, and return Python path. |
+| `_ensure_coverage_venv() -> str` | Create or recover the venv, install project/tool dependencies, and return Python path. |
 | `_coverage_python_cmd() -> BoundCommand` | Return the cached venv Python command. |
 <!-- markdownlint-enable MD013 MD060 -->

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -18,12 +18,10 @@ action and the evolution of its supporting scripts.
   variables but do not inherit the wrapper process's ad hoc `--config` flags.
 - *2026-04-27* — Python coverage runs now execute inside an isolated,
   short-lived virtual environment (`.venv-coverage`) rather than relying on
-  `uv run --with` or the system interpreter. The venv is created on first use
-  by `create_venv()`, which also handles broken-cache recovery by detecting a
-  missing Python executable and recreating the directory. Tooling (`slipcover`,
-  `pytest`, `coverage`) is installed via `uv pip install --python` into that
-  venv and the resulting interpreter path is cached for the lifetime of the
-  process.
+  `uv run --with` or the system interpreter. `_ensure_coverage_venv()` creates
+  or repairs the venv on first use, installs tooling (`slipcover`, `pytest`,
+  `coverage`) via `uv pip install --python`, and `_coverage_python_cmd()` caches
+  the resulting interpreter command for the lifetime of the process.
 
 ## Rust Coverage Environment Overrides
 
@@ -189,28 +187,29 @@ the same job, and discarded when the runner workspace is cleaned up.
 
 ### Lifecycle
 
-1. `create_venv()` checks whether `.venv-coverage` exists.
+1. `_ensure_coverage_venv()` checks whether `.venv-coverage` contains a Python
+   executable.
    - If absent, it creates the venv via `uv venv .venv-coverage`.
    - If present but broken (Python binary missing), it removes the directory
      and recreates it.
-2. `install_coverage_tools(python)` installs `slipcover`, `pytest`, and
-   `coverage` into the venv using `uv pip install --python <venv-python>`. The
-   `--system` flag is deliberately excluded to keep the install isolated.
-3. `_coverage_python_cmd()` calls steps 1-2 on first use, caches the resulting
-   `plumbum` command, and returns the cached value on all subsequent calls
-   within the same process.
+2. `_ensure_coverage_venv()` installs `slipcover`, `pytest`, and `coverage`
+   into the venv using `uv pip install --python <venv-python>`. The `--system`
+   flag is deliberately excluded to keep the install isolated.
+3. `_coverage_python_cmd()` calls `_ensure_coverage_venv()` on first use, caches
+   the resulting `plumbum` command via `functools.lru_cache`, and returns the
+   cached value on all subsequent calls within the same process.
 
 ### Concurrency Model
 
 GitHub Actions executes action steps sequentially in a single thread. The
-module-level `_COVERAGE_PYTHON_CMD` singleton therefore requires no explicit
-synchronisation.
+`functools.lru_cache` memoized `_coverage_python_cmd()` accessor therefore
+requires no explicit synchronisation.
 
 ### Public API
 
 <!-- markdownlint-disable MD013 MD060 -->
 | Symbol | Role |
 |---|---|
-| `create_venv() -> str` | Create or recover the venv; return Python path. |
-| `install_coverage_tools(python: str) -> None` | Install tooling into the venv. |
+| `_ensure_coverage_venv() -> str` | Create or recover the venv, install tooling, and return Python path. |
+| `_coverage_python_cmd() -> BoundCommand` | Return the cached venv Python command. |
 <!-- markdownlint-enable MD013 MD060 -->

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -207,7 +207,7 @@ the same job, and discarded when the runner workspace is cleaned up.
 
 GitHub Actions executes action steps sequentially in a single thread. The
 `functools.lru_cache` memoized `_coverage_python_cmd()` accessor therefore
-requires no explicit synchronisation.
+requires no explicit synchronization.
 
 ### Public API
 

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -176,6 +176,10 @@ stops short of that complexity.
   suffixes.
 - [x] Document the Rust coverage environment-override design for
   Cranelift-configured repositories.
+- [x] Replace `uv run --with` ephemeral environments with a persistent,
+  job-local `.venv-coverage` virtual environment to enable intra-process
+  caching of the Python interpreter path via `functools.lru_cache` and to add
+  broken-venv recovery.
 
 ## Python Coverage Venv Architecture
 

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -196,9 +196,10 @@ the same job, and discarded when the runner workspace is cleaned up.
 2. `_ensure_coverage_venv()` syncs the current project into the venv with
    `uv sync --inexact --python <venv-python>` so tests can import project
    dependencies.
-3. `_ensure_coverage_venv()` installs `slipcover`, `pytest`, and `coverage`
-   into the venv using `uv pip install --python <venv-python>`. The `--system`
-   flag is deliberately excluded to keep the install isolated.
+3. `_ensure_coverage_venv()` performs installation of `slipcover`, `pytest`,
+   and `coverage` into the venv using
+   `uv pip install --python <venv-python>`. The `--system` flag is deliberately
+   excluded to keep the install isolated.
 4. `_coverage_python_cmd()` calls `_ensure_coverage_venv()` on first use, caches
    the resulting `plumbum` command via `functools.lru_cache`, and returns the
    cached value on all subsequent calls within the same process.

--- a/workflow_scripts/markdownlint-check.sh
+++ b/workflow_scripts/markdownlint-check.sh
@@ -8,15 +8,15 @@ if files=$(git diff --name-only --diff-filter=ACMRT "${MARKDOWNLINT_BASE}...HEAD
     if [ -n "${files}" ]; then
         status=0
         while IFS= read -r file; do
-            ${MDLINT} "${file}" || status=1
+            "${MDLINT}" "${file}" || status=1
         done <<EOF
 ${files}
 EOF
         exit "${status}"
     else
-        find . -type f -name '*.md' -not -path './target/*' -exec ${MDLINT} {} +
+        find . -type f -name '*.md' -not -path './target/*' -exec "${MDLINT}" {} +
     fi
 else
     echo "markdownlint: git diff failed or base '${MARKDOWNLINT_BASE}' not found; linting all .md files" >&2
-    find . -type f -name '*.md' -not -path './target/*' -exec ${MDLINT} {} +
+    find . -type f -name '*.md' -not -path './target/*' -exec "${MDLINT}" {} +
 fi

--- a/workflow_scripts/markdownlint-check.sh
+++ b/workflow_scripts/markdownlint-check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -eu
+
+MARKDOWNLINT_BASE="${MARKDOWNLINT_BASE:-origin/main}"
+MDLINT="${MDLINT:-markdownlint}"
+
+if files=$(git diff --name-only --diff-filter=ACMRT "${MARKDOWNLINT_BASE}...HEAD" -- '*.md' 2>/dev/null); then
+    if [ -n "${files}" ]; then
+        status=0
+        while IFS= read -r file; do
+            ${MDLINT} "${file}" || status=1
+        done <<EOF
+${files}
+EOF
+        exit "${status}"
+    else
+        find . -type f -name '*.md' -not -path './target/*' -exec ${MDLINT} {} +
+    fi
+else
+    echo "markdownlint: git diff failed or base '${MARKDOWNLINT_BASE}' not found; linting all .md files" >&2
+    find . -type f -name '*.md' -not -path './target/*' -exec ${MDLINT} {} +
+fi

--- a/workflow_scripts/markdownlint-check.sh
+++ b/workflow_scripts/markdownlint-check.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env sh
+#
+# markdownlint-check.sh - Run markdownlint over changed or all Markdown files.
+#
+# Usage (called from the Makefile `markdownlint` target):
+#   MARKDOWNLINT_BASE=origin/main MDLINT=markdownlint ./workflow_scripts/markdownlint-check.sh
+#
+# Environment variables:
+#   MARKDOWNLINT_BASE  Git ref used as the base for `git diff`; defaults to
+#                      origin/main.  If the ref does not exist, falls back to
+#                      linting all *.md files.
+#   MDLINT             Path or name of the markdownlint binary; defaults to
+#                      markdownlint.
+#
 set -eu
 
 MARKDOWNLINT_BASE="${MARKDOWNLINT_BASE:-origin/main}"


### PR DESCRIPTION
## Summary

This branch runs the `generate-coverage` Python coverage phase from a short-lived virtual environment instead of relying on `uv run` or any system interpreter install path. The change avoids PEP 668 failures on GitHub-hosted Ubuntu runners where Python 3.12 is externally managed, while keeping coverage tooling isolated from the system interpreter.

It also hardens the Makefile check targets so automation with a narrow `PATH` can still find `uv` and `action-validator` from their common user-local install locations.

## Review walkthrough

- Start with [.github/actions/generate-coverage/scripts/run_python.py](https://github.com/leynos/shared-actions/blob/c6669c4d0823cd51c6bbcca10dfdb1c844acab13/.github/actions/generate-coverage/scripts/run_python.py) to see the new `.venv-coverage` creation, `uv pip install --python` tooling install, and venv Python reuse for slipcover, pytest, and coverage XML export.
- Then review [.github/actions/generate-coverage/tests/test_scripts.py](https://github.com/leynos/shared-actions/blob/c6669c4d0823cd51c6bbcca10dfdb1c844acab13/.github/actions/generate-coverage/tests/test_scripts.py) for the updated command-shape tests that assert the venv path and reject `--system` installs.
- Finish with [Makefile](https://github.com/leynos/shared-actions/blob/c6669c4d0823cd51c6bbcca10dfdb1c844acab13/Makefile) for the `UV` and `ACTION_VALIDATOR` command resolution used by local and hook-driven checks.

## Validation

- `python -c "import ast, sys; ast.parse(open('.github/actions/generate-coverage/scripts/run_python.py').read()); print('parse ok')"`: passed
- `uv run --with typer --with packaging --with plumbum --with pyyaml pytest .github/actions/generate-coverage/tests/test_scripts.py -k 'coverage_cmd_uses_venv_python or tmp_coveragepy_xml_invokes_venv_python or run_python_cobertura_passes_out_flag' -v`: passed, 3 selected tests passed
- `make check-fmt`: passed
- `make typecheck`: passed
- `make lint`: passed
- `make test`: passed, 668 passed and 90 skipped
- `make check-fmt lint typecheck`: passed
- `env PATH=/usr/bin:/bin make check-fmt lint typecheck`: passed

## Notes

The branch deliberately does not add `--break-system-packages` or restore a system install path. Coverage tooling is installed into `.venv-coverage` and invoked through that venv's Python interpreter.

## Summary by Sourcery

Run Python coverage tooling from an isolated, job-local virtual environment instead of via `uv run`, and make local tooling resolution in the Makefile more robust.

New Features:
- Introduce a dedicated `.venv-coverage` virtual environment and helper functions to create it, install coverage tooling into it, and reuse its Python interpreter for all coverage commands.

Bug Fixes:
- Avoid relying on system Python or `uv run --with` for coverage, preventing failures on externally managed Python installations such as GitHub-hosted Ubuntu runners.

Enhancements:
- Refactor coverage command construction to use a cached venv-based Python command while keeping slipcover, pytest, and coverage invocation behaviour consistent.
- Strengthen tests around coverage command construction and venv lifecycle, including recovery from broken or missing venv Python executables.
- Improve Makefile commands to resolve `uv`, `action-validator`, and `markdownlint` from common user-local install locations and to lint only changed Markdown files where possible.

Documentation:
- Document the new Python coverage venv architecture, lifecycle, and concurrency assumptions, and update the generate-coverage README to describe the venv-based installation behaviour.