### PR TITLE
Keep coverage installs on the venv Python path

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.3.15 (2026-04-30)
+
+- Preserve the `.venv-coverage/bin/python` path when installing coverage
+  tooling. Linux venv Python executables are often symlinks to the base
+  interpreter, and resolving the symlink made `uv pip install --python` target
+  the externally managed system Python instead of the coverage venv.
+
 ## v1.3.14 (2026-04-28)
 
 - Run Python coverage tooling in an isolated, job-local virtual environment

--- a/.github/actions/generate-coverage/scripts/_cargo_runner.py
+++ b/.github/actions/generate-coverage/scripts/_cargo_runner.py
@@ -45,7 +45,7 @@ class _CargoProcCtx:
     wait_timeout: float
 
 
-def _safe_close_text_stream(stream: typ.TextIO | None) -> None:
+def _safe_close_text_stream(stream: typ.IO[str] | None) -> None:
     """Close ``stream`` while suppressing any cleanup errors."""
     if stream is None:
         return

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -168,18 +168,12 @@ def _install_coverage_tooling(python: Path) -> None:
     typer.echo(f"Coverage tooling installed into {COVERAGE_VENV}")
 
 
-def _ensure_coverage_venv() -> str:
-    """Create or repair the coverage venv and install project/test tooling.
-
-    Checks whether ``.venv-coverage`` contains a healthy Python executable.
-    If not, delegates to :func:`_recreate_coverage_venv` to remove any
-    broken state and create a fresh venv.  Then runs ``uv sync`` to install
-    project dependencies, followed by ``uv pip install`` to add
-    ``slipcover``, ``pytest``, and ``coverage``.
+def _acquire_coverage_python() -> Path:
+    """Discover or create the coverage venv and return its Python path.
 
     Returns
     -------
-    str
+    Path
         Absolute path to the Python executable inside the coverage venv.
 
     Raises
@@ -187,9 +181,6 @@ def _ensure_coverage_venv() -> str:
     RuntimeError
         Propagated from :func:`_recreate_coverage_venv` when the Python
         executable cannot be located after venv creation.
-    plumbum.commands.processes.ProcessExecutionError
-        Propagated from ``uv sync`` or ``uv pip install`` when either
-        command exits with a non-zero return code.
     """
     candidates = _coverage_python_candidates()
     logger.debug(
@@ -228,6 +219,31 @@ def _ensure_coverage_venv() -> str:
                 "preserved_symlink": raw_candidate.is_symlink(),
             },
         )
+    return python
+
+
+def _ensure_coverage_venv() -> str:
+    """Create or repair the coverage venv and install project/test tooling.
+
+    Delegates venv discovery and creation to _acquire_coverage_python, then
+    runs ``uv sync`` to install project dependencies, followed by
+    ``uv pip install`` to add ``slipcover``, ``pytest``, and ``coverage``.
+
+    Returns
+    -------
+    str
+        Absolute path to the Python executable inside the coverage venv.
+
+    Raises
+    ------
+    RuntimeError
+        Propagated from :func:`_recreate_coverage_venv` when the Python
+        executable cannot be located after venv creation.
+    plumbum.commands.processes.ProcessExecutionError
+        Propagated from ``uv sync`` or ``uv pip install`` when either
+        command exits with a non-zero return code.
+    """
+    python = _acquire_coverage_python()
     logger.info(
         "using coverage venv Python for uv commands",
         extra={

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -51,7 +51,12 @@ PYTEST_ARGS: tuple[str, ...] = (
 
 
 def _find_coverage_python() -> Path | None:
-    """Return the coverage venv Python executable path when it exists."""
+    """Return the coverage venv Python executable path when it exists.
+
+    Virtual environment Python executables are commonly symlinks to the base
+    interpreter. Keep the venv path so uv targets the venv instead of the
+    externally managed system Python.
+    """
     if COVERAGE_VENV.is_symlink() or not COVERAGE_VENV.is_dir():
         return None
     candidates = (
@@ -59,7 +64,7 @@ def _find_coverage_python() -> Path | None:
         COVERAGE_VENV / "Scripts" / "python.exe",
         COVERAGE_VENV / "Scripts" / "python",
     )
-    return next((c.resolve() for c in candidates if c.is_file()), None)
+    return next((c.absolute() for c in candidates if c.is_file()), None)
 
 
 def _remove_coverage_venv() -> None:

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import collections.abc as cabc  # noqa: TC003 - used at runtime
 import contextlib
+import logging
 import os
 import shutil
 import typing as typ
@@ -25,6 +26,8 @@ from shared_utils import read_previous_coverage
 
 if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
     from plumbum.commands.base import BoundCommand
+
+logger = logging.getLogger(__name__)
 
 OUTPUT_PATH_OPT = typer.Option(..., envvar="INPUT_OUTPUT_PATH")
 LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
@@ -50,6 +53,15 @@ PYTEST_ARGS: tuple[str, ...] = (
 )
 
 
+def _coverage_python_candidates() -> tuple[Path, ...]:
+    """Return the supported Python executable locations inside the venv."""
+    return (
+        COVERAGE_VENV / "bin" / "python",
+        COVERAGE_VENV / "Scripts" / "python.exe",
+        COVERAGE_VENV / "Scripts" / "python",
+    )
+
+
 def _find_coverage_python() -> Path | None:
     """Return the coverage venv Python executable path when it exists.
 
@@ -58,13 +70,48 @@ def _find_coverage_python() -> Path | None:
     externally managed system Python.
     """
     if COVERAGE_VENV.is_symlink() or not COVERAGE_VENV.is_dir():
+        logger.debug(
+            "coverage venv path is not a usable directory",
+            extra={
+                "coverage_venv": str(COVERAGE_VENV),
+                "exists": COVERAGE_VENV.exists(),
+                "is_dir": COVERAGE_VENV.is_dir(),
+                "is_symlink": COVERAGE_VENV.is_symlink(),
+            },
+        )
         return None
-    candidates = (
-        COVERAGE_VENV / "bin" / "python",
-        COVERAGE_VENV / "Scripts" / "python.exe",
-        COVERAGE_VENV / "Scripts" / "python",
+    for candidate in _coverage_python_candidates():
+        logger.debug(
+            "checking coverage venv Python candidate",
+            extra={
+                "coverage_venv": str(COVERAGE_VENV),
+                "candidate": str(candidate),
+                "candidate_absolute": str(candidate.absolute()),
+                "candidate_resolved": str(candidate.resolve(strict=False)),
+                "is_file": candidate.is_file(),
+                "is_symlink": candidate.is_symlink(),
+            },
+        )
+        if candidate.is_file():
+            selected = candidate.absolute()
+            logger.debug(
+                "selected coverage venv Python candidate",
+                extra={
+                    "coverage_venv": str(COVERAGE_VENV),
+                    "python": str(selected),
+                    "resolved_python": str(candidate.resolve(strict=False)),
+                    "preserved_symlink": candidate.is_symlink(),
+                },
+            )
+            return selected
+    logger.debug(
+        "coverage venv contains no Python executable candidates",
+        extra={
+            "coverage_venv": str(COVERAGE_VENV),
+            "candidates": [str(c) for c in _coverage_python_candidates()],
+        },
     )
-    return next((c.absolute() for c in candidates if c.is_file()), None)
+    return None
 
 
 def _remove_coverage_venv() -> None:
@@ -176,12 +223,36 @@ def _ensure_coverage_venv() -> str:
         Propagated from ``uv sync`` or ``uv pip install`` when either
         command exits with a non-zero return code.
     """
+    logger.info(
+        "checking coverage venv Python candidates",
+        extra={
+            "coverage_venv": str(COVERAGE_VENV),
+            "candidates": [str(c) for c in _coverage_python_candidates()],
+        },
+    )
     python = _find_coverage_python()
     if python is None:
         python = _recreate_coverage_venv()
     else:
         typer.echo(f"Reusing existing coverage venv at {COVERAGE_VENV}")
+    logger.info(
+        "using coverage venv Python for uv commands",
+        extra={
+            "coverage_venv": str(COVERAGE_VENV),
+            "python": str(python),
+            "sync_args": [*PROJECT_SYNC_ARGS, str(python)],
+            "tooling_packages": [*TOOLING_PACKAGES],
+        },
+    )
     _sync_project_deps(python)
+    logger.info(
+        "installing coverage tooling with uv pip",
+        extra={
+            "coverage_venv": str(COVERAGE_VENV),
+            "python": str(python),
+            "pip_args": ["pip", "install", "--python", str(python), *TOOLING_PACKAGES],
+        },
+    )
     _install_coverage_tooling(python)
     return str(python)
 

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -52,6 +52,11 @@ PYTEST_ARGS: tuple[str, ...] = (
     "-v",
 )
 
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(levelname)s %(name)s %(message)s",
+)
+
 
 def _coverage_python_candidates() -> tuple[Path, ...]:
     """Return the supported Python executable locations inside the venv."""
@@ -70,47 +75,10 @@ def _find_coverage_python() -> Path | None:
     externally managed system Python.
     """
     if COVERAGE_VENV.is_symlink() or not COVERAGE_VENV.is_dir():
-        logger.debug(
-            "coverage venv path is not a usable directory",
-            extra={
-                "coverage_venv": str(COVERAGE_VENV),
-                "exists": COVERAGE_VENV.exists(),
-                "is_dir": COVERAGE_VENV.is_dir(),
-                "is_symlink": COVERAGE_VENV.is_symlink(),
-            },
-        )
         return None
     for candidate in _coverage_python_candidates():
-        logger.debug(
-            "checking coverage venv Python candidate",
-            extra={
-                "coverage_venv": str(COVERAGE_VENV),
-                "candidate": str(candidate),
-                "candidate_absolute": str(candidate.absolute()),
-                "candidate_resolved": str(candidate.resolve(strict=False)),
-                "is_file": candidate.is_file(),
-                "is_symlink": candidate.is_symlink(),
-            },
-        )
         if candidate.is_file():
-            selected = candidate.absolute()
-            logger.debug(
-                "selected coverage venv Python candidate",
-                extra={
-                    "coverage_venv": str(COVERAGE_VENV),
-                    "python": str(selected),
-                    "resolved_python": str(candidate.resolve(strict=False)),
-                    "preserved_symlink": candidate.is_symlink(),
-                },
-            )
-            return selected
-    logger.debug(
-        "coverage venv contains no Python executable candidates",
-        extra={
-            "coverage_venv": str(COVERAGE_VENV),
-            "candidates": [str(c) for c in _coverage_python_candidates()],
-        },
-    )
+            return candidate.absolute()
     return None
 
 
@@ -223,18 +191,43 @@ def _ensure_coverage_venv() -> str:
         Propagated from ``uv sync`` or ``uv pip install`` when either
         command exits with a non-zero return code.
     """
-    logger.info(
+    candidates = _coverage_python_candidates()
+    logger.debug(
         "checking coverage venv Python candidates",
         extra={
             "coverage_venv": str(COVERAGE_VENV),
-            "candidates": [str(c) for c in _coverage_python_candidates()],
+            "candidates": [str(c) for c in candidates],
         },
     )
     python = _find_coverage_python()
     if python is None:
         python = _recreate_coverage_venv()
+        logger.debug(
+            "created fresh coverage venv",
+            extra={
+                "coverage_venv": str(COVERAGE_VENV),
+                "python": str(python),
+            },
+        )
     else:
         typer.echo(f"Reusing existing coverage venv at {COVERAGE_VENV}")
+        raw_candidate = next(
+            (candidate for candidate in candidates if candidate.absolute() == python),
+            python,
+        )
+        logger.debug(
+            "selected coverage venv Python candidate",
+            extra={
+                "coverage_venv": str(COVERAGE_VENV),
+                "candidate": str(raw_candidate),
+                "candidate_absolute": str(raw_candidate.absolute()),
+                "candidate_resolved": str(raw_candidate.resolve(strict=False)),
+                "is_symlink": raw_candidate.is_symlink(),
+                "python": str(python),
+                "resolved_python": str(raw_candidate.resolve(strict=False)),
+                "preserved_symlink": raw_candidate.is_symlink(),
+            },
+        )
     logger.info(
         "using coverage venv Python for uv commands",
         extra={

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -8,7 +8,6 @@ import hashlib
 import importlib.util
 import io
 import itertools
-import logging
 import os
 import sys
 import typing as typ
@@ -1983,7 +1982,6 @@ def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Do not resolve venv Python symlinks back to the system interpreter."""
     setup = _setup_coverage_venv_test(
@@ -1996,7 +1994,6 @@ def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
     venv_python.parent.mkdir(parents=True)
     venv_python.symlink_to(system_python)
     expected_python = venv_python.absolute()
-    caplog.set_level(logging.DEBUG, logger=run_python_module.__name__)
 
     assert run_python_module._ensure_coverage_venv() == str(expected_python)
 
@@ -2005,40 +2002,6 @@ def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
     assert setup.recorded[0][1:] == [
         "sync",
         "--inexact",
-        "--python",
-        str(expected_python),
-    ]
-    selected_logs = [
-        r
-        for r in caplog.records
-        if r.message == "selected coverage venv Python candidate"
-    ]
-    assert selected_logs
-    assert selected_logs[0].python == str(expected_python)
-    assert selected_logs[0].resolved_python == str(system_python.resolve())
-    assert selected_logs[0].preserved_symlink is True
-    uv_logs = [
-        r
-        for r in caplog.records
-        if r.message == "using coverage venv Python for uv commands"
-    ]
-    assert uv_logs
-    assert uv_logs[0].python == str(expected_python)
-    assert uv_logs[0].sync_args == [
-        "sync",
-        "--inexact",
-        "--python",
-        str(expected_python),
-    ]
-    pip_logs = [
-        r
-        for r in caplog.records
-        if r.message == "installing coverage tooling with uv pip"
-    ]
-    assert pip_logs
-    assert pip_logs[0].pip_args[:4] == [
-        "pip",
-        "install",
         "--python",
         str(expected_python),
     ]
@@ -2836,3 +2799,58 @@ def test_run_python_integration_uv_failure_modes(
     assert returncode != 0
     if spec.expected_in_stderr is not None:
         assert spec.expected_in_stderr in stderr
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")
+def test_run_python_integration_venv_python_symlink_targets_venv(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uv receives the venv symlink path, not the resolved system Python."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "uv-calls.log"
+    system_python = tmp_path / "usr" / "bin" / "python3.12"
+    uv = bin_dir / "uv"
+    uv.write_text(
+        f"""#!/usr/bin/env sh
+printf '%s\\n' "$*" >> '{log}'
+if [ "$1" = "venv" ]; then
+    mkdir -p "$2/bin" '{system_python.parent}'
+    cat > '{system_python}' <<'PY'
+#!/usr/bin/env sh
+exit 0
+PY
+    chmod +x '{system_python}'
+    ln -s '{system_python}' "$2/bin/python"
+    exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+
+    returncode, _stdout, _stderr = _run_integration_script(
+        tmp_path, shell_stubs, bin_dir, monkeypatch
+    )
+
+    uv_calls = log.read_text(encoding="utf-8").splitlines()
+    sync_calls = [c for c in uv_calls if c.startswith("sync ")]
+    pip_calls = [c for c in uv_calls if c.startswith("pip install ")]
+    assert returncode == 0
+    assert sync_calls, "uv sync must be called to install project deps"
+    assert pip_calls, "uv pip install must be called to install tooling"
+    expected_python = (tmp_path / ".venv-coverage" / "bin" / "python").absolute()
+    resolved_python = system_python.resolve()
+
+    sync_args = sync_calls[0].split()
+    pip_args = pip_calls[0].split()
+    sync_python = sync_args[sync_args.index("--python") + 1]
+    pip_python = pip_args[pip_args.index("--python") + 1]
+
+    assert sync_python == str(expected_python)
+    assert pip_python == str(expected_python)
+    assert sync_python != str(resolved_python)
+    assert pip_python != str(resolved_python)

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -8,6 +8,7 @@ import hashlib
 import importlib.util
 import io
 import itertools
+import logging
 import os
 import sys
 import typing as typ
@@ -1982,6 +1983,7 @@ def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
     tmp_path: Path,
     run_python_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Do not resolve venv Python symlinks back to the system interpreter."""
     setup = _setup_coverage_venv_test(
@@ -1994,6 +1996,7 @@ def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
     venv_python.parent.mkdir(parents=True)
     venv_python.symlink_to(system_python)
     expected_python = venv_python.absolute()
+    caplog.set_level(logging.DEBUG, logger=run_python_module.__name__)
 
     assert run_python_module._ensure_coverage_venv() == str(expected_python)
 
@@ -2002,6 +2005,40 @@ def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
     assert setup.recorded[0][1:] == [
         "sync",
         "--inexact",
+        "--python",
+        str(expected_python),
+    ]
+    selected_logs = [
+        r
+        for r in caplog.records
+        if r.message == "selected coverage venv Python candidate"
+    ]
+    assert selected_logs
+    assert selected_logs[0].python == str(expected_python)
+    assert selected_logs[0].resolved_python == str(system_python.resolve())
+    assert selected_logs[0].preserved_symlink is True
+    uv_logs = [
+        r
+        for r in caplog.records
+        if r.message == "using coverage venv Python for uv commands"
+    ]
+    assert uv_logs
+    assert uv_logs[0].python == str(expected_python)
+    assert uv_logs[0].sync_args == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(expected_python),
+    ]
+    pip_logs = [
+        r
+        for r in caplog.records
+        if r.message == "installing coverage tooling with uv pip"
+    ]
+    assert pip_logs
+    assert pip_logs[0].pip_args[:4] == [
+        "pip",
+        "install",
         "--python",
         str(expected_python),
     ]

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1978,6 +1978,41 @@ def test_find_coverage_python_returns_absolute_path(
     assert found.is_absolute()
 
 
+def test_ensure_coverage_venv_keeps_symlinked_venv_python_path(
+    tmp_path: Path,
+    run_python_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not resolve venv Python symlinks back to the system interpreter."""
+    setup = _setup_coverage_venv_test(
+        tmp_path, run_python_module, monkeypatch, python_to_create=None
+    )
+    system_python = tmp_path / "usr" / "bin" / "python3.12"
+    system_python.parent.mkdir(parents=True)
+    system_python.touch()
+    venv_python = setup.coverage_venv / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(system_python)
+    expected_python = venv_python.absolute()
+
+    assert run_python_module._ensure_coverage_venv() == str(expected_python)
+
+    assert expected_python != system_python.resolve()
+    assert len(setup.recorded) == 2
+    assert setup.recorded[0][1:] == [
+        "sync",
+        "--inexact",
+        "--python",
+        str(expected_python),
+    ]
+    assert setup.recorded[1][1:5] == [
+        "pip",
+        "install",
+        "--python",
+        str(expected_python),
+    ]
+
+
 def test_ensure_coverage_venv_raises_when_created_venv_has_no_python(
     tmp_path: Path,
     run_python_module: ModuleType,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -33,6 +33,8 @@ uses `shutil.rmtree` for directories and `Path.unlink` for files or symlinks.
 absent after creation. `_ensure_coverage_venv()` runs
 `uv sync --inexact --python <venv_python>` and
 `uv pip install --python <venv_python> slipcover pytest coverage`.
+`<venv_python>` is the absolute path inside `.venv-coverage`; it is not
+resolved through symlinks before being passed to uv.
 `_coverage_python_cmd()` uses `@lru_cache(maxsize=1)` and returns the cached
 command for `<venv_python>` thereafter.
 
@@ -68,6 +70,19 @@ removes the directory and recreates it from scratch. The case is detected by
 - `COVERAGE_VENV/bin/python` (POSIX)
 - `COVERAGE_VENV/Scripts/python.exe` (Windows)
 - `COVERAGE_VENV/Scripts/python` (Windows without extension)
+
+On POSIX, `bin/python` is commonly a symlink to the base interpreter, for
+example `/usr/bin/python3.12`. `_find_coverage_python()` deliberately returns
+`Path.absolute()` rather than `Path.resolve()` so the action passes
+`.venv-coverage/bin/python` to uv. Resolving that symlink would make
+`uv pip install --python` target the externally managed system interpreter
+instead of the throwaway coverage venv.
+
+The helper logs each candidate at DEBUG level with the candidate path, absolute
+path, resolved target, file status, and symlink status. `_ensure_coverage_venv()`
+logs the candidate set and the exact Python path passed to `uv sync` and
+`uv pip install` at INFO level so CI logs can identify whether uv targeted the
+venv path or the base interpreter.
 
 ## Makefile Tool Resolution
 

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -23,6 +23,13 @@ action and the evolution of its supporting scripts.
   `uv sync --inexact --python`, installs tooling (`slipcover`, `pytest`,
   `coverage`) via `uv pip install --python`, and `_coverage_python_cmd()` caches
   the resulting interpreter command for the lifetime of the process.
+- *2026-04-30* — Python coverage venv discovery now preserves the absolute
+  venv interpreter path instead of resolving it through symlinks. On Linux,
+  `.venv-coverage/bin/python` can point at `/usr/bin/python3.12`; passing the
+  resolved target to `uv pip install --python` makes uv treat `/usr` as the
+  install environment and trips externally-managed-interpreter protections.
+  The action must pass the venv path itself to uv, and it logs the candidate
+  paths, resolved targets, and selected uv command interpreter for diagnosis.
 
 ## Rust Coverage Environment Overrides
 
@@ -208,6 +215,13 @@ the same job, and discarded when the runner workspace is cleaned up.
 4. `_coverage_python_cmd()` calls `_ensure_coverage_venv()` on first use, caches
    the resulting `plumbum` command via `functools.lru_cache`, and returns the
    cached value on all subsequent calls within the same process.
+
+`<venv-python>` is the absolute path to the Python executable inside
+`.venv-coverage`, not the result of resolving that executable through symlinks.
+This distinction matters on Linux because venv Python executables commonly
+symlink to the base interpreter. Resolving the symlink before invoking uv
+would redirect installs back to the system Python and defeat the isolation
+provided by `.venv-coverage`.
 
 ### Concurrency Model
 


### PR DESCRIPTION
## Summary

This branch keeps Python coverage tooling installs inside `.venv-coverage` on Linux by preserving the venv interpreter path passed to `uv sync` and `uv pip install`. The previous fix created the venv, but then resolved `.venv-coverage/bin/python` through its symlink to the base interpreter, so uv received `/usr/bin/python3.12` and targeted the externally managed system Python.

No roadmap task, issue or execplan is associated with this branch.

## Review walkthrough

- Start with [`.github/actions/generate-coverage/scripts/run_python.py`](https://github.com/leynos/shared-actions/blob/c17a7f9038c0b0767deb77c85cca8102821fab01/.github/actions/generate-coverage/scripts/run_python.py#L53) to see the venv Python path preservation.
- Then review [`.github/actions/generate-coverage/tests/test_scripts.py`](https://github.com/leynos/shared-actions/blob/c17a7f9038c0b0767deb77c85cca8102821fab01/.github/actions/generate-coverage/tests/test_scripts.py#L1981) for the symlink regression test that proves uv receives the venv path rather than the system target.
- Check [`.github/actions/generate-coverage/scripts/_cargo_runner.py`](https://github.com/leynos/shared-actions/blob/c17a7f9038c0b0767deb77c85cca8102821fab01/.github/actions/generate-coverage/scripts/_cargo_runner.py#L48) for the narrow type annotation correction needed to keep the typecheck gate green.
- Finish with [`.github/actions/generate-coverage/CHANGELOG.md`](https://github.com/leynos/shared-actions/blob/c17a7f9038c0b0767deb77c85cca8102821fab01/.github/actions/generate-coverage/CHANGELOG.md#L3) for the action-facing release note.

## Validation

- `uv run --with typer --with packaging --with plumbum --with pyyaml pytest .github/actions/generate-coverage/tests/test_scripts.py -k 'coverage_venv' -v`: 10 passed, 79 deselected.
- `make check-fmt`: passed.
- `make typecheck`: passed.
- `make lint`: passed.
- `make test`: 680 passed, 93 skipped.

## Notes

The relevant behaviour is that Linux virtual environments commonly expose `bin/python` as a symlink to the base interpreter. The action must pass the venv path itself to uv; resolving the path defeats the isolation that the previous PR intended to add.