### PR TITLE
Export the cargo-binstall version pin

### DIFF
--- a/.github/actions/setup-rust/README.md
+++ b/.github/actions/setup-rust/README.md
@@ -38,9 +38,12 @@ uses: ./.github/actions/setup-rust@v1
 
 The action installs `cargo-binstall` by default. Set `install-binstall: 'false'`
 to skip this step. If you bump the pinned `cargo-binstall` version, update the
-corresponding SHA-256 in the action manifest at the same time. You can obtain
-the new checksum by replacing `VERSION` with the desired tag (for example,
-`v1.16.6`) and running:
+corresponding SHA-256 in the action manifest at the same time. Keep
+`BINSTALL_VERSION` exported in the install step: the downloaded installer runs
+in a child shell and reads `BINSTALL_VERSION` from the environment. A plain
+shell variable is not inherited, which makes the installer fall back to
+`releases/latest`. You can obtain the new checksum by replacing `VERSION` with
+the desired tag (for example, `v1.16.6`) and running:
 
 ```bash
 curl -fsSL "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/VERSION/install-from-binstall-release.sh" \

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -70,7 +70,7 @@ runs:
         set -euo pipefail
         # Keep BINSTALL_VERSION and BINSTALL_SHA256 in sync; update both together.
         # To refresh the checksum: curl -fsSL "$INSTALLER_URL" | shasum -a 256 | awk '{print $1}'
-        BINSTALL_VERSION="v1.16.6"
+        export BINSTALL_VERSION="v1.16.6"
         BINSTALL_SHA256="c2e963fbab3bdd8653b59c28d349bf85740cf4998e5e398d250dcd2884cd667d"
         INSTALLER_URL="https://raw.githubusercontent.com/cargo-bins/cargo-binstall/${BINSTALL_VERSION}/install-from-binstall-release.sh"
         INSTALLER_PATH="$(mktemp)"
@@ -90,6 +90,7 @@ runs:
           exit 1
         fi
         bash "$INSTALLER_PATH"
+        cargo-binstall -V | grep -q "1.16.6"
       shell: bash
     - name: Install uv
       # v6.4.3

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -95,6 +95,7 @@ runs:
           cargo-binstall -V >&2
           exit 1
         fi
+        echo "cargo-binstall $(cargo-binstall -V) verified"
       shell: bash
     - name: Install uv
       # v6.4.3

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -90,7 +90,11 @@ runs:
           exit 1
         fi
         bash "$INSTALLER_PATH"
-        cargo-binstall -V | grep -q "1.16.6"
+        if ! cargo-binstall -V | grep -q "1.16.6"; then
+          echo "cargo-binstall version verification failed: expected 1.16.6" >&2
+          cargo-binstall -V >&2
+          exit 1
+        fi
       shell: bash
     - name: Install uv
       # v6.4.3

--- a/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
+++ b/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
@@ -24,6 +24,14 @@ def _install_binstall_run_script() -> str:
     return run_script
 
 
+def _get_step_condition(step_name: str) -> str:
+    steps = _load_steps()
+    step = next(step for step in steps if step.get("name") == step_name)
+    condition = step.get("if")
+    assert isinstance(condition, str)
+    return condition
+
+
 def test_manifest_exposes_toolchain_input() -> None:
     """The action should accept a toolchain override input."""
     manifest = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
@@ -33,26 +41,14 @@ def test_manifest_exposes_toolchain_input() -> None:
 
 def test_install_postgres_deps_is_linux_only() -> None:
     """Postgres packages should only install on Linux when requested."""
-    steps = _load_steps()
-    install_step = next(
-        step for step in steps if step.get("name") == "Install system dependencies"
-    )
-    condition = install_step.get("if")
-    assert isinstance(condition, str)
+    condition = _get_step_condition("Install system dependencies")
     assert "runner.os == 'Linux'" in condition
     assert "inputs.install-postgres-deps == 'true'" in condition
 
 
 def test_install_postgres_deps_windows_uses_choco() -> None:
     """Windows Postgres deps should install via Chocolatey when requested."""
-    steps = _load_steps()
-    windows_step = next(
-        step
-        for step in steps
-        if step.get("name") == "Install libpq (headers + import library)"
-    )
-    condition = windows_step.get("if")
-    assert isinstance(condition, str)
+    condition = _get_step_condition("Install libpq (headers + import library)")
     assert "runner.os == 'Windows'" in condition
     assert "inputs.install-postgres-deps == 'true'" in condition
 

--- a/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
+++ b/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
@@ -14,6 +14,16 @@ def _load_steps() -> list[dict[str, object]]:
     return manifest["runs"]["steps"]
 
 
+def _install_binstall_run_script() -> str:
+    steps = _load_steps()
+    install_step = next(
+        step for step in steps if step.get("name") == "Install cargo-binstall"
+    )
+    run_script = install_step.get("run")
+    assert isinstance(run_script, str)
+    return run_script
+
+
 def test_manifest_exposes_toolchain_input() -> None:
     """The action should accept a toolchain override input."""
     manifest = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
@@ -45,3 +55,15 @@ def test_install_postgres_deps_windows_uses_choco() -> None:
     assert isinstance(condition, str)
     assert "runner.os == 'Windows'" in condition
     assert "inputs.install-postgres-deps == 'true'" in condition
+
+
+def test_install_binstall_exports_version_pin() -> None:
+    """The cargo-binstall installer should inherit the pinned version."""
+    run_script = _install_binstall_run_script()
+    assert 'export BINSTALL_VERSION="v1.16.6"' in run_script
+
+
+def test_install_binstall_verifies_installed_version() -> None:
+    """The cargo-binstall step should assert the installed pinned version."""
+    run_script = _install_binstall_run_script()
+    assert 'cargo-binstall -V | grep -q "1.16.6"' in run_script

--- a/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
+++ b/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
@@ -10,25 +10,32 @@ ACTION_PATH = Path(__file__).resolve().parents[1] / "action.yml"
 
 
 def _load_steps() -> list[dict[str, object]]:
+    """Load the composite action steps from the setup-rust manifest."""
     manifest = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
     return manifest["runs"]["steps"]
 
 
-def _install_binstall_run_script() -> str:
+def _get_step(step_name: str) -> dict[str, object]:
+    """Return a named composite action step, failing clearly if it is absent."""
     steps = _load_steps()
-    install_step = next(
-        step for step in steps if step.get("name") == "Install cargo-binstall"
-    )
+    step = next((step for step in steps if step.get("name") == step_name), None)
+    assert step is not None, f"Missing setup-rust step: {step_name}"
+    return step
+
+
+def _install_binstall_run_script() -> str:
+    """Return the cargo-binstall install step shell script."""
+    install_step = _get_step("Install cargo-binstall")
     run_script = install_step.get("run")
-    assert isinstance(run_script, str)
+    assert isinstance(run_script, str), "Install cargo-binstall step has no run script"
     return run_script
 
 
 def _get_step_condition(step_name: str) -> str:
-    steps = _load_steps()
-    step = next(step for step in steps if step.get("name") == step_name)
+    """Return a named composite action step condition."""
+    step = _get_step(step_name)
     condition = step.get("if")
-    assert isinstance(condition, str)
+    assert isinstance(condition, str), f"Step has no string condition: {step_name}"
     return condition
 
 
@@ -56,10 +63,12 @@ def test_install_postgres_deps_windows_uses_choco() -> None:
 def test_install_binstall_exports_version_pin() -> None:
     """The cargo-binstall installer should inherit the pinned version."""
     run_script = _install_binstall_run_script()
-    assert 'export BINSTALL_VERSION="v1.16.6"' in run_script
+    run_lines = {line.strip() for line in run_script.splitlines()}
+    assert 'export BINSTALL_VERSION="v1.16.6"' in run_lines
 
 
 def test_install_binstall_verifies_installed_version() -> None:
     """The cargo-binstall step should assert the installed pinned version."""
     run_script = _install_binstall_run_script()
-    assert 'cargo-binstall -V | grep -q "1.16.6"' in run_script
+    run_lines = {line.strip() for line in run_script.splitlines()}
+    assert 'if ! cargo-binstall -V | grep -q "1.16.6"; then' in run_lines

--- a/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
+++ b/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 ACTION_PATH = Path(__file__).resolve().parents[1] / "action.yml"
+PINNED_BINSTALL_VERSION = "1.16.6"
+PINNED_BINSTALL_TAG = f"v{PINNED_BINSTALL_VERSION}"
+PINNED_BINSTALL_SHA256 = (
+    "c2e963fbab3bdd8653b59c28d349bf85740cf4998e5e398d250dcd2884cd667d"
+)
 
 
 def _load_steps() -> list[dict[str, object]]:
@@ -39,6 +48,97 @@ def _get_step_condition(step_name: str) -> str:
     return condition
 
 
+def _requires_bash() -> str:
+    """Return a usable bash path or skip shell-fragment tests."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash not found on PATH")
+    return bash
+
+
+def _write_executable(path: Path, content: str) -> None:
+    """Write an executable test stub script."""
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _write_binstall_stubs(tmp_path: Path) -> Path:
+    """Create command stubs used by the cargo-binstall install fragment."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "curl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$FAKE_CURL_ARGS"
+output_path=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-o" ]; then
+    output_path="$arg"
+    break
+  fi
+  previous="$arg"
+done
+if [ -z "$output_path" ]; then
+  echo "fake curl expected -o" >&2
+  exit 2
+fi
+cat > "$output_path" <<'INSTALLER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "${BINSTALL_VERSION:-}" > "$FAKE_INSTALLER_VERSION"
+cat > "$FAKE_BIN_DIR/cargo-binstall" <<'BINSTALL'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-V" ]; then
+  printf '%s\\n' "${FAKE_BINSTALL_VERSION:-1.16.6}"
+else
+  echo "unexpected cargo-binstall invocation: $*" >&2
+  exit 2
+fi
+BINSTALL
+chmod +x "$FAKE_BIN_DIR/cargo-binstall"
+INSTALLER
+chmod +x "$output_path"
+""",
+    )
+    _write_executable(
+        bin_dir / "sha256sum",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '{PINNED_BINSTALL_SHA256}  %s\\n' "$1"
+""",
+    )
+    return bin_dir
+
+
+def _run_install_binstall_script(
+    tmp_path: Path,
+    *,
+    installed_version: str = PINNED_BINSTALL_VERSION,
+) -> subprocess.CompletedProcess[str]:
+    """Run the cargo-binstall install fragment with deterministic stubs."""
+    bash = _requires_bash()
+    bin_dir = _write_binstall_stubs(tmp_path)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_BIN_DIR": bin_dir.as_posix(),
+        "FAKE_BINSTALL_VERSION": installed_version,
+        "FAKE_CURL_ARGS": (tmp_path / "curl-args").as_posix(),
+        "FAKE_INSTALLER_VERSION": (tmp_path / "installer-version").as_posix(),
+    }
+    return subprocess.run(  # noqa: S603,TID251 - exercise the bash fragment.
+        [bash, "-c", _install_binstall_run_script()],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
 def test_manifest_exposes_toolchain_input() -> None:
     """The action should accept a toolchain override input."""
     manifest = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
@@ -64,11 +164,57 @@ def test_install_binstall_exports_version_pin() -> None:
     """The cargo-binstall installer should inherit the pinned version."""
     run_script = _install_binstall_run_script()
     run_lines = {line.strip() for line in run_script.splitlines()}
-    assert 'export BINSTALL_VERSION="v1.16.6"' in run_lines
+    assert f'export BINSTALL_VERSION="{PINNED_BINSTALL_TAG}"' in run_lines
 
 
 def test_install_binstall_verifies_installed_version() -> None:
     """The cargo-binstall step should assert the installed pinned version."""
     run_script = _install_binstall_run_script()
     run_lines = {line.strip() for line in run_script.splitlines()}
-    assert 'if ! cargo-binstall -V | grep -q "1.16.6"; then' in run_lines
+    assert (
+        f'if ! cargo-binstall -V | grep -q "{PINNED_BINSTALL_VERSION}"; then'
+        in run_lines
+    )
+
+
+def test_install_binstall_script_exports_pin_to_installer(tmp_path: Path) -> None:
+    """The install fragment should pass the pinned version to the child installer."""
+    result = _run_install_binstall_script(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "installer-version").read_text(encoding="utf-8").strip() == (
+        PINNED_BINSTALL_TAG
+    )
+
+
+def test_install_binstall_script_uses_pinned_installer_url(tmp_path: Path) -> None:
+    """The install fragment should download the installer from the pinned tag."""
+    result = _run_install_binstall_script(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    curl_args = (tmp_path / "curl-args").read_text(encoding="utf-8")
+    assert (
+        "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/"
+        f"{PINNED_BINSTALL_TAG}/install-from-binstall-release.sh"
+    ) in curl_args
+
+
+def test_install_binstall_script_logs_verified_version(tmp_path: Path) -> None:
+    """The install fragment should log the verified cargo-binstall version."""
+    result = _run_install_binstall_script(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert f"cargo-binstall {PINNED_BINSTALL_VERSION} verified" in result.stdout
+
+
+def test_install_binstall_script_fails_on_version_mismatch(tmp_path: Path) -> None:
+    """The install fragment should fail clearly when the installed version differs."""
+    result = _run_install_binstall_script(tmp_path, installed_version="1.99.0")
+
+    assert result.returncode != 0
+    expected_error = (
+        "cargo-binstall version verification failed: "
+        f"expected {PINNED_BINSTALL_VERSION}"
+    )
+    assert expected_error in result.stderr
+    assert "1.99.0" in result.stderr

--- a/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
+++ b/.github/actions/setup-rust/tests/test_setup_rust_manifest.py
@@ -139,6 +139,44 @@ def _run_install_binstall_script(
     )
 
 
+def test_get_step_reports_missing_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing manifest steps should fail with a contextual assertion."""
+    monkeypatch.setattr(__name__ + "._load_steps", lambda: [{"name": "Other Step"}])
+
+    with pytest.raises(
+        AssertionError,
+        match="Missing setup-rust step: Nonexistent Step",
+    ):
+        _get_step("Nonexistent Step")
+
+
+def test_get_step_condition_requires_string_condition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Step conditions should be present and string-valued."""
+    step_name = "Install system dependencies"
+    monkeypatch.setattr(__name__ + "._load_steps", lambda: [{"name": step_name}])
+
+    with pytest.raises(AssertionError, match="Step has no string condition"):
+        _get_step_condition(step_name)
+
+
+def test_install_binstall_run_script_requires_string_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cargo-binstall step should expose a shell run script."""
+    monkeypatch.setattr(
+        __name__ + "._load_steps",
+        lambda: [{"name": "Install cargo-binstall"}],
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="Install cargo-binstall step has no run script",
+    ):
+        _install_binstall_run_script()
+
+
 def test_manifest_exposes_toolchain_input() -> None:
     """The action should accept a toolchain override input."""
     manifest = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -111,6 +111,25 @@ Override example:
 make lint UV=uv MARKDOWNLINT_BASE=origin/develop
 ```
 
+## `setup-rust` cargo-binstall Pinning
+
+The `setup-rust` action pins `cargo-binstall` by downloading
+`install-from-binstall-release.sh` from a tagged cargo-binstall release and
+checking the installer script against a fixed SHA-256 digest. Treat the version
+tag and checksum as a pair: update both in the same change and keep the
+checksum tied to the installer script at that tag.
+
+`BINSTALL_VERSION` must be exported in the install step. The installer script
+is executed by a child `bash` process and reads `BINSTALL_VERSION` from its
+environment to decide whether to download from `releases/download/<version>/`
+or from `releases/latest/download/`. If the value is only a shell variable, the
+child process sees it as empty and silently uses `latest`, defeating the pin.
+
+After the installer runs, the action verifies the installed binary with
+`cargo-binstall -V` and fails with the actual version in the log if it does not
+match the pinned release. Keep that runtime check in sync with
+`BINSTALL_VERSION` whenever the pin changes.
+
 ## `stage-release-artefacts` Action Architecture
 
 ### Staging Pipeline


### PR DESCRIPTION
## Summary

This branch exports the `BINSTALL_VERSION` variable in the setup-rust action so the cargo-binstall installer subprocess receives the pinned `v1.16.6` release instead of falling back to `releases/latest`. It also adds a smoke assertion that the installed binary reports `1.16.6`, proving the action did not install whatever latest resolves to at run time.

No linked issue, roadmap task, or execplan was found for this branch.

## Review walkthrough

- Start with [.github/actions/setup-rust/action.yml](https://github.com/leynos/shared-actions/blob/a02c46955750ebff431a75b42ef811786c1bfb2d/.github/actions/setup-rust/action.yml#L67) to review the `Install cargo-binstall` step, the exported version pin, unchanged checksum, and installed-version assertion.

## Validation

- `make check-fmt`: passed.
- `make typecheck`: passed.
- `make lint`: passed.
- `make test`: passed with `719 passed, 93 skipped`.
- Isolated Linux x86_64 cargo-binstall smoke: passed; the installer requested `https://github.com/cargo-bins/cargo-binstall/releases/download/v1.16.6/cargo-binstall-x86_64-unknown-linux-musl.tgz` and the installed binary reported `1.16.6`.

## Notes

The requested `cargo binstall --version | grep -q "1.16.6"` assertion was adjusted to `cargo-binstall -V | grep -q "1.16.6"` because cargo-binstall v1.16.6 treats `--version` as a package-selection option requiring a value. The `-V` flag is the supported binary-version output for this pinned release.

## Summary by Sourcery

Pin the cargo-binstall installer to a specific version in the setup-rust GitHub Action and verify that the installed binary matches the pinned version.

Enhancements:
- Export the BINSTALL_VERSION environment variable so the cargo-binstall installer script reliably uses the pinned v1.16.6 release.
- Add a smoke check to assert that the installed cargo-binstall binary reports version 1.16.6.