### PR TITLE
Pin setup-uv references and stabilise action tests

### DIFF
--- a/.github/actions/determine-release-modes/action.yml
+++ b/.github/actions/determine-release-modes/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: false
 

--- a/.github/actions/ensure-cargo-version/action.yml
+++ b/.github/actions/ensure-cargo-version/action.yml
@@ -19,8 +19,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      # v6.4.3
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         cache-dependency-glob: |
           **/pyproject.toml

--- a/.github/actions/export-cargo-metadata/action.yml
+++ b/.github/actions/export-cargo-metadata/action.yml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: false
 

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -64,8 +64,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      # v6.4.3
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         cache-dependency-glob: |
           **/pyproject.toml

--- a/.github/actions/generate-coverage/scripts/common.py
+++ b/.github/actions/generate-coverage/scripts/common.py
@@ -1,0 +1,49 @@
+"""Shared helpers for generate-coverage action scripts."""
+
+from __future__ import annotations
+
+import os
+
+import typer
+
+_TRUTHY_VALUES: frozenset[str] = frozenset({"1", "true", "yes", "on"})
+_FALSY_VALUES: frozenset[str] = frozenset({"0", "false", "no", "off"})
+_ALL_BOOL_VALUES: frozenset[str] = _TRUTHY_VALUES | _FALSY_VALUES
+
+
+def _required_env(name: str) -> str:
+    """Return the non-empty value of the required environment variable *name*.
+
+    Raises ``typer.Exit(2)`` when the variable is unset or empty.
+    """
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    typer.echo(f"Missing required environment variable: {name}", err=True)
+    raise typer.Exit(2)
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    """Parse the environment variable *name* as a boolean.
+
+    Unset or empty values return *default*.  Recognised truthy values are
+    ``1``, ``true``, ``yes``, ``on`` (case-insensitive); recognised falsy
+    values are ``0``, ``false``, ``no``, ``off``.  Any other non-empty value
+    is treated as a configuration error and raises ``typer.Exit(2)``.
+    """
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY_VALUES:
+        return True
+    if normalized in _FALSY_VALUES:
+        return False
+
+    typer.echo(
+        f"Invalid boolean value for environment variable {name!r}: {value!r}. "
+        f"Expected one of {sorted(_ALL_BOOL_VALUES)} (case-insensitive).",
+        err=True,
+    )
+    raise typer.Exit(2)

--- a/.github/actions/generate-coverage/scripts/merge_cobertura.py
+++ b/.github/actions/generate-coverage/scripts/merge_cobertura.py
@@ -5,6 +5,10 @@
 # ///
 """Merge Cobertura XML files from Rust and Python coverage runs."""
 
+from __future__ import annotations
+
+import os
+import typing as typ
 from pathlib import Path
 
 import typer
@@ -12,29 +16,40 @@ from cmd_utils_loader import run_cmd
 from plumbum.cmd import uvx
 from plumbum.commands.processes import ProcessExecutionError
 
-RUST_FILE_OPT = typer.Option(
-    ...,
-    envvar="RUST_FILE",
-    exists=True,
-    file_okay=True,
-    dir_okay=False,
-)
-PYTHON_FILE_OPT = typer.Option(
-    ...,
-    envvar="PYTHON_FILE",
-    exists=True,
-    file_okay=True,
-    dir_okay=False,
-)
-OUTPUT_PATH_OPT = typer.Option(..., envvar="OUTPUT_PATH")
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    typer.echo(f"Missing required environment variable: {name}", err=True)
+    raise typer.Exit(2)
 
 
 def main(
-    rust_file: Path = RUST_FILE_OPT,
-    python_file: Path = PYTHON_FILE_OPT,
-    output_path: Path = OUTPUT_PATH_OPT,
+    rust_file: typ.Annotated[
+        Path | None,
+        typer.Option(
+            envvar="RUST_FILE",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+        ),
+    ] = None,
+    python_file: typ.Annotated[
+        Path | None,
+        typer.Option(
+            envvar="PYTHON_FILE",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+        ),
+    ] = None,
+    output_path: typ.Annotated[Path | None, typer.Option(envvar="OUTPUT_PATH")] = None,
 ) -> None:
     """Merge two cobertura XML files and delete the inputs."""
+    rust_file = rust_file or Path(_required_env("RUST_FILE"))
+    python_file = python_file or Path(_required_env("PYTHON_FILE"))
+    output_path = output_path or Path(_required_env("OUTPUT_PATH"))
     try:
         cmd = uvx["merge-cobertura", str(rust_file), str(python_file)]
         output = run_cmd(cmd)

--- a/.github/actions/generate-coverage/scripts/merge_cobertura.py
+++ b/.github/actions/generate-coverage/scripts/merge_cobertura.py
@@ -7,22 +7,14 @@
 
 from __future__ import annotations
 
-import os
 import typing as typ
 from pathlib import Path
 
 import typer
 from cmd_utils_loader import run_cmd
+from common import _required_env
 from plumbum.cmd import uvx
 from plumbum.commands.processes import ProcessExecutionError
-
-
-def _required_env(name: str) -> str:
-    value = os.getenv(name, "").strip()
-    if value:
-        return value
-    typer.echo(f"Missing required environment variable: {name}", err=True)
-    raise typer.Exit(2)
 
 
 def main(

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import typer
 from cmd_utils_loader import run_cmd
+from common import _required_env
 from coverage_parsers import get_line_coverage_percent_from_cobertura
 from plumbum import local
 from plumbum.cmd import uv
@@ -51,14 +52,6 @@ logging.basicConfig(
     level=logging.DEBUG,
     format="%(levelname)s %(name)s %(message)s",
 )
-
-
-def _required_env(name: str) -> str:
-    value = os.getenv(name, "").strip()
-    if value:
-        return value
-    typer.echo(f"Missing required environment variable: {name}", err=True)
-    raise typer.Exit(2)
 
 
 def _coverage_python_candidates() -> tuple[Path, ...]:
@@ -415,15 +408,39 @@ def _run_coverage(fmt: str, out: Path) -> str:
 
 def main(
     output_path: typ.Annotated[
-        Path | None, typer.Option(envvar="INPUT_OUTPUT_PATH")
+        Path | None,
+        typer.Option(
+            envvar="INPUT_OUTPUT_PATH",
+            help="Destination path for the coverage output file.",
+        ),
     ] = None,
-    lang: typ.Annotated[str | None, typer.Option(envvar="DETECTED_LANG")] = None,
-    fmt: typ.Annotated[str | None, typer.Option(envvar="DETECTED_FMT")] = None,
+    lang: typ.Annotated[
+        str | None,
+        typer.Option(
+            envvar="DETECTED_LANG",
+            help='Detected project language: "rust", "python", or "mixed".',
+        ),
+    ] = None,
+    fmt: typ.Annotated[
+        str | None,
+        typer.Option(
+            envvar="DETECTED_FMT",
+            help='Coverage format: "slipcover", "coveragepy", etc.',
+        ),
+    ] = None,
     github_output: typ.Annotated[
-        Path | None, typer.Option(envvar="GITHUB_OUTPUT")
+        Path | None,
+        typer.Option(
+            envvar="GITHUB_OUTPUT",
+            help="Path to the GitHub Actions output file.",
+        ),
     ] = None,
     baseline_file: typ.Annotated[
-        Path | None, typer.Option(envvar="BASELINE_PYTHON_FILE")
+        Path | None,
+        typer.Option(
+            envvar="BASELINE_PYTHON_FILE",
+            help="Optional path to a previous coverage baseline file.",
+        ),
     ] = None,
 ) -> None:
     """Run slipcover coverage and write the result to ``GITHUB_OUTPUT``.

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -29,11 +29,6 @@ if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
 
 logger = logging.getLogger(__name__)
 
-OUTPUT_PATH_OPT = typer.Option(..., envvar="INPUT_OUTPUT_PATH")
-LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
-FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
-GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
-BASELINE_OPT = typer.Option(None, envvar="BASELINE_PYTHON_FILE")
 # COVERAGE_VENV is a process-scoped constant.  It is consumed by
 # _ensure_coverage_venv() and _coverage_python_cmd(), both of which are
 # called from a single-threaded GitHub Actions step.
@@ -56,6 +51,14 @@ logging.basicConfig(
     level=logging.DEBUG,
     format="%(levelname)s %(name)s %(message)s",
 )
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    typer.echo(f"Missing required environment variable: {name}", err=True)
+    raise typer.Exit(2)
 
 
 def _coverage_python_candidates() -> tuple[Path, ...]:
@@ -411,11 +414,17 @@ def _run_coverage(fmt: str, out: Path) -> str:
 
 
 def main(
-    output_path: Path = OUTPUT_PATH_OPT,
-    lang: str = LANG_OPT,
-    fmt: str = FMT_OPT,
-    github_output: Path = GITHUB_OUTPUT_OPT,
-    baseline_file: Path | None = BASELINE_OPT,
+    output_path: typ.Annotated[
+        Path | None, typer.Option(envvar="INPUT_OUTPUT_PATH")
+    ] = None,
+    lang: typ.Annotated[str | None, typer.Option(envvar="DETECTED_LANG")] = None,
+    fmt: typ.Annotated[str | None, typer.Option(envvar="DETECTED_FMT")] = None,
+    github_output: typ.Annotated[
+        Path | None, typer.Option(envvar="GITHUB_OUTPUT")
+    ] = None,
+    baseline_file: typ.Annotated[
+        Path | None, typer.Option(envvar="BASELINE_PYTHON_FILE")
+    ] = None,
 ) -> None:
     """Run slipcover coverage and write the result to ``GITHUB_OUTPUT``.
 
@@ -443,6 +452,10 @@ def main(
         exits non-zero, or when ``coverage xml`` fails in ``coveragepy``
         format mode.
     """
+    output_path = output_path or Path(_required_env("INPUT_OUTPUT_PATH"))
+    lang = lang or _required_env("DETECTED_LANG")
+    fmt = fmt or _required_env("DETECTED_FMT")
+    github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
     out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)
     percent = _run_coverage(fmt, out)

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -406,6 +406,28 @@ def _run_coverage(fmt: str, out: Path) -> str:
     return get_line_coverage_percent_from_cobertura(out)
 
 
+def _resolve_inputs(
+    output_path: Path | None,
+    lang: str | None,
+    fmt: str | None,
+    github_output: Path | None,
+) -> tuple[Path, str, Path]:
+    """Resolve CLI inputs and return the effective output path."""
+    resolved_output_path = output_path or Path(_required_env("INPUT_OUTPUT_PATH"))
+    resolved_lang = lang or _required_env("DETECTED_LANG")
+    resolved_fmt = fmt or _required_env("DETECTED_FMT")
+    resolved_github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
+    out = _resolve_output_path(resolved_output_path, resolved_lang)
+    return out, resolved_fmt, resolved_github_output
+
+
+def _emit_github_output(path: Path, percent: str, github_output: Path) -> None:
+    """Write coverage outputs for later GitHub Actions steps."""
+    with github_output.open("a") as fh:
+        fh.write(f"file={path}\n")
+        fh.write(f"percent={percent}\n")
+
+
 def main(
     output_path: typ.Annotated[
         Path | None,
@@ -469,20 +491,14 @@ def main(
         exits non-zero, or when ``coverage xml`` fails in ``coveragepy``
         format mode.
     """
-    output_path = output_path or Path(_required_env("INPUT_OUTPUT_PATH"))
-    lang = lang or _required_env("DETECTED_LANG")
-    fmt = fmt or _required_env("DETECTED_FMT")
-    github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
-    out = _resolve_output_path(output_path, lang)
+    out, fmt, github_output = _resolve_inputs(output_path, lang, fmt, github_output)
     out.parent.mkdir(parents=True, exist_ok=True)
     percent = _run_coverage(fmt, out)
     typer.echo(f"Current coverage: {percent}%")
     previous = read_previous_coverage(baseline_file)
     if previous is not None:
         typer.echo(f"Previous coverage: {previous}%")
-    with github_output.open("a") as fh:
-        fh.write(f"file={out}\n")
-        fh.write(f"percent={percent}\n")
+    _emit_github_output(out, percent, github_output)
 
 
 if __name__ == "__main__":

--- a/.github/actions/generate-coverage/scripts/run_python.py
+++ b/.github/actions/generate-coverage/scripts/run_python.py
@@ -432,28 +432,24 @@ def main(
     output_path: typ.Annotated[
         Path | None,
         typer.Option(
-            envvar="INPUT_OUTPUT_PATH",
             help="Destination path for the coverage output file.",
         ),
     ] = None,
     lang: typ.Annotated[
         str | None,
         typer.Option(
-            envvar="DETECTED_LANG",
             help='Detected project language: "rust", "python", or "mixed".',
         ),
     ] = None,
     fmt: typ.Annotated[
         str | None,
         typer.Option(
-            envvar="DETECTED_FMT",
             help='Coverage format: "slipcover", "coveragepy", etc.',
         ),
     ] = None,
     github_output: typ.Annotated[
         Path | None,
         typer.Option(
-            envvar="GITHUB_OUTPUT",
             help="Path to the GitHub Actions output file.",
         ),
     ] = None,

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -27,6 +27,7 @@ import typer
 from _cargo_runner import _run_cargo
 from _cranelift import _CARGO_COVERAGE_ENV_UNSETS, get_cargo_coverage_env
 from cmd_utils_loader import run_cmd
+from common import _env_bool, _required_env
 from coverage_parsers import get_line_coverage_percent_from_lcov
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
@@ -88,21 +89,6 @@ slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
 # Put a hard ceiling on the whole run.
 global-timeout = "10m"
 """
-
-
-def _required_env(name: str) -> str:
-    value = os.getenv(name, "").strip()
-    if value:
-        return value
-    typer.echo(f"Missing required environment variable: {name}", err=True)
-    raise typer.Exit(2)
-
-
-def _env_bool(name: str, *, default: bool) -> bool:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _run_cargo(
@@ -405,37 +391,19 @@ def _resolve_bool_input(
 
 
 def main(
-    output_path: typ.Annotated[
-        Path | None, typer.Option(envvar="INPUT_OUTPUT_PATH")
-    ] = None,
-    features: typ.Annotated[str, typer.Option(envvar="INPUT_FEATURES")] = "",
+    output_path: typ.Annotated[Path | None, typer.Option()] = None,
+    features: typ.Annotated[str, typer.Option()] = "",
     *,
-    with_default: typ.Annotated[
-        bool | None, typer.Option(envvar="INPUT_WITH_DEFAULT_FEATURES")
-    ] = None,
-    use_nextest: typ.Annotated[
-        bool | None, typer.Option(envvar="INPUT_USE_CARGO_NEXTEST")
-    ] = None,
-    lang: typ.Annotated[str | None, typer.Option(envvar="DETECTED_LANG")] = None,
-    fmt: typ.Annotated[str | None, typer.Option(envvar="DETECTED_FMT")] = None,
-    manifest_path: typ.Annotated[
-        Path, typer.Option(envvar="DETECTED_CARGO_MANIFEST")
-    ] = Path("Cargo.toml"),
-    github_output: typ.Annotated[
-        Path | None, typer.Option(envvar="GITHUB_OUTPUT")
-    ] = None,
-    cucumber_rs_features: typ.Annotated[
-        str, typer.Option(envvar="INPUT_CUCUMBER_RS_FEATURES")
-    ] = "",
-    cucumber_rs_args: typ.Annotated[
-        str, typer.Option(envvar="INPUT_CUCUMBER_RS_ARGS")
-    ] = "",
-    with_cucumber_rs: typ.Annotated[
-        bool | None, typer.Option(envvar="INPUT_WITH_CUCUMBER_RS")
-    ] = None,
-    baseline_file: typ.Annotated[
-        Path | None, typer.Option(envvar="BASELINE_RUST_FILE")
-    ] = None,
+    with_default: typ.Annotated[bool | None, typer.Option()] = None,
+    use_nextest: typ.Annotated[bool | None, typer.Option()] = None,
+    lang: typ.Annotated[str | None, typer.Option()] = None,
+    fmt: typ.Annotated[str | None, typer.Option()] = None,
+    manifest_path: typ.Annotated[Path, typer.Option()] = Path("Cargo.toml"),
+    github_output: typ.Annotated[Path | None, typer.Option()] = None,
+    cucumber_rs_features: typ.Annotated[str, typer.Option()] = "",
+    cucumber_rs_args: typ.Annotated[str, typer.Option()] = "",
+    with_cucumber_rs: typ.Annotated[bool | None, typer.Option()] = None,
+    baseline_file: typ.Annotated[Path | None, typer.Option()] = None,
 ) -> None:
     """Run cargo llvm-cov and write the output file path to ``GITHUB_OUTPUT``."""
     output_path = output_path or Path(_required_env("INPUT_OUTPUT_PATH"))

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -361,6 +361,37 @@ def _resolve_nextest_config_path() -> Path:
     return NEXTEST_CONFIG_PATH
 
 
+def _resolve_output_path(output_path: Path, lang: str) -> Path:
+    """Return the effective output path, adjusted for mixed-language projects."""
+    if lang == "mixed":
+        return output_path.with_name(f"{output_path.stem}.rust{output_path.suffix}")
+    return output_path
+
+
+def _compute_coverage_percent(fmt: str, out: Path, stdout: str) -> str:
+    """Return the coverage percentage for the given output format."""
+    if fmt == "lcov":
+        return get_line_coverage_percent_from_lcov(out)
+    if fmt == "cobertura":
+        return get_line_coverage_percent_from_cobertura(out)
+    return extract_percent(stdout)
+
+
+def _report_coverage(
+    percent: str,
+    previous: str | None,
+    github_output: Path,
+    out: Path,
+) -> None:
+    """Echo coverage figures and write them to GITHUB_OUTPUT."""
+    typer.echo(f"Current coverage: {percent}%")
+    if previous is not None:
+        typer.echo(f"Previous coverage: {previous}%")
+    with github_output.open("a") as fh:
+        fh.write(f"file={out}\n")
+        fh.write(f"percent={percent}\n")
+
+
 def main(
     output_path: typ.Annotated[
         Path | None, typer.Option(envvar="INPUT_OUTPUT_PATH")
@@ -420,9 +451,7 @@ def main(
         if with_cucumber_rs is None
         else with_cucumber_rs
     )
-    out = output_path
-    if lang == "mixed":
-        out = output_path.with_name(f"{output_path.stem}.rust{output_path.suffix}")
+    out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)
 
     args = get_cargo_coverage_cmd(
@@ -456,21 +485,9 @@ def main(
                 cucumber_rs_features=cucumber_rs_features,
                 cucumber_rs_args=cucumber_rs_args,
             )
-    if fmt == "lcov":
-        percent = get_line_coverage_percent_from_lcov(out)
-    elif fmt == "cobertura":
-        percent = get_line_coverage_percent_from_cobertura(out)
-    else:
-        percent = extract_percent(stdout)
-
-    typer.echo(f"Current coverage: {percent}%")
+    percent = _compute_coverage_percent(fmt, out, stdout)
     previous = read_previous_coverage(baseline_file)
-    if previous is not None:
-        typer.echo(f"Previous coverage: {previous}%")
-
-    with github_output.open("a") as fh:
-        fh.write(f"file={out}\n")
-        fh.write(f"percent={percent}\n")
+    _report_coverage(percent, previous, github_output, out)
 
 
 if __name__ == "__main__":

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -78,19 +78,6 @@ if os.name == "nt":
         elif debug:
             logger.debug("%s has no buffer; leaving as-is", name)
 
-OUTPUT_PATH_OPT = typer.Option(..., envvar="INPUT_OUTPUT_PATH")
-FEATURES_OPT = typer.Option("", envvar="INPUT_FEATURES")
-WITH_DEFAULT_OPT = typer.Option(default=True, envvar="INPUT_WITH_DEFAULT_FEATURES")
-USE_NEXTEST_OPT = typer.Option(default=True, envvar="INPUT_USE_CARGO_NEXTEST")
-LANG_OPT = typer.Option(..., envvar="DETECTED_LANG")
-FMT_OPT = typer.Option(..., envvar="DETECTED_FMT")
-MANIFEST_PATH_OPT = typer.Option(Path("Cargo.toml"), envvar="DETECTED_CARGO_MANIFEST")
-GITHUB_OUTPUT_OPT = typer.Option(..., envvar="GITHUB_OUTPUT")
-CUCUMBER_RS_FEATURES_OPT = typer.Option("", envvar="INPUT_CUCUMBER_RS_FEATURES")
-CUCUMBER_RS_ARGS_OPT = typer.Option("", envvar="INPUT_CUCUMBER_RS_ARGS")
-WITH_CUCUMBER_RS_OPT = typer.Option(default=False, envvar="INPUT_WITH_CUCUMBER_RS")
-BASELINE_OPT = typer.Option(None, envvar="BASELINE_RUST_FILE")
-
 NEXTEST_CONFIG_PATH = Path(".config/nextest.toml")
 NEXTEST_DEFAULT_CONFIG = """[profile.default]
 # Default slow timeout is 180s; nextest sends SIGTERM after the period and
@@ -101,6 +88,21 @@ slow-timeout = { period = "180s", terminate-after = 1, grace-period = "5s" }
 # Put a hard ceiling on the whole run.
 global-timeout = "10m"
 """
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if value:
+        return value
+    typer.echo(f"Missing required environment variable: {name}", err=True)
+    raise typer.Exit(2)
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _run_cargo(
@@ -360,21 +362,64 @@ def _resolve_nextest_config_path() -> Path:
 
 
 def main(
-    output_path: Path = OUTPUT_PATH_OPT,
-    features: str = FEATURES_OPT,
+    output_path: typ.Annotated[
+        Path | None, typer.Option(envvar="INPUT_OUTPUT_PATH")
+    ] = None,
+    features: typ.Annotated[str, typer.Option(envvar="INPUT_FEATURES")] = "",
     *,
-    with_default: bool = WITH_DEFAULT_OPT,
-    use_nextest: bool = USE_NEXTEST_OPT,
-    lang: str = LANG_OPT,
-    fmt: str = FMT_OPT,
-    manifest_path: Path = MANIFEST_PATH_OPT,
-    github_output: Path = GITHUB_OUTPUT_OPT,
-    cucumber_rs_features: str = CUCUMBER_RS_FEATURES_OPT,
-    cucumber_rs_args: str = CUCUMBER_RS_ARGS_OPT,
-    with_cucumber_rs: bool = WITH_CUCUMBER_RS_OPT,
-    baseline_file: Path | None = BASELINE_OPT,
+    with_default: typ.Annotated[
+        bool | None, typer.Option(envvar="INPUT_WITH_DEFAULT_FEATURES")
+    ] = None,
+    use_nextest: typ.Annotated[
+        bool | None, typer.Option(envvar="INPUT_USE_CARGO_NEXTEST")
+    ] = None,
+    lang: typ.Annotated[str | None, typer.Option(envvar="DETECTED_LANG")] = None,
+    fmt: typ.Annotated[str | None, typer.Option(envvar="DETECTED_FMT")] = None,
+    manifest_path: typ.Annotated[
+        Path, typer.Option(envvar="DETECTED_CARGO_MANIFEST")
+    ] = Path("Cargo.toml"),
+    github_output: typ.Annotated[
+        Path | None, typer.Option(envvar="GITHUB_OUTPUT")
+    ] = None,
+    cucumber_rs_features: typ.Annotated[
+        str, typer.Option(envvar="INPUT_CUCUMBER_RS_FEATURES")
+    ] = "",
+    cucumber_rs_args: typ.Annotated[
+        str, typer.Option(envvar="INPUT_CUCUMBER_RS_ARGS")
+    ] = "",
+    with_cucumber_rs: typ.Annotated[
+        bool | None, typer.Option(envvar="INPUT_WITH_CUCUMBER_RS")
+    ] = None,
+    baseline_file: typ.Annotated[
+        Path | None, typer.Option(envvar="BASELINE_RUST_FILE")
+    ] = None,
 ) -> None:
     """Run cargo llvm-cov and write the output file path to ``GITHUB_OUTPUT``."""
+    output_path = output_path or Path(_required_env("INPUT_OUTPUT_PATH"))
+    lang = lang or _required_env("DETECTED_LANG")
+    fmt = fmt or _required_env("DETECTED_FMT")
+    github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
+    features = features or os.getenv("INPUT_FEATURES", "")
+    manifest_path = Path(os.getenv("DETECTED_CARGO_MANIFEST", str(manifest_path)))
+    cucumber_rs_features = cucumber_rs_features or os.getenv(
+        "INPUT_CUCUMBER_RS_FEATURES", ""
+    )
+    cucumber_rs_args = cucumber_rs_args or os.getenv("INPUT_CUCUMBER_RS_ARGS", "")
+    with_default = (
+        _env_bool("INPUT_WITH_DEFAULT_FEATURES", default=True)
+        if with_default is None
+        else with_default
+    )
+    use_nextest = (
+        _env_bool("INPUT_USE_CARGO_NEXTEST", default=True)
+        if use_nextest is None
+        else use_nextest
+    )
+    with_cucumber_rs = (
+        _env_bool("INPUT_WITH_CUCUMBER_RS", default=False)
+        if with_cucumber_rs is None
+        else with_cucumber_rs
+    )
     out = output_path
     if lang == "mixed":
         out = output_path.with_name(f"{output_path.stem}.rust{output_path.suffix}")

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -412,7 +412,8 @@ def main(
     github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
     features = features or os.getenv("INPUT_FEATURES", "")
     if manifest_path is None:
-        manifest_path = Path(os.getenv("DETECTED_CARGO_MANIFEST", "Cargo.toml"))
+        detected_manifest = os.getenv("DETECTED_CARGO_MANIFEST", "").strip()
+        manifest_path = Path(detected_manifest or "Cargo.toml")
     cucumber_rs_features = cucumber_rs_features or os.getenv(
         "INPUT_CUCUMBER_RS_FEATURES", ""
     )

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -398,7 +398,7 @@ def main(
     use_nextest: typ.Annotated[bool | None, typer.Option()] = None,
     lang: typ.Annotated[str | None, typer.Option()] = None,
     fmt: typ.Annotated[str | None, typer.Option()] = None,
-    manifest_path: typ.Annotated[Path, typer.Option()] = Path("Cargo.toml"),
+    manifest_path: typ.Annotated[Path | None, typer.Option()] = None,
     github_output: typ.Annotated[Path | None, typer.Option()] = None,
     cucumber_rs_features: typ.Annotated[str, typer.Option()] = "",
     cucumber_rs_args: typ.Annotated[str, typer.Option()] = "",
@@ -411,8 +411,8 @@ def main(
     fmt = fmt or _required_env("DETECTED_FMT")
     github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
     features = features or os.getenv("INPUT_FEATURES", "")
-    if manifest_path == Path("Cargo.toml"):
-        manifest_path = Path(os.getenv("DETECTED_CARGO_MANIFEST", str(manifest_path)))
+    if manifest_path is None:
+        manifest_path = Path(os.getenv("DETECTED_CARGO_MANIFEST", "Cargo.toml"))
     cucumber_rs_features = cucumber_rs_features or os.getenv(
         "INPUT_CUCUMBER_RS_FEATURES", ""
     )

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -392,6 +392,18 @@ def _report_coverage(
         fh.write(f"percent={percent}\n")
 
 
+def _resolve_bool_input(
+    value: bool | None,  # noqa: FBT001
+    envvar: str,
+    *,
+    default: bool,
+) -> bool:
+    """Return *value* directly when set; otherwise read *envvar* from the environment."""  # noqa: E501
+    if value is not None:
+        return value
+    return _env_bool(envvar, default=default)
+
+
 def main(
     output_path: typ.Annotated[
         Path | None, typer.Option(envvar="INPUT_OUTPUT_PATH")
@@ -436,20 +448,14 @@ def main(
         "INPUT_CUCUMBER_RS_FEATURES", ""
     )
     cucumber_rs_args = cucumber_rs_args or os.getenv("INPUT_CUCUMBER_RS_ARGS", "")
-    with_default = (
-        _env_bool("INPUT_WITH_DEFAULT_FEATURES", default=True)
-        if with_default is None
-        else with_default
+    with_default = _resolve_bool_input(
+        with_default, "INPUT_WITH_DEFAULT_FEATURES", default=True
     )
-    use_nextest = (
-        _env_bool("INPUT_USE_CARGO_NEXTEST", default=True)
-        if use_nextest is None
-        else use_nextest
+    use_nextest = _resolve_bool_input(
+        use_nextest, "INPUT_USE_CARGO_NEXTEST", default=True
     )
-    with_cucumber_rs = (
-        _env_bool("INPUT_WITH_CUCUMBER_RS", default=False)
-        if with_cucumber_rs is None
-        else with_cucumber_rs
+    with_cucumber_rs = _resolve_bool_input(
+        with_cucumber_rs, "INPUT_WITH_CUCUMBER_RS", default=False
     )
     out = _resolve_output_path(output_path, lang)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -411,7 +411,8 @@ def main(
     fmt = fmt or _required_env("DETECTED_FMT")
     github_output = github_output or Path(_required_env("GITHUB_OUTPUT"))
     features = features or os.getenv("INPUT_FEATURES", "")
-    manifest_path = Path(os.getenv("DETECTED_CARGO_MANIFEST", str(manifest_path)))
+    if manifest_path == Path("Cargo.toml"):
+        manifest_path = Path(os.getenv("DETECTED_CARGO_MANIFEST", str(manifest_path)))
     cucumber_rs_features = cucumber_rs_features or os.getenv(
         "INPUT_CUCUMBER_RS_FEATURES", ""
     )

--- a/.github/actions/generate-coverage/tests/__snapshots__/test_scripts.ambr
+++ b/.github/actions/generate-coverage/tests/__snapshots__/test_scripts.ambr
@@ -1,0 +1,8 @@
+# serializer version: 1
+# name: test_run_python_integration_cobertura_success[run_python_cobertura_github_output]
+  '''
+  file=<TMP>/cov.xml
+  percent=100.00
+  
+  '''
+# ---

--- a/.github/actions/generate-coverage/tests/test_common.py
+++ b/.github/actions/generate-coverage/tests/test_common.py
@@ -1,0 +1,148 @@
+"""Unit tests for the shared environment-variable helpers in common.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from common import _env_bool, _required_env  # noqa: I001
+
+
+# ---------------------------------------------------------------------------
+# _required_env
+# ---------------------------------------------------------------------------
+
+
+def test_required_env_returns_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-empty variable value is returned unchanged."""
+    monkeypatch.setenv("TEST_VAR", "hello")
+    assert _required_env("TEST_VAR") == "hello"
+
+
+def test_required_env_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Leading and trailing whitespace is stripped from the returned value."""
+    monkeypatch.setenv("TEST_VAR", "  value  ")
+    assert _required_env("TEST_VAR") == "value"
+
+
+def test_required_env_raises_on_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset variable causes typer.Exit(2)."""
+    monkeypatch.delenv("TEST_VAR", raising=False)
+    with pytest.raises(typer.Exit) as exc_info:
+        _required_env("TEST_VAR")
+    assert exc_info.value.exit_code == 2
+
+
+def test_required_env_raises_on_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty string causes typer.Exit(2)."""
+    monkeypatch.setenv("TEST_VAR", "")
+    with pytest.raises(typer.Exit) as exc_info:
+        _required_env("TEST_VAR")
+    assert exc_info.value.exit_code == 2
+
+
+def test_required_env_raises_on_whitespace_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only value causes typer.Exit(2)."""
+    monkeypatch.setenv("TEST_VAR", "   ")
+    with pytest.raises(typer.Exit) as exc_info:
+        _required_env("TEST_VAR")
+    assert exc_info.value.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# _env_bool - unset / empty returns default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("default", [True, False])
+def test_env_bool_unset_returns_default(
+    monkeypatch: pytest.MonkeyPatch,
+    default: bool,  # noqa: FBT001
+) -> None:
+    """Unset variable returns the supplied default."""
+    monkeypatch.delenv("TEST_BOOL", raising=False)
+    assert _env_bool("TEST_BOOL", default=default) is default
+
+
+@pytest.mark.parametrize("default", [True, False])
+def test_env_bool_empty_returns_default(
+    monkeypatch: pytest.MonkeyPatch,
+    default: bool,  # noqa: FBT001
+) -> None:
+    """Empty string returns the supplied default."""
+    monkeypatch.setenv("TEST_BOOL", "")
+    assert _env_bool("TEST_BOOL", default=default) is default
+
+
+@pytest.mark.parametrize("default", [True, False])
+def test_env_bool_whitespace_only_returns_default(
+    monkeypatch: pytest.MonkeyPatch,
+    default: bool,  # noqa: FBT001
+) -> None:
+    """Whitespace-only value returns the supplied default."""
+    monkeypatch.setenv("TEST_BOOL", "   ")
+    assert _env_bool("TEST_BOOL", default=default) is default
+
+
+# ---------------------------------------------------------------------------
+# _env_bool - truthy values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["1", "true", "True", "TRUE", "yes", "YES", "Yes", "on", "ON", "On"],
+)
+def test_env_bool_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """All recognised truthy string representations return True."""
+    monkeypatch.setenv("TEST_BOOL", value)
+    assert _env_bool("TEST_BOOL", default=False) is True
+
+
+# ---------------------------------------------------------------------------
+# _env_bool - falsy values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "0",
+        "false",
+        "False",
+        "FALSE",
+        "no",
+        "NO",
+        "No",
+        "off",
+        "OFF",
+        "Off",
+    ],
+)
+def test_env_bool_falsy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """All recognised falsy string representations return False."""
+    monkeypatch.setenv("TEST_BOOL", value)
+    assert _env_bool("TEST_BOOL", default=True) is False
+
+
+# ---------------------------------------------------------------------------
+# _env_bool - invalid values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["tru", "ye", "nope", "2", "enable", "enabled"])
+def test_env_bool_invalid_value_raises(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Any non-empty unrecognised value causes typer.Exit(2)."""
+    monkeypatch.setenv("TEST_BOOL", value)
+    with pytest.raises(typer.Exit) as exc_info:
+        _env_bool("TEST_BOOL", default=False)
+    assert exc_info.value.exit_code == 2

--- a/.github/actions/generate-coverage/tests/test_common.py
+++ b/.github/actions/generate-coverage/tests/test_common.py
@@ -152,6 +152,26 @@ def test_env_bool_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> 
     assert _env_bool("TEST_BOOL", default=False) is True
 
 
+def _assert_bool_case_insensitive(
+    value: str,
+    prefix: str,
+    suffix: str,
+    *,
+    default: bool,
+    expected: bool,
+) -> None:
+    """Assert _env_bool handles case variants and surrounding whitespace."""
+    original = os.environ.get("TEST_BOOL")
+    os.environ["TEST_BOOL"] = f"{prefix}{value}{suffix}"
+    try:
+        assert _env_bool("TEST_BOOL", default=default) is expected
+    finally:
+        if original is None:
+            os.environ.pop("TEST_BOOL", None)
+        else:
+            os.environ["TEST_BOOL"] = original
+
+
 @given(
     value=_case_variants(["1", "true", "yes", "on"]),
     prefix=_WHITESPACE,
@@ -163,15 +183,7 @@ def test_env_bool_truthy_values_are_case_insensitive(
     suffix: str,
 ) -> None:
     """Generated casing and surrounding whitespace keep truthy values true."""
-    original = os.environ.get("TEST_BOOL")
-    os.environ["TEST_BOOL"] = f"{prefix}{value}{suffix}"
-    try:
-        assert _env_bool("TEST_BOOL", default=False) is True
-    finally:
-        if original is None:
-            os.environ.pop("TEST_BOOL", None)
-        else:
-            os.environ["TEST_BOOL"] = original
+    _assert_bool_case_insensitive(value, prefix, suffix, default=False, expected=True)
 
 
 # ---------------------------------------------------------------------------
@@ -211,15 +223,7 @@ def test_env_bool_falsy_values_are_case_insensitive(
     suffix: str,
 ) -> None:
     """Generated casing and surrounding whitespace keep falsy values false."""
-    original = os.environ.get("TEST_BOOL")
-    os.environ["TEST_BOOL"] = f"{prefix}{value}{suffix}"
-    try:
-        assert _env_bool("TEST_BOOL", default=True) is False
-    finally:
-        if original is None:
-            os.environ.pop("TEST_BOOL", None)
-        else:
-            os.environ["TEST_BOOL"] = original
+    _assert_bool_case_insensitive(value, prefix, suffix, default=True, expected=False)
 
 
 # ---------------------------------------------------------------------------

--- a/.github/actions/generate-coverage/tests/test_common.py
+++ b/.github/actions/generate-coverage/tests/test_common.py
@@ -10,7 +10,7 @@ import typer
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from common import _env_bool, _required_env  # noqa: I001
+from common import _env_bool, _required_env  # noqa: I001  # path must be patched first
 
 
 # ---------------------------------------------------------------------------

--- a/.github/actions/generate-coverage/tests/test_common.py
+++ b/.github/actions/generate-coverage/tests/test_common.py
@@ -153,16 +153,14 @@ def test_env_bool_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> 
 
 
 def _assert_bool_case_insensitive(
-    value: str,
-    prefix: str,
-    suffix: str,
+    formatted_value: str,
     *,
     default: bool,
     expected: bool,
 ) -> None:
     """Assert _env_bool handles case variants and surrounding whitespace."""
     original = os.environ.get("TEST_BOOL")
-    os.environ["TEST_BOOL"] = f"{prefix}{value}{suffix}"
+    os.environ["TEST_BOOL"] = formatted_value
     try:
         assert _env_bool("TEST_BOOL", default=default) is expected
     finally:
@@ -183,7 +181,9 @@ def test_env_bool_truthy_values_are_case_insensitive(
     suffix: str,
 ) -> None:
     """Generated casing and surrounding whitespace keep truthy values true."""
-    _assert_bool_case_insensitive(value, prefix, suffix, default=False, expected=True)
+    _assert_bool_case_insensitive(
+        f"{prefix}{value}{suffix}", default=False, expected=True
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -223,7 +223,9 @@ def test_env_bool_falsy_values_are_case_insensitive(
     suffix: str,
 ) -> None:
     """Generated casing and surrounding whitespace keep falsy values false."""
-    _assert_bool_case_insensitive(value, prefix, suffix, default=True, expected=False)
+    _assert_bool_case_insensitive(
+        f"{prefix}{value}{suffix}", default=True, expected=False
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/.github/actions/generate-coverage/tests/test_common.py
+++ b/.github/actions/generate-coverage/tests/test_common.py
@@ -2,15 +2,43 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 import pytest
 import typer
+from hypothesis import given
+from hypothesis import strategies as st
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from common import _env_bool, _required_env  # noqa: I001  # path must be patched first
+from common import _env_bool, _required_env
+
+_WHITESPACE = st.text(alphabet=[" ", "\t", "\n", "\r"], max_size=8)
+_VISIBLE_TEXT = st.text(
+    alphabet=st.characters(
+        blacklist_categories=("Cs",),
+        blacklist_characters="\x00",
+    ),
+    min_size=1,
+).filter(lambda value: bool(value.strip()))
+
+
+def _case_variants(values: list[str]) -> st.SearchStrategy[str]:
+    """Return generated upper/lower-case combinations for known values."""
+    return st.sampled_from(values).flatmap(
+        lambda value: st.lists(
+            st.booleans(),
+            min_size=len(value),
+            max_size=len(value),
+        ).map(
+            lambda flags: "".join(
+                char.upper() if make_upper else char.lower()
+                for char, make_upper in zip(value, flags, strict=True)
+            )
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -28,6 +56,24 @@ def test_required_env_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None
     """Leading and trailing whitespace is stripped from the returned value."""
     monkeypatch.setenv("TEST_VAR", "  value  ")
     assert _required_env("TEST_VAR") == "value"
+
+
+@given(prefix=_WHITESPACE, value=_VISIBLE_TEXT, suffix=_WHITESPACE)
+def test_required_env_strips_generated_whitespace(
+    prefix: str,
+    value: str,
+    suffix: str,
+) -> None:
+    """Generated surrounding whitespace is stripped from required env values."""
+    original = os.environ.get("TEST_VAR")
+    os.environ["TEST_VAR"] = f"{prefix}{value}{suffix}"
+    try:
+        assert _required_env("TEST_VAR") == value.strip()
+    finally:
+        if original is None:
+            os.environ.pop("TEST_VAR", None)
+        else:
+            os.environ["TEST_VAR"] = original
 
 
 def test_required_env_raises_on_missing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -106,6 +152,28 @@ def test_env_bool_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> 
     assert _env_bool("TEST_BOOL", default=False) is True
 
 
+@given(
+    value=_case_variants(["1", "true", "yes", "on"]),
+    prefix=_WHITESPACE,
+    suffix=_WHITESPACE,
+)
+def test_env_bool_truthy_values_are_case_insensitive(
+    value: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    """Generated casing and surrounding whitespace keep truthy values true."""
+    original = os.environ.get("TEST_BOOL")
+    os.environ["TEST_BOOL"] = f"{prefix}{value}{suffix}"
+    try:
+        assert _env_bool("TEST_BOOL", default=False) is True
+    finally:
+        if original is None:
+            os.environ.pop("TEST_BOOL", None)
+        else:
+            os.environ["TEST_BOOL"] = original
+
+
 # ---------------------------------------------------------------------------
 # _env_bool - falsy values
 # ---------------------------------------------------------------------------
@@ -130,6 +198,28 @@ def test_env_bool_falsy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> N
     """All recognised falsy string representations return False."""
     monkeypatch.setenv("TEST_BOOL", value)
     assert _env_bool("TEST_BOOL", default=True) is False
+
+
+@given(
+    value=_case_variants(["0", "false", "no", "off"]),
+    prefix=_WHITESPACE,
+    suffix=_WHITESPACE,
+)
+def test_env_bool_falsy_values_are_case_insensitive(
+    value: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    """Generated casing and surrounding whitespace keep falsy values false."""
+    original = os.environ.get("TEST_BOOL")
+    os.environ["TEST_BOOL"] = f"{prefix}{value}{suffix}"
+    try:
+        assert _env_bool("TEST_BOOL", default=True) is False
+    finally:
+        if original is None:
+            os.environ.pop("TEST_BOOL", None)
+        else:
+            os.environ["TEST_BOOL"] = original
 
 
 # ---------------------------------------------------------------------------

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -39,7 +39,7 @@ def _exit_code(exc: BaseException) -> int | None:
 
 
 def run_script(script: Path, env: dict[str, str], *args: str) -> RunResult:
-    """Run ``script`` via ``uv run --script`` with ``env`` and return the result.
+    """Run ``script`` with ``env`` and return the result.
 
     Parameters
     ----------
@@ -48,7 +48,7 @@ def run_script(script: Path, env: dict[str, str], *args: str) -> RunResult:
     env : dict[str, str]
         Environment variables to merge on top of the current environment.
     *args : str
-        Additional positional arguments appended to the ``uv run`` command.
+        Additional positional arguments appended to the Python command.
 
     Returns
     -------
@@ -61,7 +61,7 @@ def run_script(script: Path, env: dict[str, str], *args: str) -> RunResult:
         This helper does not raise for non-zero exits; failures are conveyed
         via the returned exit code and stderr captured from the child process.
     """
-    command = local["uv"]["run", "--script", str(script)]
+    command = local[sys.executable][str(script)]
     if args:
         command = command[list(args)]
     root = Path(__file__).resolve().parents[4]

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -411,6 +411,22 @@ def test_run_rust_uses_detected_manifest_path(
     assert "nextest" not in cargo_args
 
 
+def test_run_rust_omitted_manifest_arg_ignores_blank_detected_manifest(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted manifest CLI arg falls back to Cargo.toml for blank env values."""
+    cargo_args, _out, _gh = _run_rust_coverage_test(
+        tmp_path,
+        shell_stubs,
+        RustCoverageConfig(use_nextest=False, manifest_path=" \t "),
+        monkeypatch=monkeypatch,
+    )
+    mp_idx = cargo_args.index("--manifest-path")
+    assert cargo_args[mp_idx + 1] == "Cargo.toml"
+
+
 @pytest.mark.parametrize(
     "case",
     [
@@ -2723,6 +2739,24 @@ def test_run_python_integration_cobertura_success(
     gh_content = gh.read_text(encoding="utf-8")
     assert "file=" in gh_content, "GITHUB_OUTPUT must contain file= key"
     assert "percent=" in gh_content, "GITHUB_OUTPUT must contain percent= key"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")
+def test_run_python_integration_uses_env_fallbacks_for_omitted_cli_args(
+    tmp_path: Path,
+    shell_stubs: StubManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted CLI args are resolved from GitHub Actions environment variables."""
+    bin_dir, _log = _write_fake_uv(tmp_path)
+    returncode, _stdout, _stderr = _run_integration_script(
+        tmp_path, shell_stubs, bin_dir, monkeypatch
+    )
+
+    gh_content = (tmp_path / "gh.txt").read_text(encoding="utf-8").splitlines()
+    assert returncode == 0
+    assert f"file={tmp_path / 'cov.xml'}" in gh_content
+    assert "percent=100.00" in gh_content
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -24,6 +24,8 @@ from test_support.plumbum_helpers import run_plumbum_command
 if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
     from types import ModuleType
 
+    from syrupy.assertion import SnapshotAssertion
+
     from cmd_utils import RunResult
     from test_support.cmd_mox_stub_adapter import StubManager
 else:
@@ -2708,6 +2710,7 @@ def test_run_python_integration_cobertura_success(
     tmp_path: Path,
     shell_stubs: StubManager,
     monkeypatch: pytest.MonkeyPatch,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """run_python.py creates the venv, syncs deps, installs tooling.
 
@@ -2733,12 +2736,12 @@ def test_run_python_integration_cobertura_success(
     assert "slipcover" in pip_args
     assert "pytest" in pip_args
     assert "coverage" in pip_args
-    # Verify GITHUB_OUTPUT was written with expected keys
     gh = tmp_path / "gh.txt"
     assert gh.exists(), "GITHUB_OUTPUT file must be written"
     gh_content = gh.read_text(encoding="utf-8")
-    assert "file=" in gh_content, "GITHUB_OUTPUT must contain file= key"
-    assert "percent=" in gh_content, "GITHUB_OUTPUT must contain percent= key"
+    assert gh_content.replace(tmp_path.as_posix(), "<TMP>") == snapshot(
+        name="run_python_cobertura_github_output"
+    )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fake uv helper emits POSIX sh")

--- a/.github/actions/linux-packages/action.yml
+++ b/.github/actions/linux-packages/action.yml
@@ -132,7 +132,7 @@ runs:
             | tar xf - -C _self
         fi
     - name: Setup uv
-      uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
     - name: Install nfpm
       uses: ./_self/.github/actions/install-nfpm
     - name: Build Linux packages

--- a/.github/actions/macos-package/action.yml
+++ b/.github/actions/macos-package/action.yml
@@ -50,7 +50,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
     - name: Ensure macOS runner
       shell: bash
       run: uv run "${{ github.action_path }}/scripts/check_platform.py"

--- a/.github/actions/ratchet-coverage/action.yml
+++ b/.github/actions/ratchet-coverage/action.yml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         uv-version: ">=0.7.19,<0.8.0"
         cache-dependency-glob: |

--- a/.github/actions/release-to-pypi-uv/action.yml
+++ b/.github/actions/release-to-pypi-uv/action.yml
@@ -53,8 +53,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      # v6.4.3
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         python-version: ${{ inputs.python-version }}
         cache-dependency-glob: |

--- a/.github/actions/release-to-pypi-uv/scripts/publish_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/publish_release.py
@@ -83,7 +83,10 @@ def cli(
     index: typ.Annotated[
         str | None,
         typer.Option(
-            help="Optional index name or URL for uv publish.",
+            help=(
+                "Optional index name or URL for uv publish. If not provided, "
+                "falls back to the INPUT_UV_INDEX environment variable."
+            ),
         ),
     ] = None,
 ) -> None:

--- a/.github/actions/release-to-pypi-uv/scripts/publish_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/publish_release.py
@@ -11,6 +11,7 @@ import contextlib
 import os
 import shutil
 import sys
+import typing as typ
 from pathlib import Path
 
 import typer
@@ -61,12 +62,6 @@ _extend_sys_path()
 
 run_cmd = import_cmd_utils().run_cmd
 
-INDEX_OPTION = typer.Option(
-    "",
-    envvar="INPUT_UV_INDEX",
-    help="Optional index name or URL for uv publish.",
-)
-
 
 def main(index: str = "") -> None:
     """Publish the built distributions with uv.
@@ -84,9 +79,17 @@ def main(index: str = "") -> None:
         run_cmd(local["uv"]["publish"])
 
 
-def cli(index: str = INDEX_OPTION) -> None:
+def cli(
+    index: typ.Annotated[
+        str,
+        typer.Option(
+            envvar="INPUT_UV_INDEX",
+            help="Optional index name or URL for uv publish.",
+        ),
+    ] = "",
+) -> None:
     """CLI entrypoint."""
-    main(index=index)
+    main(index=index or os.getenv("INPUT_UV_INDEX", ""))
 
 
 if __name__ == "__main__":

--- a/.github/actions/release-to-pypi-uv/scripts/publish_release.py
+++ b/.github/actions/release-to-pypi-uv/scripts/publish_release.py
@@ -81,15 +81,14 @@ def main(index: str = "") -> None:
 
 def cli(
     index: typ.Annotated[
-        str,
+        str | None,
         typer.Option(
-            envvar="INPUT_UV_INDEX",
             help="Optional index name or URL for uv publish.",
         ),
-    ] = "",
+    ] = None,
 ) -> None:
     """CLI entrypoint."""
-    main(index=index or os.getenv("INPUT_UV_INDEX", ""))
+    main(index=index if index is not None else os.getenv("INPUT_UV_INDEX", ""))
 
 
 if __name__ == "__main__":

--- a/.github/actions/rust-build-release/action.yml
+++ b/.github/actions/rust-build-release/action.yml
@@ -36,8 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      # v6.6.1
-      uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
     - name: Validate target
       shell: bash
       run: |

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -604,6 +604,13 @@ def _manifest_argument(manifest_path: Path) -> Path:
         return manifest_path
 
 
+def _resolve_env_backed_option(value: str | None, envvar: str) -> str:
+    """Return the explicit option value, or the environment fallback."""
+    if value is not None:
+        return value
+    return os.getenv(envvar, "")
+
+
 @app.command()
 def main(
     target: typ.Annotated[str, typer.Argument(help="Target triple to build")] = "",
@@ -625,8 +632,8 @@ def main(
     """Build the project for *target* using *toolchain*."""
     target_to_build = _resolve_target_argument(target)
     manifest_path = _resolve_manifest_path()
-    resolved_features: str = features if features is not None else ""
-    resolved_toolchain: str = toolchain if toolchain is not None else ""
+    resolved_features = _resolve_env_backed_option(features, "RBR_FEATURES")
+    resolved_toolchain = _resolve_env_backed_option(toolchain, "RBR_TOOLCHAIN")
     explicit_toolchain = resolved_toolchain.strip()
     requested_toolchain = explicit_toolchain or resolve_requested_toolchain(
         explicit_toolchain,

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -620,6 +620,7 @@ def main(
 ) -> None:
     """Build the project for *target* using *toolchain*."""
     target_to_build = _resolve_target_argument(target)
+    features = features or os.getenv("RBR_FEATURES", "")
     manifest_path = _resolve_manifest_path()
     explicit_toolchain = toolchain.strip()
     requested_toolchain = explicit_toolchain or resolve_requested_toolchain(

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -607,21 +607,26 @@ def _manifest_argument(manifest_path: Path) -> Path:
 @app.command()
 def main(
     target: str = typer.Argument("", help="Target triple to build"),
-    toolchain: str = typer.Option(
-        "",
-        envvar="RBR_TOOLCHAIN",
-        help="Rust toolchain version override",
-    ),
-    features: str = typer.Option(
-        "",
-        envvar="RBR_FEATURES",
-        help="Comma-separated list of Cargo features to enable",
-    ),
+    toolchain: typ.Annotated[
+        str | None,
+        typer.Option(
+            envvar="RBR_TOOLCHAIN",
+            help="Rust toolchain version override",
+        ),
+    ] = None,
+    features: typ.Annotated[
+        str | None,
+        typer.Option(
+            envvar="RBR_FEATURES",
+            help="Comma-separated list of Cargo features to enable",
+        ),
+    ] = None,
 ) -> None:
     """Build the project for *target* using *toolchain*."""
     target_to_build = _resolve_target_argument(target)
-    features = features or os.getenv("RBR_FEATURES", "")
+    features = os.getenv("RBR_FEATURES", "") if features is None else features
     manifest_path = _resolve_manifest_path()
+    toolchain = os.getenv("RBR_TOOLCHAIN", "") if toolchain is None else toolchain
     explicit_toolchain = toolchain.strip()
     requested_toolchain = explicit_toolchain or resolve_requested_toolchain(
         explicit_toolchain,

--- a/.github/actions/rust-build-release/src/main.py
+++ b/.github/actions/rust-build-release/src/main.py
@@ -606,7 +606,7 @@ def _manifest_argument(manifest_path: Path) -> Path:
 
 @app.command()
 def main(
-    target: str = typer.Argument("", help="Target triple to build"),
+    target: typ.Annotated[str, typer.Argument(help="Target triple to build")] = "",
     toolchain: typ.Annotated[
         str | None,
         typer.Option(
@@ -624,10 +624,10 @@ def main(
 ) -> None:
     """Build the project for *target* using *toolchain*."""
     target_to_build = _resolve_target_argument(target)
-    features = os.getenv("RBR_FEATURES", "") if features is None else features
     manifest_path = _resolve_manifest_path()
-    toolchain = os.getenv("RBR_TOOLCHAIN", "") if toolchain is None else toolchain
-    explicit_toolchain = toolchain.strip()
+    resolved_features: str = features if features is not None else ""
+    resolved_toolchain: str = toolchain if toolchain is not None else ""
+    explicit_toolchain = resolved_toolchain.strip()
     requested_toolchain = explicit_toolchain or resolve_requested_toolchain(
         explicit_toolchain,
         project_dir=Path.cwd(),
@@ -666,7 +666,7 @@ def main(
     manifest_argument = _manifest_argument(manifest_path)
     if decision.use_cross:
         build_cmd = _build_cross_command(
-            decision, target_to_build, manifest_argument, features
+            decision, target_to_build, manifest_argument, resolved_features
         )
         if explicit_toolchain:
             build_cmd = typ.cast("_SupportsEnvFormulate", build_cmd).with_env(
@@ -674,13 +674,16 @@ def main(
             )
     else:
         build_cmd = _build_cargo_command(
-            decision.cargo_toolchain_spec, target_to_build, manifest_argument, features
+            decision.cargo_toolchain_spec,
+            target_to_build,
+            manifest_argument,
+            resolved_features,
         )
     try:
         run_cmd(build_cmd)
     except ProcessExecutionError as exc:
         _handle_cross_container_error(
-            exc, decision, target_to_build, manifest_argument, features
+            exc, decision, target_to_build, manifest_argument, resolved_features
         )
     finally:
         _restore_container_engine(previous_engine, applied_engine=applied_engine)

--- a/.github/actions/rust-build-release/tests/conftest.py
+++ b/.github/actions/rust-build-release/tests/conftest.py
@@ -137,6 +137,8 @@ def _load_module(
     deps: cabc.Sequence[tuple[str, str | None]] = (),
 ) -> ModuleType:
     prepend_to_syspath(SRC_DIR)
+    for sibling in ("cross_manager", "runtime", "toolchain", "utils"):
+        sys.modules.pop(sibling, None)
     for dep_name, attr in deps:
         _ensure_dependency(dep_name, attr)
     module_path = SRC_DIR / filename

--- a/.github/actions/rust-build-release/tests/test_features.py
+++ b/.github/actions/rust-build-release/tests/test_features.py
@@ -388,7 +388,8 @@ class TestFeaturesEnvVar:
         runner = CliRunner()
         result = runner.invoke(
             context.main_module.app,
-            [target, "--toolchain", "stable", "--features", "env-feature"],
+            [target, "--toolchain", "stable"],
+            env={"RBR_FEATURES": "env-feature"},
         )
 
         assert result.exit_code == 0

--- a/.github/actions/rust-build-release/tests/test_features.py
+++ b/.github/actions/rust-build-release/tests/test_features.py
@@ -6,6 +6,7 @@ import dataclasses
 import typing as typ
 
 import pytest
+import typer
 from plumbum.commands.processes import ProcessExecutionError
 from rust_build_release_test_helpers import assert_no_toolchain_override
 
@@ -357,15 +358,12 @@ class TestFeaturesEnvVar:
     def test_features_from_environment(
         self,
         main_features_context: MainFeaturesContext,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Features can be set via RBR_FEATURES environment variable."""
         context = main_features_context
         harness = context.harness
         captured: dict[str, object] = {}
         target = "x86_64-unknown-linux-gnu"
-
-        monkeypatch.setenv("RBR_FEATURES", "env-feature")
 
         decision = context.cross_decision_factory(context.main_module, use_cross=False)
         harness.patch_attr("_resolve_target_argument", lambda _value: target)
@@ -379,13 +377,21 @@ class TestFeaturesEnvVar:
 
         harness.patch_attr("_build_cargo_command", fake_cargo)
 
-        # Invoke via typer app to properly read environment variables
         from typer.testing import CliRunner
 
-        runner = CliRunner()
-        runner.invoke(context.main_module.app, [target, "--toolchain", "stable"])
+        command = typer.main.get_command(context.main_module.app)
+        features_option = next(
+            param for param in command.params if param.name == "features"
+        )
+        assert features_option.envvar == "RBR_FEATURES"
 
-        # The environment variable should be used - check captured value
+        runner = CliRunner()
+        result = runner.invoke(
+            context.main_module.app,
+            [target, "--toolchain", "stable", "--features", "env-feature"],
+        )
+
+        assert result.exit_code == 0
         assert captured.get("features") == "env-feature"
 
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -98,8 +98,7 @@ runs:
         echo "cargo-binstall $(cargo-binstall -V) verified"
       shell: bash
     - name: Install uv
-      # v6.4.3
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         cache-dependency-glob: |
           **/pyproject.toml

--- a/.github/actions/stage-release-artefacts/action.yml
+++ b/.github/actions/stage-release-artefacts/action.yml
@@ -61,7 +61,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: false
 

--- a/.github/actions/upload-release-assets/action.yml
+++ b/.github/actions/upload-release-assets/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: false
 

--- a/.github/actions/validate-linux-packages/action.yml
+++ b/.github/actions/validate-linux-packages/action.yml
@@ -71,7 +71,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
     - name: Install sandbox dependencies
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
         # v4
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup uv
-        # v6.4.3
-        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: '3.13'
           cache-dependency-glob: |
@@ -71,8 +70,7 @@ jobs:
         # v4
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup uv
-        # v6.4.3
-        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: '3.13'
           cache-dependency-glob: |

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Setup uv
         if: ${{ env.ACT != 'true' }}
-        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: '3.13'
           cache-dependency-glob: |

--- a/.github/workflows/rust-toy-app.yml
+++ b/.github/workflows/rust-toy-app.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup uv
-        # v6.4.3
-        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: '3.13'
       - name: Extract crate version

--- a/.github/workflows/test-rust-build-release-root-discovery.yml
+++ b/.github/workflows/test-rust-build-release-root-discovery.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: false
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ clean: ## Remove transient artefacts
 
 BUILD_JOBS ?=
 ACTION_VALIDATOR ?= $(or $(firstword $(wildcard $(HOME)/.bun/bin/action-validator) $(wildcard $(HOME)/.cargo/bin/action-validator)),action-validator)
+ACT ?= $(or $(firstword $(wildcard $(HOME)/go/bin/act) $(wildcard $(HOME)/.local/bin/act)),act)
 MDLINT ?= $(if $(wildcard $(HOME)/.bun/bin/markdownlint),$(HOME)/.bun/bin/markdownlint,markdownlint)
 MARKDOWNLINT_BASE ?= origin/main
 NIXIE ?= nixie
@@ -25,7 +26,7 @@ test: .venv ## Run tests
 	$(UV) run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist --with pytest-bdd --with syrupy --with hypothesis pytest -n auto --dist worksteal -v
 # Truthy values: 1, true, TRUE, True, yes, YES, Yes, on, ON, On
 ifneq ($(strip $(filter 1 true TRUE True yes YES Yes on ON On,$(ACT_WORKFLOW_TESTS))),)
-	ACT_WORKFLOW_TESTS=1 $(UV) run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist --with pytest-bdd --with syrupy --with hypothesis pytest tests/workflows -v
+	ACT='$(ACT)' ACT_WORKFLOW_TESTS=1 $(UV) run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist --with pytest-bdd --with syrupy --with hypothesis pytest tests/workflows -v
 endif
 
 .venv:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -97,7 +97,9 @@ to bare names on `PATH`.
 | Variable | Default resolution order |
 | --- | --- |
 | `UV` | `~/.local/bin/uv` if present, otherwise `uv` |
+<!-- markdownlint-disable MD013 -->
 | `ACT` | `~/go/bin/act` if present, then `~/.local/bin/act` if present, otherwise `act` |
+<!-- markdownlint-enable MD013 -->
 | `ACTION_VALIDATOR` | Bun install, then Cargo install, then `PATH` |
 | `MDLINT` | `~/.bun/bin/markdownlint` if present, otherwise `markdownlint` |
 | `MARKDOWNLINT_BASE` | `origin/main` |
@@ -245,12 +247,14 @@ pytest -o log_cli=true --log-level=DEBUG
 The workflow test harness determines whether `act` and a compatible container
 runtime are available before running tests. The probe result is represented by:
 
+<!-- markdownlint-disable MD013 -->
 | Symbol | Type | Role |
-|---|---|---|
+| --- | --- | --- |
 | `ActRuntimeStatus` | frozen dataclass | Holds `available: bool`, `reason: str`, `env: dict[str, str]`. |
 | `_probe_act_runtime` | `(environ?) -> ActRuntimeStatus` | Execute a fresh probe against the given environment mapping (defaults to `os.environ`). |
 | `_get_act_runtime_status` | `() -> ActRuntimeStatus` | Return the cached probe result, performing the probe on first call. |
 | `_act_command` | `(environ?) -> str` | Return the act executable path from the `ACT` environment variable, defaulting to `"act"`. |
+<!-- markdownlint-enable MD013 -->
 
 `_get_act_runtime_status` is decorated with `@functools.cache` so the probe
 runs at most once per process. Tests that need to observe a different runtime
@@ -263,10 +267,12 @@ when a healthy Podman socket is discovered automatically.
 
 ### Skip Markers
 
+<!-- markdownlint-disable MD013 -->
 | Marker | Condition |
-|---|---|
+| --- | --- |
 | `skip_unless_act` | Skip when `_get_act_runtime_status().available` is `False`. |
 | `skip_unless_workflow_tests` | Skip when `ACT_WORKFLOW_TESTS` is not set to a truthy value. |
+<!-- markdownlint-enable MD013 -->
 
 ## Running the Test Suite
 
@@ -312,7 +318,7 @@ change in the Docker bind-mount target directory (e.g. between cached and
 uncached CI runs) forces the build script to rerun and regenerate the man page
 at the correct stable path.
 
-### Observability
+### Build Observability
 
 `build.rs` emits a `cargo:warning=writing man page to ...` diagnostic so that
 the chosen stable path is visible in the `cargo build` log. The staging step

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -97,6 +97,7 @@ to bare names on `PATH`.
 | Variable | Default resolution order |
 | --- | --- |
 | `UV` | `~/.local/bin/uv` if present, otherwise `uv` |
+| `ACT` | `~/go/bin/act` if present, then `~/.local/bin/act` if present, otherwise `act` |
 | `ACTION_VALIDATOR` | Bun install, then Cargo install, then `PATH` |
 | `MDLINT` | `~/.bun/bin/markdownlint` if present, otherwise `markdownlint` |
 | `MARKDOWNLINT_BASE` | `origin/main` |
@@ -109,6 +110,7 @@ Override example:
 
 ```bash
 make lint UV=uv MARKDOWNLINT_BASE=origin/develop
+make test ACT=/usr/local/bin/act
 ```
 
 ## `setup-rust` cargo-binstall Pinning
@@ -217,6 +219,36 @@ enable DEBUG output during local investigation or CI repro jobs:
 ```bash
 pytest -o log_cli=true --log-level=DEBUG
 ```
+
+## Workflow Test Harness (`tests/workflows/conftest.py`)
+
+### Runtime Probing
+
+The workflow test harness determines whether `act` and a compatible container
+runtime are available before running tests. The probe result is represented by:
+
+| Symbol | Type | Role |
+|---|---|---|
+| `ActRuntimeStatus` | frozen dataclass | Holds `available: bool`, `reason: str`, `env: dict[str, str]`. |
+| `_probe_act_runtime` | `(environ?) -> ActRuntimeStatus` | Execute a fresh probe against the given environment mapping (defaults to `os.environ`). |
+| `_get_act_runtime_status` | `() -> ActRuntimeStatus` | Return the cached probe result, performing the probe on first call. |
+| `_act_command` | `(environ?) -> str` | Return the act executable path from the `ACT` environment variable, defaulting to `"act"`. |
+
+`_get_act_runtime_status` is decorated with `@functools.cache` so the probe
+runs at most once per process. Tests that need to observe a different runtime
+environment must call `_probe_act_runtime(environ)` directly with an explicit
+mapping, bypassing the cache.
+
+`ActRuntimeStatus.env` carries any additional environment variables that must
+be injected into the `act` subprocess - currently used to forward `DOCKER_HOST`
+when a healthy Podman socket is discovered automatically.
+
+### Skip Markers
+
+| Marker | Condition |
+|---|---|
+| `skip_unless_act` | Skip when `_get_act_runtime_status().available` is `False`. |
+| `skip_unless_workflow_tests` | Skip when `ACT_WORKFLOW_TESTS` is not set to a truthy value. |
 
 ## Running the Test Suite
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -113,6 +113,24 @@ make lint UV=uv MARKDOWNLINT_BASE=origin/develop
 make test ACT=/usr/local/bin/act
 ```
 
+## `setup-uv` Pinning
+
+Actions and workflows in this repository consume `astral-sh/setup-uv` by full
+commit SHA rather than by mutable version tags. This follows the repository
+security rule for third-party actions: callers should execute a reviewed Git
+object, not whatever a tag happens to resolve to later.
+
+Keep all `setup-uv` references on the same SHA unless there is a deliberate
+compatibility reason to split them. A pin update is repository-wide maintenance:
+search for `astral-sh/setup-uv@`, update every matching action or workflow
+reference together, and run the normal action test gates before review.
+
+When changing the pin, include the target SHA in the change description and
+verify affected act workflow tests where the action runs under `nektos/act`.
+If act cannot execute the real `setup-uv` path on the local runner, document
+the reason and keep the unit or manifest tests that assert the pinned reference
+in sync with the new SHA.
+
 ## `setup-rust` cargo-binstall Pinning
 
 The `setup-rust` action pins `cargo-binstall` by downloading

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -187,10 +187,12 @@ handling so error messages and exit codes are consistent across all scripts.
 
 ### Public API
 
+<!-- markdownlint-disable MD013 -->
 | Symbol | Signature | Role |
-|---|---|---|
+| --- | --- | --- |
 | `_required_env` | `(name: str) -> str` | Return the non-empty value of a required env var or exit with code 2. |
 | `_env_bool` | `(name: str, *, default: bool) -> bool` | Parse a boolean env var; raise `typer.Exit(2)` for unrecognized non-empty values. |
+<!-- markdownlint-enable MD013 -->
 
 `_required_env` trims whitespace before testing emptiness so a variable set to
 only spaces is treated as absent.
@@ -267,7 +269,7 @@ GitHub Actions executes action steps sequentially in a single thread. The
 `functools.lru_cache` memoized `_coverage_python_cmd()` accessor therefore
 requires no explicit synchronization.
 
-### Public API
+### Coverage Venv API
 
 <!-- markdownlint-disable MD013 MD060 -->
 | Symbol | Role |

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -177,8 +177,46 @@ If the repository ever needs finer-grained handling, the next step would be a
 real TOML parser plus table-aware resolution. The current design intentionally
 stops short of that complexity.
 
+## Shared Script Helpers (`common.py`)
+
+### Purpose
+
+`common.py` is a shared utility module imported by `run_rust.py`,
+`run_python.py`, and `merge_cobertura.py`. It centralises environment-variable
+handling so error messages and exit codes are consistent across all scripts.
+
+### Public API
+
+| Symbol | Signature | Role |
+|---|---|---|
+| `_required_env` | `(name: str) -> str` | Return the non-empty value of a required env var or exit with code 2. |
+| `_env_bool` | `(name: str, *, default: bool) -> bool` | Parse a boolean env var; raise `typer.Exit(2)` for unrecognised non-empty values. |
+
+`_required_env` trims whitespace before testing emptiness so a variable set to
+only spaces is treated as absent.
+
+`_env_bool` accepts the following case-insensitive truthy values: `1`, `true`,
+`yes`, `on`; and the following falsy values: `0`, `false`, `no`, `off`. Any
+other non-empty value causes the script to print a diagnostic to stderr and
+exit with code 2.
+
+### Design Rationale
+
+Prior to `common.py` each script declared its own inline `_required_env`
+helper, leading to divergent exit codes and error messages. Centralising the
+helper ensures that a missing required variable always produces a message of
+the form `Missing required environment variable: NAME` and exits with code 2,
+regardless of which script is running.
+
+Boolean environment variables similarly used Typer's built-in `envvar`
+binding, which silently accepted any non-empty string as truthy. `_env_bool`
+replaces that path to provide an explicit rejection of unrecognised values.
+
 ## Roadmap
 
+- [x] Centralise environment-variable parsing helpers (`_required_env`,
+  `_env_bool`) into `common.py` so error messages and exit codes are
+  consistent across all generate-coverage scripts.
 - [x] Extend artefact naming to include platform metadata and support custom
   suffixes.
 - [x] Document the Rust coverage environment-override design for

--- a/docs/generate-coverage-design.md
+++ b/docs/generate-coverage-design.md
@@ -182,7 +182,7 @@ stops short of that complexity.
 ### Purpose
 
 `common.py` is a shared utility module imported by `run_rust.py`,
-`run_python.py`, and `merge_cobertura.py`. It centralises environment-variable
+`run_python.py`, and `merge_cobertura.py`. It centralizes environment-variable
 handling so error messages and exit codes are consistent across all scripts.
 
 ### Public API
@@ -190,7 +190,7 @@ handling so error messages and exit codes are consistent across all scripts.
 | Symbol | Signature | Role |
 |---|---|---|
 | `_required_env` | `(name: str) -> str` | Return the non-empty value of a required env var or exit with code 2. |
-| `_env_bool` | `(name: str, *, default: bool) -> bool` | Parse a boolean env var; raise `typer.Exit(2)` for unrecognised non-empty values. |
+| `_env_bool` | `(name: str, *, default: bool) -> bool` | Parse a boolean env var; raise `typer.Exit(2)` for unrecognized non-empty values. |
 
 `_required_env` trims whitespace before testing emptiness so a variable set to
 only spaces is treated as absent.
@@ -203,18 +203,18 @@ exit with code 2.
 ### Design Rationale
 
 Prior to `common.py` each script declared its own inline `_required_env`
-helper, leading to divergent exit codes and error messages. Centralising the
+helper, leading to divergent exit codes and error messages. Centralizing the
 helper ensures that a missing required variable always produces a message of
 the form `Missing required environment variable: NAME` and exits with code 2,
 regardless of which script is running.
 
 Boolean environment variables similarly used Typer's built-in `envvar`
 binding, which silently accepted any non-empty string as truthy. `_env_bool`
-replaces that path to provide an explicit rejection of unrecognised values.
+replaces that path to provide an explicit rejection of unrecognized values.
 
 ## Roadmap
 
-- [x] Centralise environment-variable parsing helpers (`_required_env`,
+- [x] Centralize environment-variable parsing helpers (`_required_env`,
   `_env_bool`) into `common.py` so error messages and exit codes are
   consistent across all generate-coverage scripts.
 - [x] Extend artefact naming to include platform metadata and support custom

--- a/docs/local-validation-of-github-actions-with-act-and-pytest.md
+++ b/docs/local-validation-of-github-actions-with-act-and-pytest.md
@@ -30,7 +30,7 @@ command interception is intentionally avoided; containers execute in isolation.
   3. Commands that talk to the socket (such as `act …` or the pytest harness)
      run with permission to access it. In this repo, use
      `ACT_WORKFLOW_TESTS=1 sudo -E make test` to exercise the workflow harness
-     when your sandbox requires elevated runtime access.
+     when the sandbox requires elevated runtime access.
   4. The release workflow now redirects `uv` caches and the project virtualenv
      to `/tmp` when it detects it is running under `act`, so the container no
      longer leaves root-owned files in the workspace. If residue from older runs

--- a/docs/local-validation-of-github-actions-with-act-and-pytest.md
+++ b/docs/local-validation-of-github-actions-with-act-and-pytest.md
@@ -22,10 +22,16 @@ command interception is intentionally avoided; containers execute in isolation.
 - When developing inside a sandbox (for example, this Codex CLI), ensure the
   container runtime socket is reachable. On Fedora/Podman that normally means:
   1. `systemctl --user status podman.socket` reports `active (listening)`.
-  2. Commands that talk to the socket (such as `podman info`, `act …`, or the
-     pytest harness) run with escalated permissions. In this repo, use
-     `ACT_WORKFLOW_TESTS=1 sudo -E make test` to exercise the workflow harness.
-  3. The release workflow now redirects `uv` caches and the project virtualenv
+  2. The Docker-compatible Podman API can list all containers. The pytest
+     harness checks `GET /v1.41/containers/json?all=true`, because this is the
+     path `act` uses before starting a job. If the API returns
+     `container not known`, repair or remove stale Podman containers stuck in
+     `Removing` state before rerunning.
+  3. Commands that talk to the socket (such as `act …` or the pytest harness)
+     run with permission to access it. In this repo, use
+     `ACT_WORKFLOW_TESTS=1 sudo -E make test` to exercise the workflow harness
+     when your sandbox requires elevated runtime access.
+  4. The release workflow now redirects `uv` caches and the project virtualenv
      to `/tmp` when it detects it is running under `act`, so the container no
      longer leaves root-owned files in the workspace. If residue from older runs
      remains, remove the `.venv` or `.uv-*` directories once, then re-run.
@@ -181,7 +187,8 @@ def test_workflow_produces_expected_artefact_and_logs(tmp_path: Path) -> None:
 
 Because the test launches containers, it requires the same Podman/Docker setup
 described in the prerequisites. The harness skips automatically when the
-runtime or socket is unavailable, but to _run_ it you must opt in:
+runtime, socket, or Docker-compatible container listing API is unavailable, but
+to _run_ it you must opt in:
 
 ```bash
 # Inside a sandbox where podman requires sudo:

--- a/docs/local-validation-of-github-actions-with-act-and-pytest.md
+++ b/docs/local-validation-of-github-actions-with-act-and-pytest.md
@@ -23,13 +23,13 @@ command interception is intentionally avoided; containers execute in isolation.
   container runtime socket is reachable. On Fedora/Podman that normally means:
   1. `systemctl --user status podman.socket` reports `active (listening)`.
   2. The Docker-compatible Podman API can list all containers. The pytest
-     harness checks `GET /v1.41/containers/json?all=true`, because this is the
+     harness checks `GET /v1.41/containers/json?all=true` because this is the
      path `act` uses before starting a job. If the API returns
      `container not known`, repair or remove stale Podman containers stuck in
      `Removing` state before rerunning.
   3. Commands that talk to the socket (such as `act …` or the pytest harness)
-     run with permission to access it. In this repo, use
-     `ACT_WORKFLOW_TESTS=1 sudo -E make test` to exercise the workflow harness
+     run with permission to access it. In this repo,
+     `ACT_WORKFLOW_TESTS=1 sudo -E make test` exercises the workflow harness
      when the sandbox requires elevated runtime access.
   4. The release workflow now redirects `uv` caches and the project virtualenv
      to `/tmp` when it detects it is running under `act`, so the container no
@@ -188,7 +188,7 @@ def test_workflow_produces_expected_artefact_and_logs(tmp_path: Path) -> None:
 Because the test launches containers, it requires the same Podman/Docker setup
 described in the prerequisites. The harness skips automatically when the
 runtime, socket, or Docker-compatible container listing API is unavailable, but
-to _run_ it you must opt in:
+running it requires opting in:
 
 ```bash
 # Inside a sandbox where podman requires sudo:

--- a/docs/python-action-scripts.md
+++ b/docs/python-action-scripts.md
@@ -48,3 +48,18 @@ parameters, so the scripts remain declarative and free of ad-hoc parsing logic.
 The [plumbum](https://plumbum.readthedocs.io/) library is used for invoking
 external commands through the shared `run_cmd` helper, which prints each command
 before execution to aid debugging.
+
+## Testing Action Scripts
+
+Action scripts are tested by the pytest suite in their action's `tests/`
+directory. The test helper `run_script` in
+`.github/actions/generate-coverage/tests/test_scripts.py` executes scripts
+directly with the current test interpreter (`sys.executable`) rather than via
+`uv run --script`. This ensures that the `cmd_mox` IPC stubs registered by the
+test fixture are available inside the script process, because the script
+inherits the same virtual environment that pytest is running in.
+
+Scripts still declare their runtime requirements in a PEP 723 `/// script`
+header for production use via `uv run --script`. All dependencies declared
+there must also be present in the project's development virtual environment so
+both production and test execution paths work correctly.

--- a/rust-toy-app/build.rs
+++ b/rust-toy-app/build.rs
@@ -5,10 +5,6 @@ use std::env;
 use std::path::PathBuf;
 use time::OffsetDateTime;
 
-#[expect(
-    dead_code,
-    reason = "the build script includes the CLI module only to render clap metadata"
-)]
 #[path = "src/cli.rs"]
 mod cli;
 

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -48,11 +48,6 @@ def _command_available(command: str) -> bool:
     return shutil.which(command) is not None
 
 
-def _act_available() -> bool:
-    """Return True if act is installed and runnable."""
-    return _command_available(_act_command())
-
-
 def _default_podman_socket(environ: cabc.Mapping[str, str]) -> Path:
     """Return the default rootless Podman Docker-compatible socket path."""
     runtime_dir = environ.get("XDG_RUNTIME_DIR")
@@ -112,15 +107,6 @@ def _docker_host_usable(docker_host: str) -> tuple[bool, str]:
         detail = body.strip() or f"HTTP {status}"
         return False, f"Docker API cannot list containers: {detail}"
     return True, ""
-
-
-def _container_runtime_available() -> bool:
-    """Return True if a container runtime (docker/podman) is available.
-
-    Probes lazily so callers that modify ACT, DOCKER_HOST or related
-    environment variables after import see the updated configuration.
-    """
-    return _probe_act_runtime().available
 
 
 def _command_succeeds(command: str, *args: str) -> bool:
@@ -198,6 +184,18 @@ def _get_act_runtime_status() -> ActRuntimeStatus:
     or related environment variables see the updated configuration.
     """
     return _probe_act_runtime()
+
+
+@pytest.fixture(autouse=True)
+def _reset_act_runtime_cache() -> typ.Generator[None, None, None]:
+    """Clear the cached act runtime probe result after each test.
+
+    Ensures that tests which modify ``ACT``, ``DOCKER_HOST``, or related
+    environment variables via monkeypatch do not have their changes obscured
+    by a stale cached result from a prior test.
+    """
+    yield
+    _get_act_runtime_status.cache_clear()
 
 
 def _workflow_tests_enabled() -> bool:

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -205,15 +205,27 @@ def _workflow_tests_enabled() -> bool:
     return coerce_bool(os.environ.get("ACT_WORKFLOW_TESTS"), default=False)
 
 
-skip_unless_act = pytest.mark.skipif(
-    not _get_act_runtime_status().available,
-    reason=_get_act_runtime_status().reason or "act or container runtime not available",
-)
+skip_unless_act = pytest.mark.skip_unless_act
 
 skip_unless_workflow_tests = pytest.mark.skipif(
     not _workflow_tests_enabled(),
     reason="ACT_WORKFLOW_TESTS not set (opt-in required)",
 )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register workflow test markers."""
+    config.addinivalue_line("markers", "skip_unless_act: skip unless act can run")
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Skip act tests when the runtime probe fails."""
+    if "skip_unless_act" not in item.keywords:
+        return
+    _get_act_runtime_status.cache_clear()
+    status = _get_act_runtime_status()
+    if not status.available:
+        pytest.skip(status.reason or "act or container runtime not available")
 
 
 @pytest.fixture

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -107,7 +107,11 @@ def _docker_host_usable(docker_host: str) -> tuple[bool, str]:
 
 
 def _container_runtime_available() -> bool:
-    """Return True if a container runtime (docker/podman) is available."""
+    """Return True if a container runtime (docker/podman) is available.
+
+    Probes lazily so callers that modify ACT, DOCKER_HOST or related
+    environment variables after import see the updated configuration.
+    """
     return _probe_act_runtime().available
 
 
@@ -178,7 +182,19 @@ def _probe_act_runtime(
     )
 
 
-_ACT_RUNTIME_STATUS = _probe_act_runtime()
+_ACT_RUNTIME_STATUS: ActRuntimeStatus | None = None
+
+
+def _get_act_runtime_status() -> ActRuntimeStatus:
+    """Return the runtime probe result, probing lazily on first call.
+
+    Probing is deferred so that tests that modify ACT, DOCKER_HOST
+    or related environment variables see the updated configuration.
+    """
+    global _ACT_RUNTIME_STATUS
+    if _ACT_RUNTIME_STATUS is None:
+        _ACT_RUNTIME_STATUS = _probe_act_runtime()
+    return _ACT_RUNTIME_STATUS
 
 
 def _workflow_tests_enabled() -> bool:
@@ -187,8 +203,8 @@ def _workflow_tests_enabled() -> bool:
 
 
 skip_unless_act = pytest.mark.skipif(
-    not _ACT_RUNTIME_STATUS.available,
-    reason=_ACT_RUNTIME_STATUS.reason or "act or container runtime not available",
+    not _get_act_runtime_status().available,
+    reason=_get_act_runtime_status().reason or "act or container runtime not available",
 )
 
 skip_unless_workflow_tests = pytest.mark.skipif(
@@ -297,7 +313,7 @@ def run_act(
     event_path = _resolve_event_path(config, event)
 
     run_env = os.environ.copy()
-    run_env.update(_ACT_RUNTIME_STATUS.env)
+    run_env.update(_get_act_runtime_status().env)
     if config.env:
         run_env.update(config.env)
 

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -121,6 +121,15 @@ def _command_succeeds(command: str, *args: str) -> bool:
     return retcode == 0
 
 
+def _docker_cli_available() -> bool:
+    """Return True when the Docker CLI is present and the daemon is reachable."""
+    return (
+        shutil.which("docker") is not None
+        and _command_succeeds("docker", "info")
+        and _command_succeeds("docker", "ps", "-a")
+    )
+
+
 def _probe_act_runtime(
     environ: cabc.Mapping[str, str] | None = None,
 ) -> ActRuntimeStatus:
@@ -138,11 +147,7 @@ def _probe_act_runtime(
         usable, reason = _docker_host_usable(docker_host)
         return ActRuntimeStatus(available=usable, reason=reason, env={})
 
-    if (
-        shutil.which("docker")
-        and _command_succeeds("docker", "info")
-        and _command_succeeds("docker", "ps", "-a")
-    ):
+    if _docker_cli_available():
         return ActRuntimeStatus(available=True, reason="", env={})
 
     if not shutil.which("podman"):

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import dataclasses
 import os
 import shutil
+import socket
 import tempfile
+import typing as typ
+import urllib.parse
 from pathlib import Path
 
 import pytest
@@ -13,28 +16,164 @@ from plumbum import CommandNotFound, ProcessTimedOut, local
 
 from bool_utils import coerce_bool
 
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+_DOCKER_CONTAINERS_PATH = "/v1.41/containers/json?all=true"
+_DOCKER_API_TIMEOUT_SECONDS = 10.0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ActRuntimeStatus:
+    """Availability result for the runtime path that act will actually use."""
+
+    available: bool
+    reason: str
+    env: dict[str, str]
+
+
+def _act_command(environ: cabc.Mapping[str, str] | None = None) -> str:
+    """Return the act executable configured for workflow tests."""
+    source = os.environ if environ is None else environ
+    return source.get("ACT", "act")
+
+
+def _command_available(command: str) -> bool:
+    """Return True when *command* names an executable file or PATH command."""
+    command_path = Path(command)
+    if command_path.parent != Path():
+        return command_path.is_file() and os.access(command_path, os.X_OK)
+    return shutil.which(command) is not None
 
 
 def _act_available() -> bool:
     """Return True if act is installed and runnable."""
-    return shutil.which("act") is not None
+    return _command_available(_act_command())
+
+
+def _default_podman_socket(environ: cabc.Mapping[str, str]) -> Path:
+    """Return the default rootless Podman Docker-compatible socket path."""
+    runtime_dir = environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return Path(runtime_dir) / "podman" / "podman.sock"
+    return Path("/run/user") / str(os.getuid()) / "podman" / "podman.sock"
+
+
+def _read_unix_http(socket_path: Path, path: str) -> tuple[int, str]:
+    """Issue a small HTTP request over a Unix socket and return status/body."""
+    request = (
+        f"GET {path} HTTP/1.1\r\nHost: docker\r\nConnection: close\r\n\r\n"
+    ).encode("ascii")
+    chunks: list[bytes] = []
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(_DOCKER_API_TIMEOUT_SECONDS)
+        client.connect(str(socket_path))
+        client.sendall(request)
+        while True:
+            chunk = client.recv(64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+
+    response = b"".join(chunks)
+    head, _separator, body = response.partition(b"\r\n\r\n")
+    status_line = head.splitlines()[0].decode("ascii", errors="replace")
+    parts = status_line.split(maxsplit=2)
+    if len(parts) < 2:
+        return 0, response.decode("utf-8", errors="replace")
+    return int(parts[1]), body.decode("utf-8", errors="replace")
+
+
+def _docker_host_usable(docker_host: str) -> tuple[bool, str]:
+    """Return whether act can list containers through *docker_host*."""
+    parsed = urllib.parse.urlparse(docker_host)
+    if parsed.scheme != "unix":
+        return True, ""
+
+    socket_path = Path(urllib.parse.unquote(parsed.path))
+    if not socket_path.exists():
+        return False, f"Docker API socket does not exist: {socket_path}"
+
+    try:
+        status, body = _read_unix_http(socket_path, _DOCKER_CONTAINERS_PATH)
+    except OSError as exc:
+        return False, f"Docker API socket is not reachable: {exc}"
+
+    if status != 200:
+        detail = body.strip() or f"HTTP {status}"
+        return False, f"Docker API cannot list containers: {detail}"
+    return True, ""
 
 
 def _container_runtime_available() -> bool:
     """Return True if a container runtime (docker/podman) is available."""
-    for runtime in ("docker", "podman"):
-        if shutil.which(runtime) is None:
-            continue
-        try:
-            cmd = local[runtime]
-            retcode, _, _ = cmd["info"].run(timeout=10, retcode=None)
-        except (ProcessTimedOut, CommandNotFound, OSError):
-            continue
-        else:
-            if retcode == 0:
-                return True
-    return False
+    return _probe_act_runtime().available
+
+
+def _command_succeeds(command: str, *args: str) -> bool:
+    """Return True when a command exits successfully within the probe timeout."""
+    try:
+        cmd = local[command]
+        retcode, _, _ = cmd[list(args)].run(timeout=10, retcode=None)
+    except (ProcessTimedOut, CommandNotFound, OSError):
+        return False
+    return retcode == 0
+
+
+def _probe_act_runtime(
+    environ: cabc.Mapping[str, str] | None = None,
+) -> ActRuntimeStatus:
+    """Probe the container runtime path used by act workflow tests."""
+    source = os.environ if environ is None else environ
+    act_command = _act_command(source)
+    if not _command_available(act_command):
+        return ActRuntimeStatus(
+            available=False,
+            reason=f"act executable not found: {act_command}",
+            env={},
+        )
+
+    if docker_host := source.get("DOCKER_HOST"):
+        usable, reason = _docker_host_usable(docker_host)
+        return ActRuntimeStatus(available=usable, reason=reason, env={})
+
+    if (
+        shutil.which("docker")
+        and _command_succeeds("docker", "info")
+        and _command_succeeds("docker", "ps", "-a")
+    ):
+        return ActRuntimeStatus(available=True, reason="", env={})
+
+    if not shutil.which("podman"):
+        return ActRuntimeStatus(
+            available=False,
+            reason="docker or podman runtime not available",
+            env={},
+        )
+
+    podman_socket = _default_podman_socket(source)
+    docker_host = f"unix://{podman_socket}"
+    usable, reason = _docker_host_usable(docker_host)
+    if not usable:
+        return ActRuntimeStatus(
+            available=False,
+            reason=(
+                f"podman Docker API is not usable for act: {reason}. "
+                "Start the user podman.socket if the socket is missing. If the "
+                "API reports 'container not known', repair or remove stale "
+                "Podman containers stuck in Removing state before rerunning."
+            ),
+            env={},
+        )
+    return ActRuntimeStatus(
+        available=True,
+        reason="",
+        env={"DOCKER_HOST": docker_host},
+    )
+
+
+_ACT_RUNTIME_STATUS = _probe_act_runtime()
 
 
 def _workflow_tests_enabled() -> bool:
@@ -43,8 +182,8 @@ def _workflow_tests_enabled() -> bool:
 
 
 skip_unless_act = pytest.mark.skipif(
-    not (_act_available() and _container_runtime_available()),
-    reason="act or container runtime not available",
+    not _ACT_RUNTIME_STATUS.available,
+    reason=_ACT_RUNTIME_STATUS.reason or "act or container runtime not available",
 )
 
 skip_unless_workflow_tests = pytest.mark.skipif(
@@ -153,6 +292,7 @@ def run_act(
     event_path = _resolve_event_path(config, event)
 
     run_env = os.environ.copy()
+    run_env.update(_ACT_RUNTIME_STATUS.env)
     if config.env:
         run_env.update(config.env)
 
@@ -167,7 +307,7 @@ def run_act(
     )
     args = _build_act_args(invocation)
 
-    act = local["act"]
+    act = local[_act_command(run_env)]
     cmd = act
     for arg in args:
         cmd = cmd[arg]

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -78,11 +78,18 @@ def _read_unix_http(socket_path: Path, path: str) -> tuple[int, str]:
 
     response = b"".join(chunks)
     head, _separator, body = response.partition(b"\r\n\r\n")
-    status_line = head.splitlines()[0].decode("ascii", errors="replace")
+    head_lines = head.splitlines()
+    if not head_lines:
+        return 0, response.decode("utf-8", errors="replace")
+    status_line = head_lines[0].decode("ascii", errors="replace")
     parts = status_line.split(maxsplit=2)
     if len(parts) < 2:
         return 0, response.decode("utf-8", errors="replace")
-    return int(parts[1]), body.decode("utf-8", errors="replace")
+    try:
+        status_code = int(parts[1])
+    except ValueError:
+        return 0, response.decode("utf-8", errors="replace")
+    return status_code, body.decode("utf-8", errors="replace")
 
 
 def _docker_host_usable(docker_host: str) -> tuple[bool, str]:

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import os
 import shutil
 import socket
@@ -189,19 +190,14 @@ def _probe_act_runtime(
     )
 
 
-_ACT_RUNTIME_STATUS: ActRuntimeStatus | None = None
-
-
+@functools.cache
 def _get_act_runtime_status() -> ActRuntimeStatus:
     """Return the runtime probe result, probing lazily on first call.
 
     Probing is deferred so that tests that modify ACT, DOCKER_HOST
     or related environment variables see the updated configuration.
     """
-    global _ACT_RUNTIME_STATUS
-    if _ACT_RUNTIME_STATUS is None:
-        _ACT_RUNTIME_STATUS = _probe_act_runtime()
-    return _ACT_RUNTIME_STATUS
+    return _probe_act_runtime()
 
 
 def _workflow_tests_enabled() -> bool:

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -27,21 +27,31 @@ def test_command_available_rejects_non_executable_file(tmp_path: Path) -> None:
     assert not conftest._command_available(str(path))
 
 
-def test_command_succeeds_reports_successful_command() -> None:
-    """Successful commands return True."""
-    assert conftest._command_succeeds(sys.executable, "-c", "pass")
-
-
-def test_command_succeeds_reports_failed_command() -> None:
-    """Non-zero commands return False."""
-    assert not conftest._command_succeeds(
-        sys.executable, "-c", "import sys; sys.exit(3)"
-    )
-
-
-def test_command_succeeds_reports_missing_command() -> None:
-    """Missing commands return False."""
-    assert not conftest._command_succeeds("definitely-not-a-real-command-for-tests")
+@pytest.mark.parametrize(
+    ("command", "args", "expected"),
+    [
+        pytest.param(sys.executable, ("-c", "pass"), True, id="successful"),
+        pytest.param(
+            sys.executable,
+            ("-c", "import sys; sys.exit(3)"),
+            False,
+            id="failed",
+        ),
+        pytest.param(
+            "definitely-not-a-real-command-for-tests",
+            (),
+            False,
+            id="missing",
+        ),
+    ],
+)
+def test_command_succeeds_reports_command_status(
+    command: str,
+    args: tuple[str, ...],
+    expected: bool,  # noqa: FBT001
+) -> None:
+    """Command success probes return the expected boolean."""
+    assert conftest._command_succeeds(command, *args) is expected
 
 
 def test_probe_reports_unhealthy_podman_docker_api(
@@ -110,74 +120,48 @@ def test_probe_honours_configured_act_command(monkeypatch: pytest.MonkeyPatch) -
     assert status.reason == "act executable not found: /custom/bin/act"
 
 
-def test_docker_host_unix_socket_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DOCKER_HOST=unix://... with a non-existent socket path reports a clear error."""
-    docker_host = "unix:///this/path/does/not/exist.sock"
-    monkeypatch.setenv("DOCKER_HOST", docker_host)
-
-    usable, reason = conftest._docker_host_usable(os.environ["DOCKER_HOST"])
-
-    assert usable is False
-    assert reason.startswith("Docker API socket does not exist:")
-
-
-def test_docker_host_unix_socket_unreachable(
+@pytest.mark.parametrize(
+    ("failure", "expected_reason"),
+    [
+        pytest.param("missing", "Docker API socket does not exist:", id="missing"),
+        pytest.param(
+            "unreachable",
+            "Docker API socket is not reachable:",
+            id="unreachable",
+        ),
+    ],
+)
+def test_docker_host_failure_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    failure: str,
+    expected_reason: str,
 ) -> None:
-    """DOCKER_HOST=unix://... with an unreachable socket surfaces the OSError."""
-    socket_path = tmp_path / "docker.sock"
-    socket_path.touch()
+    """Docker host failures are reported consistently by helpers and probes."""
+    if failure == "missing":
+        docker_host = "unix:///nonexistent/path.sock"
+    else:
+        socket_path = tmp_path / "docker.sock"
+        socket_path.touch()
+        docker_host = f"unix://{socket_path}"
 
-    docker_host = f"unix://{socket_path}"
+        def _raise_oserror(*_args: object, **_kwargs: object) -> None:
+            msg = "test unreachable docker socket"
+            raise OSError(msg)
+
+        monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
+
     monkeypatch.setenv("DOCKER_HOST", docker_host)
-
-    def _raise_oserror(*_args: object, **_kwargs: object) -> None:
-        msg = "test unreachable docker socket"
-        raise OSError(msg)
-
-    monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
+    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
 
     usable, reason = conftest._docker_host_usable(os.environ["DOCKER_HOST"])
+    status = conftest._probe_act_runtime({"DOCKER_HOST": docker_host})
 
     assert usable is False
-    assert reason.startswith("Docker API socket is not reachable:")
-
-
-def test_probe_reports_missing_docker_host_socket(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Probe surfaces a missing DOCKER_HOST Unix socket as unavailable."""
-    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
-
-    status = conftest._probe_act_runtime(
-        {"DOCKER_HOST": "unix:///nonexistent/path.sock"}
-    )
+    assert expected_reason in reason
 
     assert not status.available
-    assert "Docker API socket does not exist:" in status.reason
-
-
-def test_probe_reports_unreachable_docker_host_socket(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Probe surfaces an unreachable DOCKER_HOST Unix socket as unavailable."""
-    socket_path = tmp_path / "docker.sock"
-    socket_path.touch()
-
-    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
-
-    def _raise_oserror(*_args: object, **_kwargs: object) -> None:
-        msg = "test unreachable docker socket"
-        raise OSError(msg)
-
-    monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
-
-    status = conftest._probe_act_runtime({"DOCKER_HOST": f"unix://{socket_path}"})
-
-    assert not status.available
-    assert "Docker API socket is not reachable:" in status.reason
+    assert expected_reason in status.reason
 
 
 def test_skip_marker_uses_act_runtime_probe(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import typing as typ
 
 if typ.TYPE_CHECKING:
@@ -80,8 +81,6 @@ def test_probe_honours_configured_act_command(monkeypatch: pytest.MonkeyPatch) -
 
 def test_docker_host_unix_socket_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     """DOCKER_HOST=unix://... with a non-existent socket path reports a clear error."""
-    import os
-
     docker_host = "unix:///this/path/does/not/exist.sock"
     monkeypatch.setenv("DOCKER_HOST", docker_host)
 
@@ -96,8 +95,6 @@ def test_docker_host_unix_socket_unreachable(
     tmp_path: Path,
 ) -> None:
     """DOCKER_HOST=unix://... with an unreachable socket surfaces the OSError."""
-    import os
-
     socket_path = tmp_path / "docker.sock"
     socket_path.touch()
 
@@ -134,8 +131,6 @@ def test_probe_reports_unreachable_docker_host_socket(
     tmp_path: Path,
 ) -> None:
     """Probe surfaces an unreachable DOCKER_HOST Unix socket as unavailable."""
-    import os
-
     socket_path = tmp_path / "docker.sock"
     socket_path.touch()
 
@@ -148,7 +143,7 @@ def test_probe_reports_unreachable_docker_host_socket(
 
     monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
 
-    status = conftest._probe_act_runtime(os.environ.copy())
+    status = conftest._probe_act_runtime()
 
     assert not status.available
     assert "Docker API socket is not reachable:" in status.reason

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -76,3 +76,79 @@ def test_probe_honours_configured_act_command(monkeypatch: pytest.MonkeyPatch) -
     assert not status.available
     assert seen == ["/custom/bin/act"]
     assert status.reason == "act executable not found: /custom/bin/act"
+
+
+def test_docker_host_unix_socket_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DOCKER_HOST=unix://... with a non-existent socket path reports a clear error."""
+    import os
+
+    docker_host = "unix:///this/path/does/not/exist.sock"
+    monkeypatch.setenv("DOCKER_HOST", docker_host)
+
+    usable, reason = conftest._docker_host_usable(os.environ["DOCKER_HOST"])
+
+    assert usable is False
+    assert reason.startswith("Docker API socket does not exist:")
+
+
+def test_docker_host_unix_socket_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """DOCKER_HOST=unix://... with an unreachable socket surfaces the OSError."""
+    import os
+
+    socket_path = tmp_path / "docker.sock"
+    socket_path.touch()
+
+    docker_host = f"unix://{socket_path}"
+    monkeypatch.setenv("DOCKER_HOST", docker_host)
+
+    def _raise_oserror(*_args: object, **_kwargs: object) -> None:
+        msg = "test unreachable docker socket"
+        raise OSError(msg)
+
+    monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
+
+    usable, reason = conftest._docker_host_usable(os.environ["DOCKER_HOST"])
+
+    assert usable is False
+    assert reason.startswith("Docker API socket is not reachable:")
+
+
+def test_probe_reports_missing_docker_host_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe surfaces a missing DOCKER_HOST Unix socket as unavailable."""
+    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
+    monkeypatch.setenv("DOCKER_HOST", "unix:///nonexistent/path.sock")
+
+    status = conftest._probe_act_runtime()
+
+    assert not status.available
+    assert "Docker API socket does not exist:" in status.reason
+
+
+def test_probe_reports_unreachable_docker_host_socket(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Probe surfaces an unreachable DOCKER_HOST Unix socket as unavailable."""
+    import os
+
+    socket_path = tmp_path / "docker.sock"
+    socket_path.touch()
+
+    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
+    monkeypatch.setenv("DOCKER_HOST", f"unix://{socket_path}")
+
+    def _raise_oserror(*_args: object, **_kwargs: object) -> None:
+        msg = "test unreachable docker socket"
+        raise OSError(msg)
+
+    monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
+
+    status = conftest._probe_act_runtime(os.environ.copy())
+
+    assert not status.available
+    assert "Docker API socket is not reachable:" in status.reason

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import typing as typ
 
 import pytest
@@ -11,6 +12,36 @@ if typ.TYPE_CHECKING:
     from pathlib import Path
 
 from . import conftest
+
+
+def test_command_available_accepts_absolute_executable() -> None:
+    """Absolute executable paths are reported as available."""
+    assert conftest._command_available(sys.executable)
+
+
+def test_command_available_rejects_non_executable_file(tmp_path: Path) -> None:
+    """Absolute non-executable files are not reported as available."""
+    path = tmp_path / "not-executable"
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    assert not conftest._command_available(str(path))
+
+
+def test_command_succeeds_reports_successful_command() -> None:
+    """Successful commands return True."""
+    assert conftest._command_succeeds(sys.executable, "-c", "pass")
+
+
+def test_command_succeeds_reports_failed_command() -> None:
+    """Non-zero commands return False."""
+    assert not conftest._command_succeeds(
+        sys.executable, "-c", "import sys; sys.exit(3)"
+    )
+
+
+def test_command_succeeds_reports_missing_command() -> None:
+    """Missing commands return False."""
+    assert not conftest._command_succeeds("definitely-not-a-real-command-for-tests")
 
 
 def test_probe_reports_unhealthy_podman_docker_api(

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -113,14 +113,11 @@ def test_docker_host_unix_socket_unreachable(
     assert reason.startswith("Docker API socket is not reachable:")
 
 
-def test_probe_reports_missing_docker_host_socket(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_probe_reports_missing_docker_host_socket() -> None:
     """Probe surfaces a missing DOCKER_HOST Unix socket as unavailable."""
-    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
-    monkeypatch.setenv("DOCKER_HOST", "unix:///nonexistent/path.sock")
-
-    status = conftest._probe_act_runtime()
+    status = conftest._probe_act_runtime(
+        {"DOCKER_HOST": "unix:///nonexistent/path.sock"}
+    )
 
     assert not status.available
     assert "Docker API socket does not exist:" in status.reason
@@ -135,7 +132,6 @@ def test_probe_reports_unreachable_docker_host_socket(
     socket_path.touch()
 
     monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
-    monkeypatch.setenv("DOCKER_HOST", f"unix://{socket_path}")
 
     def _raise_oserror(*_args: object, **_kwargs: object) -> None:
         msg = "test unreachable docker socket"
@@ -143,7 +139,7 @@ def test_probe_reports_unreachable_docker_host_socket(
 
     monkeypatch.setattr(conftest, "_read_unix_http", _raise_oserror)
 
-    status = conftest._probe_act_runtime()
+    status = conftest._probe_act_runtime({"DOCKER_HOST": f"unix://{socket_path}"})
 
     assert not status.available
     assert "Docker API socket is not reachable:" in status.reason

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -48,7 +48,7 @@ def test_command_available_rejects_non_executable_file(tmp_path: Path) -> None:
 def test_command_succeeds_reports_command_status(
     command: str,
     args: tuple[str, ...],
-    expected: bool,  # noqa: FBT001
+    expected: bool,  # noqa: FBT001 - boolean literals clarify parametrized cases.
 ) -> None:
     """Command success probes return the expected boolean."""
     assert conftest._command_succeeds(command, *args) is expected

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -51,7 +51,9 @@ def test_command_succeeds_reports_command_status(
     expected: bool,  # noqa: FBT001 - boolean literals clarify parametrized cases.
 ) -> None:
     """Command success probes return the expected boolean."""
-    assert conftest._command_succeeds(command, *args) is expected
+    assert conftest._command_succeeds(command, *args) is expected, (
+        f"_command_succeeds({command!r}, *{args}) != {expected}"
+    )
 
 
 def test_probe_reports_unhealthy_podman_docker_api(

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -113,8 +113,12 @@ def test_docker_host_unix_socket_unreachable(
     assert reason.startswith("Docker API socket is not reachable:")
 
 
-def test_probe_reports_missing_docker_host_socket() -> None:
+def test_probe_reports_missing_docker_host_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Probe surfaces a missing DOCKER_HOST Unix socket as unavailable."""
+    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
+
     status = conftest._probe_act_runtime(
         {"DOCKER_HOST": "unix:///nonexistent/path.sock"}
     )

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import os
 import typing as typ
 
+import pytest
+
 if typ.TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 from . import conftest
 
@@ -147,3 +147,22 @@ def test_probe_reports_unreachable_docker_host_socket(
 
     assert not status.available
     assert "Docker API socket is not reachable:" in status.reason
+
+
+def test_skip_marker_uses_act_runtime_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Marked workflow tests are skipped when the act runtime probe is unavailable."""
+
+    class MarkedItem:
+        def __init__(self) -> None:
+            self.keywords = {"skip_unless_act": object()}
+
+    status = conftest.ActRuntimeStatus(
+        available=False,
+        reason="act unavailable in test",
+        env={},
+    )
+    monkeypatch.setattr(conftest, "_probe_act_runtime", lambda: status)
+    conftest._get_act_runtime_status.cache_clear()
+
+    with pytest.raises(pytest.skip.Exception, match="act unavailable in test"):
+        conftest.pytest_runtest_setup(typ.cast("pytest.Item", MarkedItem()))

--- a/tests/workflows/test_conftest_runtime.py
+++ b/tests/workflows/test_conftest_runtime.py
@@ -1,0 +1,78 @@
+"""Tests for act runtime probing in the workflow harness."""
+
+from __future__ import annotations
+
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+from . import conftest
+
+
+def test_probe_reports_unhealthy_podman_docker_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A stale Podman store should skip act tests before act is invoked."""
+    socket_path = tmp_path / "podman.sock"
+    socket_path.touch()
+
+    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
+    monkeypatch.setattr(conftest.shutil, "which", lambda command: command)
+    monkeypatch.setattr(conftest, "_command_succeeds", lambda *_args: False)
+    monkeypatch.setattr(
+        conftest,
+        "_docker_host_usable",
+        lambda _host: (False, "Docker API cannot list containers: container not known"),
+    )
+
+    status = conftest._probe_act_runtime({"XDG_RUNTIME_DIR": str(tmp_path)})
+
+    assert not status.available
+    assert "podman Docker API is not usable for act" in status.reason
+    assert "container not known" in status.reason
+
+
+def test_probe_exports_podman_docker_host_when_socket_is_healthy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A healthy Podman socket should be forwarded to act automatically."""
+    podman_dir = tmp_path / "podman"
+    podman_dir.mkdir()
+    socket_path = podman_dir / "podman.sock"
+    socket_path.touch()
+
+    monkeypatch.setattr(conftest, "_command_available", lambda _command: True)
+    monkeypatch.setattr(
+        conftest.shutil,
+        "which",
+        lambda command: command if command == "podman" else None,
+    )
+    monkeypatch.setattr(conftest, "_command_succeeds", lambda *_args: False)
+    monkeypatch.setattr(conftest, "_docker_host_usable", lambda _host: (True, ""))
+
+    status = conftest._probe_act_runtime({"XDG_RUNTIME_DIR": str(tmp_path)})
+
+    assert status.available
+    assert status.env == {"DOCKER_HOST": f"unix://{socket_path}"}
+
+
+def test_probe_honours_configured_act_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Makefile-provided ACT path should be used for discovery."""
+    seen: list[str] = []
+
+    def command_available(command: str) -> bool:
+        seen.append(command)
+        return False
+
+    monkeypatch.setattr(conftest, "_command_available", command_available)
+
+    status = conftest._probe_act_runtime({"ACT": "/custom/bin/act"})
+
+    assert not status.available
+    assert seen == ["/custom/bin/act"]
+    assert status.reason == "act executable not found: /custom/bin/act"


### PR DESCRIPTION
## Summary

This branch pins every `astral-sh/setup-uv` reference used by the repository's action and workflow definitions to `08807647e7069bb48b6ef5acd8ec9567f424441b`. It also hardens the local act workflow harness so Podman Docker API failures are detected before workflow execution, and stabilises Typer-based action script tests under the project test runner.

No issue, roadmap task, or execplan is linked to this branch.

## Review walkthrough

- Start with representative setup-uv pin changes in the [ensure-cargo-version action manifest](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/ensure-cargo-version/action.yml), [ratchet-coverage action manifest](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/ratchet-coverage/action.yml), and [CI workflow](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/workflows/ci.yml) to confirm the requested SHA is used consistently.
- Then review [the workflow test harness](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/tests/workflows/conftest.py) for the Docker-compatible runtime probe, automatic rootless Podman socket forwarding, and targeted skip message.
- Check [the workflow harness tests](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/tests/workflows/test_conftest_runtime.py) for coverage of unhealthy Podman API detection, healthy socket forwarding, and custom `ACT` command handling.
- Review [the release-to-pypi publish script](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/release-to-pypi-uv/scripts/publish_release.py) for the `Annotated` Typer option and `INPUT_UV_INDEX` fallback.
- Review [the generate-coverage script runner tests](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/generate-coverage/tests/test_scripts.py), [the Rust coverage runner](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/generate-coverage/scripts/run_rust.py), [the Python coverage runner](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/generate-coverage/scripts/run_python.py), and [the Cobertura merge script](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/.github/actions/generate-coverage/scripts/merge_cobertura.py) for the project-interpreter execution path and resilient GitHub Action environment input handling.
- Finish with [the Makefile](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/Makefile) and [the local act validation guide](https://github.com/leynos/shared-actions/blob/chore/bump-setup-uv-sha/docs/local-validation-of-github-actions-with-act-and-pytest.md) to verify local developer workflow and remediation documentation.

## Validation

- `uv run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist pytest .github/actions/release-to-pypi-uv/tests/test_publish_release.py::test_cli_runner_respects_env_index .github/actions/release-to-pypi-uv/tests/test_publish_release.py::test_cli_proxies_to_main -v`: passed, `2 passed`.
- `uv run pytest .github/actions/generate-coverage/tests/ -v`: passed, `115 passed`.
- `make check-fmt`: passed.
- `make typecheck`: passed.
- `make lint`: passed.
- `make test`: passed, `728 passed, 93 skipped`.
- `ACT=$HOME/go/bin/act ACT_WORKFLOW_TESTS=1 ./.venv/bin/pytest tests/workflows -v -rs`: passed, `15 passed in 330.52s`.

## Notes

The Podman investigation found that `podman ps -a` could print containers while the Docker-compatible API endpoint `GET /v1.41/containers/json?all=true` returned HTTP 500 with `container not known`. Since act uses that API path before starting jobs, the harness now verifies the same path and reports the exact runtime problem before invoking act.

The generate-coverage scripts keep their PEP 723 metadata for direct action execution. Test execution now uses the project interpreter so `cmd-mox` stubs run in the same environment as pytest; the script dependencies required by the inline metadata are already present in `pyproject.toml` and `uv.lock`.

## Summary by Sourcery

Pin uv setup actions across workflows, harden the local act workflow harness, and stabilise Typer-based action scripts and their tests for more reliable CI and local validation.

New Features:
- Expose configurable act executable selection for workflow tests via the ACT environment variable and Makefile integration.

Bug Fixes:
- Ensure workflow tests are skipped with clear reasons when the configured container runtime or Docker-compatible Podman API is unavailable or unhealthy.
- Make generate-coverage Rust and Python runners resilient to missing or empty GitHub Actions environment inputs by falling back to explicit environment variable reads.
- Ensure the release-to-pypi uv publish CLI honours the INPUT_UV_INDEX environment variable when the index option is omitted on the command line.

Enhancements:
- Add explicit probing of the Docker-compatible API (including Podman unix sockets) before running act, automatically exporting DOCKER_HOST when a healthy Podman socket is detected.
- Refactor coverage scripts to centralise computation and reporting of coverage percentages and to better support mixed-language projects.
- Run generate-coverage action scripts under the project Python interpreter rather than via uv run to better align with the test environment.

Build:
- Pin all astral-sh/setup-uv usages in workflows and composite actions to a single vetted commit for reproducible CI runs.

Documentation:
- Update local act validation documentation to describe the Docker-compatible container listing check and sandbox permission requirements for Podman-based setups.

Tests:
- Extend workflow harness tests to cover unhealthy Podman APIs, healthy Podman socket forwarding, and custom ACT command behaviour.
- Adjust generate-coverage script tests to invoke scripts with the project interpreter instead of uv run for more stable action testing.