### PR TITLE
Fix cargo-nextest checksum mismatch on glibc runners

### DIFF
--- a/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
@@ -3,20 +3,31 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
-"""Install cargo-nextest via cargo-binstall and verify its checksum."""
+"""Install and verify cargo-nextest for generate-coverage GitHub Actions runs.
+
+The generate-coverage pipeline calls this helper before Rust coverage when
+`use-cargo-nextest` is enabled so `cargo llvm-cov nextest` can run with a
+known-good, pinned toolchain binary. The installed binary is validated with a
+platform-specific SHA-256 checksum before the action continues.
+"""
 
 from __future__ import annotations
 
+import ctypes
 import hashlib
 import os
 import platform
 import shutil
+import typing as typ
 from pathlib import Path
 
 import typer
 from cmd_utils_loader import run_cmd
 from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
 
 # Keep CARGO_NEXTEST_VERSION and CARGO_NEXTEST_SHA256 in sync; update together.
 # linux-x86_64-gnu  : SHA of the extracted binary from the
@@ -43,6 +54,7 @@ CARGO_NEXTEST_SHA256 = {
 
 
 def _normalize_machine(machine: str) -> str:
+    """Normalize platform machine names to cargo-nextest release keys."""
     name = machine.lower()
     if name in {"x86_64", "amd64"}:
         return "x86_64"
@@ -51,13 +63,10 @@ def _normalize_machine(machine: str) -> str:
     return name
 
 
-import ctypes
-
-
-def _is_musl() -> bool:
-    """Return True when the running libc is musl rather than glibc."""
+def _probe_libc_is_musl(cdll: cabc.Callable[[typ.Any], typ.Any]) -> bool:
+    """Return True when probing libc finds musl or cannot find glibc symbols."""
     try:
-        libc = ctypes.CDLL(None)
+        libc = cdll(None)
         # glibc exposes gnu_get_libc_version(); musl does not.
         libc.gnu_get_libc_version.restype = ctypes.c_char_p
         libc.gnu_get_libc_version()
@@ -67,13 +76,23 @@ def _is_musl() -> bool:
         return False
 
 
+def _is_musl() -> bool:
+    """Return True when the running libc is musl rather than glibc."""
+    is_musl = _probe_libc_is_musl(ctypes.CDLL)
+    typer.echo(f"Detected libc for cargo-nextest: {'musl' if is_musl else 'glibc'}")
+    return is_musl
+
+
 def _platform_key() -> str:
+    """Return the cargo-nextest checksum key for the current platform."""
     system = platform.system()
     machine = _normalize_machine(platform.machine())
     if system == "Linux":
         if machine == "x86_64":
             suffix = "musl" if _is_musl() else "gnu"
-            return f"linux-x86_64-{suffix}"
+            key = f"linux-x86_64-{suffix}"
+            typer.echo(f"Selected cargo-nextest platform key: {key}")
+            return key
         return f"linux-{machine}"
     if system == "Darwin":
         return "mac-universal"
@@ -83,6 +102,7 @@ def _platform_key() -> str:
 
 
 def _expected_sha_for_platform() -> str:
+    """Return the pinned cargo-nextest checksum for the current platform."""
     key = _platform_key()
     try:
         return CARGO_NEXTEST_SHA256[key]
@@ -92,6 +112,7 @@ def _expected_sha_for_platform() -> str:
 
 
 def _sha256_path(path: Path) -> str:
+    """Return the SHA-256 digest for a file path."""
     hasher = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(8192), b""):
@@ -100,6 +121,7 @@ def _sha256_path(path: Path) -> str:
 
 
 def _resolve_nextest_binary() -> Path | None:
+    """Return the cargo-nextest binary path when it already exists."""
     resolved = shutil.which("cargo-nextest")
     if resolved:
         return Path(resolved)
@@ -109,6 +131,7 @@ def _resolve_nextest_binary() -> Path | None:
 
 
 def _find_nextest_binary() -> Path:
+    """Return the installed cargo-nextest binary path or exit with an error."""
     resolved = _resolve_nextest_binary()
     if resolved is not None:
         return resolved

--- a/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
@@ -19,9 +19,18 @@ from plumbum.cmd import cargo
 from plumbum.commands.processes import ProcessExecutionError
 
 # Keep CARGO_NEXTEST_VERSION and CARGO_NEXTEST_SHA256 in sync; update together.
+# linux-x86_64-gnu  : SHA of the extracted binary from the
+#   -x86_64-unknown-linux-gnu.tar.gz release
+# linux-x86_64-musl : SHA of the extracted binary from the
+#   -x86_64-unknown-linux-musl.tar.gz release
 CARGO_NEXTEST_VERSION = "0.9.120"
 CARGO_NEXTEST_SHA256 = {
-    "linux-x86_64": "8d717594668f0ec817405b9526cb657ca40fc888068277004860d0f253837d14",
+    "linux-x86_64-gnu": (
+        "73c7eb58e6507c10821998de343586cdcd37f99129f69dd0ec5605fd6d7eb291"
+    ),
+    "linux-x86_64-musl": (
+        "8d717594668f0ec817405b9526cb657ca40fc888068277004860d0f253837d14"
+    ),
     "linux-aarch64": "901f10642066a848d4bc4eaee3d91642ad0476bea4a5de26832e838e4c32939e",
     "mac-universal": "d9f8aa57f88ea948ee68629cfc22a0a86ccd0d0143139983753dcb5f167085b8",
     "windows-x86_64": (
@@ -42,10 +51,29 @@ def _normalize_machine(machine: str) -> str:
     return name
 
 
+import ctypes
+
+
+def _is_musl() -> bool:
+    """Return True when the running libc is musl rather than glibc."""
+    try:
+        libc = ctypes.CDLL(None)
+        # glibc exposes gnu_get_libc_version(); musl does not.
+        libc.gnu_get_libc_version.restype = ctypes.c_char_p
+        libc.gnu_get_libc_version()
+    except (OSError, AttributeError):
+        return True
+    else:
+        return False
+
+
 def _platform_key() -> str:
     system = platform.system()
     machine = _normalize_machine(platform.machine())
     if system == "Linux":
+        if machine == "x86_64":
+            suffix = "musl" if _is_musl() else "gnu"
+            return f"linux-x86_64-{suffix}"
         return f"linux-{machine}"
     if system == "Darwin":
         return "mac-universal"

--- a/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
+++ b/.github/actions/generate-coverage/scripts/install_cargo_nextest.py
@@ -78,9 +78,7 @@ def _probe_libc_is_musl(cdll: cabc.Callable[[typ.Any], typ.Any]) -> bool:
 
 def _is_musl() -> bool:
     """Return True when the running libc is musl rather than glibc."""
-    is_musl = _probe_libc_is_musl(ctypes.CDLL)
-    typer.echo(f"Detected libc for cargo-nextest: {'musl' if is_musl else 'glibc'}")
-    return is_musl
+    return _probe_libc_is_musl(ctypes.CDLL)
 
 
 def _platform_key() -> str:
@@ -90,9 +88,7 @@ def _platform_key() -> str:
     if system == "Linux":
         if machine == "x86_64":
             suffix = "musl" if _is_musl() else "gnu"
-            key = f"linux-x86_64-{suffix}"
-            typer.echo(f"Selected cargo-nextest platform key: {key}")
-            return key
+            return f"linux-x86_64-{suffix}"
         return f"linux-{machine}"
     if system == "Darwin":
         return "mac-universal"
@@ -101,9 +97,19 @@ def _platform_key() -> str:
     return f"{system.lower()}-{machine}"
 
 
+def _report_platform_key(key: str) -> None:
+    """Report the selected cargo-nextest platform key."""
+    if key == "linux-x86_64-musl":
+        typer.echo("Detected libc for cargo-nextest: musl")
+    elif key == "linux-x86_64-gnu":
+        typer.echo("Detected libc for cargo-nextest: glibc")
+    typer.echo(f"Selected cargo-nextest platform key: {key}")
+
+
 def _expected_sha_for_platform() -> str:
     """Return the pinned cargo-nextest checksum for the current platform."""
     key = _platform_key()
+    _report_platform_key(key)
     try:
         return CARGO_NEXTEST_SHA256[key]
     except KeyError as exc:

--- a/.github/actions/generate-coverage/tests/__snapshots__/test_scripts.ambr
+++ b/.github/actions/generate-coverage/tests/__snapshots__/test_scripts.ambr
@@ -1,4 +1,16 @@
 # serializer version: 1
+# name: test_expected_sha_for_unsupported_platform
+  '''
+  Unsupported platform for cargo-nextest: unsupported-platform
+  
+  '''
+# ---
+# name: test_install_nextest_checksum_mismatch
+  '''
+  cargo-nextest checksum mismatch: expected deadbeef, got 239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5
+  
+  '''
+# ---
 # name: test_run_python_integration_cobertura_success[run_python_cobertura_github_output]
   '''
   file=<TMP>/cov.xml

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1545,7 +1545,6 @@ def test_probe_libc_is_musl_detects_cdll_failure(
 def test_is_musl_uses_ctypes_probe(
     install_nextest_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The public libc helper exercises its ctypes.CDLL probe dependency."""
 
@@ -1559,7 +1558,6 @@ def test_is_musl_uses_ctypes_probe(
 
     monkeypatch.setattr(install_nextest_module.ctypes, "CDLL", load_libc)
     assert install_nextest_module._is_musl() is True
-    assert capsys.readouterr().out == "Detected libc for cargo-nextest: musl\n"
 
 
 @pytest.mark.parametrize(
@@ -1727,6 +1725,80 @@ def test_install_nextest_invokes_binstall(
         "--locked",
         "--no-confirm",
         "--force",
+    ]
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        ("glibc", False, "linux-x86_64-gnu"),
+        ("musl", True, "linux-x86_64-musl"),
+    ],
+)
+def test_install_nextest_main_detects_libc_platform_key(
+    case: tuple[str, bool, str],
+    tmp_path: Path,
+    install_nextest_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Installer main resolves SHA through the real libc detection chain."""
+    libc_name, is_musl, expected_key = case
+    binary = tmp_path / "cargo-nextest"
+    binary.write_bytes(b"payload")
+    install_calls: list[bool] = []
+    verified: dict[str, str] = {}
+
+    class GnuGetLibcVersion:
+        """Callable libc symbol stub that accepts a configured restype."""
+
+        restype: object = None
+
+        def __call__(self) -> bytes:
+            """Return a glibc-style version payload."""
+            return b"2.39"
+
+    class Glibc:
+        """Libc stub exposing the glibc-only version symbol."""
+
+        gnu_get_libc_version = GnuGetLibcVersion()
+
+    class Musl:
+        """Libc stub without glibc-only symbols."""
+
+    def load_libc(name: object) -> object:
+        """Return the selected fake process-global libc handle."""
+        assert name is None
+        return Musl() if is_musl else Glibc()
+
+    def fake_install() -> None:
+        """Record that installation would be performed."""
+        install_calls.append(True)
+
+    def fake_verify(path: Path, sha: str) -> bool:
+        """Capture the checksum selected by the real platform chain."""
+        assert path == binary
+        verified["sha"] = sha
+        return True
+
+    monkeypatch.setattr(install_nextest_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(install_nextest_module.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(install_nextest_module.ctypes, "CDLL", load_libc)
+    monkeypatch.setattr(install_nextest_module, "_resolve_nextest_binary", lambda: None)
+    monkeypatch.setattr(install_nextest_module, "_find_nextest_binary", lambda: binary)
+    monkeypatch.setattr(install_nextest_module, "install_cargo_nextest", fake_install)
+    monkeypatch.setattr(install_nextest_module, "verify_nextest_binary", fake_verify)
+
+    install_nextest_module.main()
+
+    assert install_calls == [True]
+    assert verified == {
+        "sha": install_nextest_module.CARGO_NEXTEST_SHA256[expected_key],
+    }
+    assert capsys.readouterr().out.splitlines() == [
+        f"Detected libc for cargo-nextest: {libc_name}",
+        f"Selected cargo-nextest platform key: {expected_key}",
+        "cargo-nextest installed and verified",
     ]
 
 

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1459,29 +1459,32 @@ def test_run_rust_failure(tmp_path: Path, shell_stubs: StubManager) -> None:
 @pytest.mark.parametrize(
     "case",
     [
-        ("Linux", "x86_64", "linux-x86_64"),
-        ("Linux", "aarch64", "linux-aarch64"),
-        ("Darwin", "arm64", "mac-universal"),
-        ("Windows", "AMD64", "windows-x86_64"),
-        ("Windows", "ARM64", "windows-aarch64"),
+        ("Linux", "x86_64", False, "linux-x86_64-gnu"),
+        ("Linux", "x86_64", True, "linux-x86_64-musl"),
+        ("Linux", "aarch64", False, "linux-aarch64"),
+        ("Darwin", "arm64", False, "mac-universal"),
+        ("Windows", "AMD64", False, "windows-x86_64"),
+        ("Windows", "ARM64", False, "windows-aarch64"),
     ],
 )
 def test_platform_key_variants(
-    case: tuple[str, str, str],
+    case: tuple[str, str, bool, str],
     install_nextest_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Platform key mapping normalises common OS/arch combinations."""
-    system, machine, expected = case
+    system, machine, is_musl, expected = case
     monkeypatch.setattr(install_nextest_module.platform, "system", lambda: system)
     monkeypatch.setattr(install_nextest_module.platform, "machine", lambda: machine)
+    monkeypatch.setattr(install_nextest_module, "_is_musl", lambda: is_musl)
     assert install_nextest_module._platform_key() == expected
 
 
 @pytest.mark.parametrize(
     "key",
     [
-        "linux-x86_64",
+        "linux-x86_64-gnu",
+        "linux-x86_64-musl",
         "linux-aarch64",
         "mac-universal",
         "windows-x86_64",

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -1,4 +1,10 @@
-"""Tests for coverage utility scripts."""
+"""Tests for generate-coverage utility scripts.
+
+This module exercises helper modules that are executed as separate script entry
+points (`run_rust`, `run_python`, `install_cargo_nextest`) and validates their
+interdependencies. It documents how script-level helpers are composed inside the
+GitHub Action runtime for Rust and Python coverage flows.
+"""
 
 from __future__ import annotations
 
@@ -1480,6 +1486,82 @@ def test_platform_key_variants(
     assert install_nextest_module._platform_key() == expected
 
 
+def test_probe_libc_is_musl_detects_glibc(
+    install_nextest_module: ModuleType,
+) -> None:
+    """Libc probing returns False when the glibc version symbol is available."""
+
+    class GnuGetLibcVersion:
+        """Callable libc symbol stub that accepts a configured restype."""
+
+        restype: object = None
+
+        def __call__(self) -> bytes:
+            """Return a glibc-style version payload."""
+            return b"2.39"
+
+    class Glibc:
+        """Libc stub exposing the glibc-only version symbol."""
+
+        gnu_get_libc_version = GnuGetLibcVersion()
+
+    def load_libc(name: object) -> Glibc:
+        """Return the fake glibc object for the process-global libc handle."""
+        assert name is None
+        return Glibc()
+
+    assert install_nextest_module._probe_libc_is_musl(load_libc) is False
+
+
+def test_probe_libc_is_musl_detects_missing_glibc_symbol(
+    install_nextest_module: ModuleType,
+) -> None:
+    """Libc probing treats a missing glibc version symbol as musl."""
+
+    class Musl:
+        """Libc stub without glibc-only symbols."""
+
+    def load_libc(name: object) -> Musl:
+        """Return the fake musl object for the process-global libc handle."""
+        assert name is None
+        return Musl()
+
+    assert install_nextest_module._probe_libc_is_musl(load_libc) is True
+
+
+def test_probe_libc_is_musl_detects_cdll_failure(
+    install_nextest_module: ModuleType,
+) -> None:
+    """Libc probing treats CDLL load failures as musl-compatible."""
+
+    def load_libc(name: object) -> object:
+        """Raise the same error shape ctypes can raise for a failed load."""
+        assert name is None
+        raise OSError
+
+    assert install_nextest_module._probe_libc_is_musl(load_libc) is True
+
+
+def test_is_musl_uses_ctypes_probe(
+    install_nextest_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The public libc helper exercises its ctypes.CDLL probe dependency."""
+
+    class Musl:
+        """Libc stub without glibc-only symbols."""
+
+    def load_libc(name: object) -> Musl:
+        """Return the fake musl object for the process-global libc handle."""
+        assert name is None
+        return Musl()
+
+    monkeypatch.setattr(install_nextest_module.ctypes, "CDLL", load_libc)
+    assert install_nextest_module._is_musl() is True
+    assert capsys.readouterr().out == "Detected libc for cargo-nextest: musl\n"
+
+
 @pytest.mark.parametrize(
     "key",
     [
@@ -1507,6 +1589,8 @@ def test_expected_sha_for_supported_platforms(
 def test_expected_sha_for_unsupported_platform(
     monkeypatch: pytest.MonkeyPatch,
     install_nextest_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Unsupported platforms raise a Typer exit."""
     monkeypatch.setattr(
@@ -1519,6 +1603,7 @@ def test_expected_sha_for_unsupported_platform(
         install_nextest_module._expected_sha_for_platform()
 
     assert _exit_code(excinfo.value) == 1
+    assert capsys.readouterr().err == snapshot
 
 
 def test_find_nextest_binary_prefers_path(
@@ -1692,12 +1777,15 @@ def test_install_nextest_checksum_match(
 def test_install_nextest_checksum_mismatch(
     tmp_path: Path,
     install_nextest_module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+    snapshot: SnapshotAssertion,
 ) -> None:
-    """Checksum mismatches raise a Typer exit."""
+    """Checksum mismatches produce stable stderr output."""
     binary = tmp_path / "cargo-nextest"
     binary.write_bytes(b"payload")
 
     assert not install_nextest_module.verify_nextest_binary(binary, "deadbeef")
+    assert capsys.readouterr().err == snapshot
 
 
 def test_merge_cobertura(tmp_path: Path, shell_stubs: StubManager) -> None:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -192,7 +192,7 @@ pin is updated.
 
 ## `generate-coverage` nextest checksum strategy
 
-`generate-coverage` delegates rust nextest installation to
+`generate-coverage` delegates Rust nextest installation to
 `.github/actions/generate-coverage/scripts/install_cargo_nextest.py`.
 
 The helper validates a pinned `cargo-nextest` version and picks the expected SHA-256

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -190,6 +190,21 @@ Keep `cargo_home_bin` resolution and the `BINSTALL_VERSION` pin in sync: both
 must reflect the same intended installation location and version whenever the
 pin is updated.
 
+## `generate-coverage` nextest checksum strategy
+
+`generate-coverage` delegates rust nextest installation to
+`.github/actions/generate-coverage/scripts/install_cargo_nextest.py`.
+
+The helper validates a pinned `cargo-nextest` version and picks the expected SHA-256
+using a platform key. Linux x86_64 is split into two keys:
+
+- `linux-x86_64-gnu` for the `-x86_64-unknown-linux-gnu` archive.
+- `linux-x86_64-musl` for the `-x86_64-unknown-linux-musl` archive.
+
+This distinction is intentional because the upstream artifacts are built against
+different libc ABIs, and validating against the wrong digest can block installs
+even when the same version number is used.
+
 ## `stage-release-artefacts` Action Architecture
 
 ### Staging Pipeline

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -201,7 +201,7 @@ using a platform key. Linux x86_64 is split into two keys:
 - `linux-x86_64-gnu` for the `-x86_64-unknown-linux-gnu` archive.
 - `linux-x86_64-musl` for the `-x86_64-unknown-linux-musl` archive.
 
-This distinction is intentional because the upstream artifacts are built against
+This distinction is intentional because the upstream artefacts are built against
 different libc ABIs, and validating against the wrong digest can block installs
 even when the same version number is used.
 


### PR DESCRIPTION
## Summary

`cargo-nextest` 0.9.120 ships two distinct Linux x86_64 builds:

- `x86_64-unknown-linux-gnu` (glibc) — what `cargo binstall` installs on
  GitHub-hosted Ubuntu runners
- `x86_64-unknown-linux-musl` — installed on Alpine/musl runners

The script stored a single `linux-x86_64` entry whose digest was for the
**musl** binary, so glibc runners failed verification with an immediate
checksum mismatch.

## Changes

- Split `linux-x86_64` into `linux-x86_64-gnu` and `linux-x86_64-musl`, and
  record the correct gnu digest
  (`73c7eb58…eb291`) alongside the existing musl digest (`8d717594…837d14`).
- Detect glibc vs musl in `_platform_key()` via a `gnu_get_libc_version`
  probe (present in glibc, absent in musl) and select the matching digest.
- Update the platform-key and expected-SHA tests to cover both libc variants
  (the renamed keys invalidate the previous single-key assertions).

## Validation

- `make lint` — pass (ruff + action-validator)
- `ruff format --check` — pass
- `make test` — 924 passed, 14 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
