### PR TITLE
Add a python-version input to the mutmut reusable workflow

### DIFF
--- a/.github/workflows/mutation-mutmut.yml
+++ b/.github/workflows/mutation-mutmut.yml
@@ -39,6 +39,13 @@ on:
         description: Extra `mutmut run` arguments (shell-lexed).
         type: string
         default: ""
+      python-version:
+        description: >-
+          Python version for uv. Must satisfy the caller project's
+          `requires-python`: the run step executes `uv run` inside the
+          caller's project, and setup-uv exports this as UV_PYTHON.
+        type: string
+        default: "3.13"
 
 # Default the token to no scopes; jobs opt in explicitly.
 permissions: {}
@@ -85,7 +92,7 @@ jobs:
         if: ${{ env.ACT != 'true' }}
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
-          python-version: '3.13'
+          python-version: ${{ inputs.python-version }}
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock

--- a/docs/mutation-mutmut-workflow.md
+++ b/docs/mutation-mutmut-workflow.md
@@ -88,6 +88,7 @@ jobs:
 | `mutmut-version` | pinned | Tool version; the results parser is validated against it. |
 | `module-prefix-strip` | `src/` | Prefix removed before module-glob translation. |
 | `extra-args` | (empty) | Extra `mutmut run` arguments (shell-lexed). |
+| `python-version` | `3.13` | Python for uv; must satisfy the project's `requires-python` (e.g. set `"3.14"` for `>=3.14` projects). |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

This branch adds a `python-version` input to the [`mutation-mutmut.yml`](https://github.com/leynos/shared-actions/blob/add-mutmut-python-version-input/.github/workflows/mutation-mutmut.yml) reusable workflow. The workflow previously hard-pinned `setup-uv` to Python 3.13, which exports `UV_PYTHON` for the job; because the run step executes `uv run --with mutmut` inside the caller's own project, any caller declaring `requires-python >= 3.14` fails with an interpreter-incompatibility error before mutmut can start. The defect was discovered (and reproduced locally) during the prosidy-darn estate rollout, and also affects the already-adopted hecate, repo-local-tools, and episodic callers, whose scheduled runs would fail on first real execution.

The input defaults to `3.13`, preserving existing behaviour for every current caller; `>= 3.14` projects set it explicitly. The [caller guide](https://github.com/leynos/shared-actions/blob/add-mutmut-python-version-input/docs/mutation-mutmut-workflow.md) inputs table documents the constraint.

## Review walkthrough

- [.github/workflows/mutation-mutmut.yml](https://github.com/leynos/shared-actions/blob/add-mutmut-python-version-input/.github/workflows/mutation-mutmut.yml): the new input and its use in the Setup uv step.
- [docs/mutation-mutmut-workflow.md](https://github.com/leynos/shared-actions/blob/add-mutmut-python-version-input/docs/mutation-mutmut-workflow.md): inputs-table row.

## Validation

- `actionlint`: clean
- YAML parses (`yaml.safe_load`)
- `make markdownlint`: 0 errors

## Notes

Estate follow-up after merge: bump the hecate, repo-local-tools, and episodic callers to the new pin with `python-version: "3.14"`, and unblock the prosidy-darn Python-side adoption.
