### PR TITLE
Preserve mutation artefacts when a run overruns its budget

### DIFF
--- a/.github/workflows/mutation-cargo.yml
+++ b/.github/workflows/mutation-cargo.yml
@@ -134,7 +134,11 @@ jobs:
     needs: detect
     if: ${{ needs.detect.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
+    # The job ceiling sits at the platform maximum while the run step
+    # carries the caller's `timeout-minutes` budget: a step timeout fails
+    # the step (so the always() artefact upload still runs), whereas a
+    # job timeout cancels everything, losing the partial mutants.out.
+    timeout-minutes: 360
     permissions:
       contents: read
       id-token: write
@@ -198,6 +202,7 @@ jobs:
 
       - name: Run mutation testing
         shell: bash
+        timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
         env:
           CARGO_TERM_COLOR: always
           INPUT_DIR: ${{ matrix.dir }}

--- a/.github/workflows/mutation-mutmut.yml
+++ b/.github/workflows/mutation-mutmut.yml
@@ -53,7 +53,11 @@ permissions: {}
 jobs:
   mutants:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
+    # The job ceiling sits at the platform maximum while the run step
+    # carries the caller's `timeout-minutes` budget: a step timeout fails
+    # the step (so the always() artefact upload still runs), whereas a
+    # job timeout cancels everything, losing the results listing.
+    timeout-minutes: 360
     permissions:
       contents: read
       id-token: write
@@ -121,6 +125,7 @@ jobs:
       - name: Run mutation testing
         if: ${{ steps.detect.outputs.has_changes == 'true' }}
         shell: bash
+        timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
         env:
           INPUT_FILES: ${{ steps.detect.outputs.root_files }}
           INPUT_MUTMUT_VERSION: ${{ inputs.mutmut-version }}


### PR DESCRIPTION
## Summary

Wireframe's Stage E dispatch run ([28806201980](https://github.com/leynos/wireframe/actions/runs/28806201980)) lost root shard 2's entire `mutants.out` to the job-level timeout: job cancellation skips even `always()` steps, discarding ~4.8 hours of incrementally written results. This branch moves the caller's `timeout-minutes` budget onto the **run step** in both reusable workflows and raises the job ceiling to the platform maximum, so an overrun fails the step and the `always()` artefact upload still captures partial results for the merged summary.

Expressions cannot do arithmetic, so the grace window is (360 − budget) rather than a fixed offset; budget = 360 degenerates to current behaviour.

## Validation

- YAML parse, `actionlint`, and `zizmor`: clean on both workflows (actionlint caught the initial `+ 10` arithmetic attempt — expressions have no operators)