### PR TITLE
Document mutmut's working-copy caveat for caller test suites

### DIFF
--- a/docs/mutation-mutmut-workflow.md
+++ b/docs/mutation-mutmut-workflow.md
@@ -96,6 +96,15 @@ jobs:
   configuration surface change between releases (3.6 renamed
   `paths_to_mutate` to `source_paths` and dropped file-path run
   arguments). Override only alongside a parser check.
+- mutmut runs the suite inside a `mutants/` working copy that contains
+  only `tests/`, `test/`, `pyproject.toml`, `setup.cfg`, root
+  `test*.py`, and whatever `[tool.mutmut] also_copy` lists. Tests that
+  read other repo-root paths fail the baseline there — notably a
+  workflow contract test reading `.github/workflows/`. Guard such
+  tests with a module-level
+  `pytest.mark.skipif(not <path>.exists(), ...)`, exclude them from
+  mutmut's test selection, or add the paths to `also_copy`. (Observed
+  live on the estate's first scheduled polythene run.)
 - "No tests" survivors mean mutmut found no covering test for the
   function; they are coverage gaps rather than assertion gaps.
 - Some survivors are equivalent mutants; triage before turning the


### PR DESCRIPTION
## Summary

The estate's first scheduled polythene mutation run failed its baseline with a FileNotFoundError: its workflow contract test reads `.github/workflows/mutation-testing.yml`, which mutmut's `mutants/` working copy does not contain. This branch documents mutmut's copy set and the three remedies (module-level skipif guard, test-selection exclusion, or `also_copy`) in [docs/mutation-mutmut-workflow.md](https://github.com/leynos/shared-actions/blob/document-mutmut-sandbox-caveat/docs/mutation-mutmut-workflow.md), so future callers avoid the trap. The eight affected estate repos are being patched with the skipif guard in parallel.

## Validation

- `make markdownlint`: 0 errors