### PR TITLE
Add a setup-commands input to the cargo mutation workflow

### DIFF
--- a/.github/workflows/mutation-cargo.yml
+++ b/.github/workflows/mutation-cargo.yml
@@ -58,6 +58,14 @@ on:
           "--all-features" so feature-gated tests run against mutants.
         type: string
         default: ""
+      setup-commands:
+        description: >-
+          Shell commands run in each mutants job before cargo-mutants
+          (e.g. installing a linker such as mold, or system packages
+          the build needs). Executed with bash under `set -euo
+          pipefail`; empty means no extra setup.
+        type: string
+        default: ""
 
 # Default the token to no scopes; jobs opt in explicitly.
 permissions: {}
@@ -184,6 +192,17 @@ jobs:
           else
             cargo binstall --no-confirm cargo-mutants
           fi
+
+      - name: Run setup commands
+        if: ${{ inputs.setup-commands != '' }}
+        shell: bash
+        env:
+          SETUP_COMMANDS: ${{ inputs.setup-commands }}
+        run: |
+          set -euo pipefail
+          script="${RUNNER_TEMP}/mutation-setup-commands.sh"
+          printf '%s\n' "${SETUP_COMMANDS}" > "${script}"
+          bash -euo pipefail "${script}"
 
       - name: Install uv (act)
         if: ${{ env.ACT == 'true' }}

--- a/docs/mutation-cargo-workflow.md
+++ b/docs/mutation-cargo-workflow.md
@@ -83,6 +83,7 @@ jobs:
 | `shard-count` | `6` | Fan-out for full dispatch runs (scoped runs stay single-shard). |
 | `cargo-mutants-version` | pinned | Tool version; the summary parser is validated against it. |
 | `extra-args` | (empty) | Extra cargo-mutants arguments (shell-lexed), e.g. `--all-features`. |
+| `setup-commands` | (empty) | Shell commands run before cargo-mutants in each mutants job (e.g. `sudo apt-get install -y mold` when the repo's `.cargo/config.toml` selects that linker). |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Callers cannot inject steps into a `workflow_call` job, so repositories whose builds need job-level preparation (linkers, system packages) had no way to satisfy it before cargo-mutants runs. The concrete case is review feedback on [agent-template-rust#52](https://github.com/leynos/agent-template-rust/pull/52): generated repos render `.cargo/config.toml` with `-fuse-ld=mold` and their CI installs mold before any cargo command — the mutation baseline would fail to link on a bare runner.

This branch adds a `setup-commands` input (default empty) to [.github/workflows/mutation-cargo.yml](https://github.com/leynos/shared-actions/blob/add-mutation-setup-commands/.github/workflows/mutation-cargo.yml), executed in each mutants job after toolchain setup via a temp script under `set -euo pipefail`, and documents it in the [caller guide](https://github.com/leynos/shared-actions/blob/add-mutation-setup-commands/docs/mutation-cargo-workflow.md). The commands run with the same privileges the caller's own workflows already hold.

## Validation

- YAML parse, `actionlint`, `zizmor`: clean
- `make markdownlint`: 0 errors