### PR TITLE
Fail fast when the mutmut workflow's python-version is below 3.13

### DIFF
--- a/.github/workflows/mutation-mutmut.yml
+++ b/.github/workflows/mutation-mutmut.yml
@@ -41,9 +41,13 @@ on:
         default: ""
       python-version:
         description: >-
-          Python version for uv. Must satisfy the caller project's
-          `requires-python`: the run step executes `uv run` inside the
-          caller's project, and setup-uv exports this as UV_PYTHON.
+          Python version for uv. Must be 3.13 or newer (the workflow's
+          helper scripts require >= 3.13, and setup-uv exports this as
+          UV_PYTHON for the whole job) AND must satisfy the caller
+          project's `requires-python`, because the run step executes
+          `uv run` inside the caller's project. Projects baselined
+          below 3.13 whose `requires-python` upper bound excludes 3.13
+          cannot use this workflow.
         type: string
         default: "3.13"
 
@@ -62,6 +66,19 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Validate python-version
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: |
+          set -euo pipefail
+          lowest=$(printf '%s\n' "3.13" "${PYTHON_VERSION}" | sort -V | head -n 1)
+          if [[ "${lowest}" != "3.13" ]]; then
+            echo "python-version must be 3.13 or newer (got ${PYTHON_VERSION}):" \
+              "the workflow's helper scripts require >= 3.13." >&2
+            exit 1
+          fi
+
       - name: Checkout caller repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docs/mutation-mutmut-workflow.md
+++ b/docs/mutation-mutmut-workflow.md
@@ -88,7 +88,7 @@ jobs:
 | `mutmut-version` | pinned | Tool version; the results parser is validated against it. |
 | `module-prefix-strip` | `src/` | Prefix removed before module-glob translation. |
 | `extra-args` | (empty) | Extra `mutmut run` arguments (shell-lexed). |
-| `python-version` | `3.13` | Python for uv; must satisfy the project's `requires-python` (e.g. set `"3.14"` for `>=3.14` projects). |
+| `python-version` | `3.13` | Python for uv; must be **3.13 or newer** (the workflow's helper scripts require it — the job fails fast otherwise) and must satisfy the project's `requires-python` (e.g. set `"3.14"` for `>=3.14` projects). |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Review of [agent-template-python#24](https://github.com/leynos/agent-template-python/pull/24) found that a `python-version` below 3.13 breaks the workflow before mutation testing starts: setup-uv exports it as `UV_PYTHON` job-wide, and the helper scripts' inline metadata requires Python >= 3.13, so detection fails with an unhelpful interpreter-resolution error. This branch adds a first-step guard rejecting sub-3.13 values with an explicit message (plain `sort -V` comparison, so it runs before any uv setup) and documents the floor on the [input](https://github.com/leynos/shared-actions/blob/validate-mutmut-python-version/.github/workflows/mutation-mutmut.yml) and in the [caller guide](https://github.com/leynos/shared-actions/blob/validate-mutmut-python-version/docs/mutation-mutmut-workflow.md).

## Validation

- YAML parse and `actionlint`: clean
- `make markdownlint`: 0 errors