### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
+    env:
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +50,32 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make check-fmt
         shell: bash
+      - name: Setup Rust
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./.github/actions/setup-rust
+      - name: Cache Whitaker installer
+        if: matrix.os == 'ubuntu-latest'
+        # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install Whitaker
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm whitaker-installer@${{ env.WHITAKER_INSTALLER_VERSION }}
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version ${{ env.WHITAKER_INSTALLER_VERSION }}
+            fi
+          fi
+          whitaker-installer
       - name: Run lint checks
         if: matrix.os == 'ubuntu-latest'
         run: make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,10 @@ jobs:
           set -euo pipefail
           if ! command -v whitaker-installer >/dev/null 2>&1; then
             if cargo binstall --version >/dev/null 2>&1; then
-              cargo binstall --no-confirm whitaker-installer@${{ env.WHITAKER_INSTALLER_VERSION }}
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
             else
               echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
-              cargo install --locked whitaker-installer --version ${{ env.WHITAKER_INSTALLER_VERSION }}
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
             fi
           fi
           whitaker-installer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ to bare names on `PATH`. The following variables are set at the top of
 | `UV`               | `~/.local/bin/uv`, otherwise `uv`                                                                        |
 | `ACTION_VALIDATOR` | `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then `action-validator` (on `PATH`) |
 | `MDLINT`           | `~/.bun/bin/markdownlint-cli2`, then `PATH`                                                              |
+| `WHITAKER`         | `~/.local/bin/whitaker`, otherwise `whitaker`                                                            |
 
 For `ACTION_VALIDATOR`, the concrete lookup order is
 `~/.bun/bin/action-validator`, then `~/.cargo/bin/action-validator`, then

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean help test lint markdownlint nixie fmt check-fmt typecheck
+.PHONY: all clean help test lint lint-whitaker markdownlint nixie fmt check-fmt typecheck
 
 export GITHUB_ACTION_PATH ?= $(CURDIR)
 
@@ -20,6 +20,7 @@ MDLINT ?= $(if $(wildcard $(HOME)/.bun/bin/markdownlint-cli2),$(HOME)/.bun/bin/m
 NIXIE ?= nixie
 RUFF_FIX_RULES ?= D202,I001
 UV ?= $(if $(wildcard $(HOME)/.local/bin/uv),$(HOME)/.local/bin/uv,uv)
+WHITAKER ?= $(if $(wildcard $(HOME)/.local/bin/whitaker),$(HOME)/.local/bin/whitaker,whitaker)
 
 test: .venv ## Run tests
 	$(UV) run --with typer --with packaging --with plumbum --with pyyaml --with pytest-xdist --with pytest-bdd --with syrupy --with hypothesis pytest -n auto --dist worksteal -v
@@ -32,10 +33,14 @@ endif
 	$(UV) venv
 	$(UV) sync --group dev
 
-lint: ## Check test scripts and actions
+lint: ## Check test scripts and actions, then run the Whitaker Dylint suite
 	$(UV) tool run ruff check
 	find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) \
 		-exec $(ACTION_VALIDATOR) {} \;
+	$(MAKE) lint-whitaker
+
+lint-whitaker: ## Run the Whitaker Dylint suite on rust-toy-app with warnings denied
+	cd rust-toy-app && RUSTFLAGS="-D warnings" $(WHITAKER) --all -- --all-targets --all-features
 
 typecheck: .venv ## Run static type checking with Ty
 	./.venv/bin/ty check \

--- a/rust-toy-app/Cargo.lock
+++ b/rust-toy-app/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
 name = "rust-toy-app"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "clap_mangen",

--- a/rust-toy-app/Cargo.toml
+++ b/rust-toy-app/Cargo.toml
@@ -19,6 +19,7 @@ clap_mangen = "0.3.0"
 time = { version = "0.3.36", features = ["formatting"] }
 
 [dev-dependencies]
+anyhow = "1"
 assert_cmd = "2"
 predicates = "3"
 rstest = "0.26"

--- a/rust-toy-app/build.rs
+++ b/rust-toy-app/build.rs
@@ -2,9 +2,12 @@
 
 use std::env;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 
+// The build script only needs `cli::command()`; the rest of the module is
+// exercised by the library crate, so unused items here are expected.
+#[allow(dead_code)]
 #[path = "src/cli.rs"]
 mod cli;
 
@@ -27,42 +30,10 @@ fn main() -> std::io::Result<()> {
 
     // Prefer the explicit target directory set by cross / CARGO_TARGET_DIR.
     // Fall back to deriving the root from OUT_DIR's ancestor structure.
-    let target_root: std::path::PathBuf =
-        if let Some(cargo_target_dir) = env::var_os("CARGO_TARGET_DIR") {
-            std::path::PathBuf::from(cargo_target_dir)
-        } else {
-            let profile_dir = out_dir.ancestors().nth(3).ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("unexpected OUT_DIR structure: {}", out_dir.display()),
-                )
-            })?;
-            if profile_dir.file_name().and_then(|name| name.to_str()) != Some(profile.as_str()) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("unexpected OUT_DIR profile: {}", out_dir.display()),
-                ));
-            }
-            let profile_parent = profile_dir.parent().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("unexpected OUT_DIR structure: {}", out_dir.display()),
-                )
-            })?;
-            if profile_parent.file_name().and_then(|name| name.to_str()) == Some(target.as_str()) {
-                profile_parent
-                    .parent()
-                    .ok_or_else(|| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("unexpected OUT_DIR structure: {}", out_dir.display()),
-                        )
-                    })?
-                    .to_path_buf()
-            } else {
-                profile_parent.to_path_buf()
-            }
-        };
+    let target_root: PathBuf = match env::var_os("CARGO_TARGET_DIR") {
+        Some(cargo_target_dir) => PathBuf::from(cargo_target_dir),
+        None => derive_target_root(&out_dir, &target, &profile)?,
+    };
 
     let man_dir = target_root
         .join("generated-man")
@@ -82,6 +53,36 @@ fn main() -> std::io::Result<()> {
     man.render(&mut buffer)?;
     std::fs::write(man_dir.join("rust-toy-app.1"), &buffer)?;
     Ok(())
+}
+
+/// Derives the Cargo target root from `OUT_DIR`'s ancestor structure.
+///
+/// `OUT_DIR` is `<target-root>[/<target>]/<profile>/build/<pkg>/out`; this
+/// walks up to the profile directory, validates its name, and strips the
+/// optional target triple component.
+fn derive_target_root(out_dir: &Path, target: &str, profile: &str) -> std::io::Result<PathBuf> {
+    let structure_error = || {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("unexpected OUT_DIR structure: {}", out_dir.display()),
+        )
+    };
+    let profile_dir = out_dir.ancestors().nth(3).ok_or_else(structure_error)?;
+    if profile_dir.file_name().and_then(|name| name.to_str()) != Some(profile) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("unexpected OUT_DIR profile: {}", out_dir.display()),
+        ));
+    }
+    let profile_parent = profile_dir.parent().ok_or_else(structure_error)?;
+    if profile_parent.file_name().and_then(|name| name.to_str()) == Some(target) {
+        Ok(profile_parent
+            .parent()
+            .ok_or_else(structure_error)?
+            .to_path_buf())
+    } else {
+        Ok(profile_parent.to_path_buf())
+    }
 }
 
 /// Returns the man-page date string.

--- a/rust-toy-app/dylint.toml
+++ b/rust-toy-app/dylint.toml
@@ -1,0 +1,11 @@
+# Whitaker Dylint suite configuration for rust-toy-app.
+#
+# The build script writes the generated man page to the ambient Cargo target
+# directory (a location dictated by Cargo and the release-staging action), so
+# capability-based filesystem handles are not applicable there.
+# The runtime probe's unit tests (compiled into both the `runtime` and
+# `rust_build_release` integration test crates) write fixture Python modules
+# and fake executables into `tempfile::TempDir`s; they are test support
+# utilities rather than product code.
+[no_std_fs_operations]
+excluded_crates = ["build_script_build", "runtime", "rust_build_release"]

--- a/rust-toy-app/src/lib.rs
+++ b/rust-toy-app/src/lib.rs
@@ -16,6 +16,8 @@ pub mod cli;
 
 #[cfg(test)]
 mod tests {
+    //! Unit tests for the greeting CLI, demonstrating rstest fixtures and
+    //! parametrized cases for coverage-collection validation.
     use super::cli::Cli;
     use rstest::{fixture, rstest};
 

--- a/rust-toy-app/tests/common/mod.rs
+++ b/rust-toy-app/tests/common/mod.rs
@@ -3,10 +3,10 @@
 use glob::glob;
 use std::path::Path;
 
-#[expect(
-    dead_code,
-    reason = "helper is only needed when tests execute the default-target path"
-)]
+// `allow` rather than `expect`: this module is compiled into several test
+// crates, and the helper is dead only in those that skip the default-target
+// path.
+#[allow(dead_code)]
 pub fn assert_manpage_exists() {
     let target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
     assert_manpage_exists_in(Path::new(&target));
@@ -15,6 +15,10 @@ pub fn assert_manpage_exists() {
 pub fn assert_manpage_exists_in(root: impl AsRef<Path>) {
     let root = root.as_ref();
     let patterns = [
+        // Stable location written by build.rs since PR #260.
+        root.join("generated-man/*/debug/rust-toy-app.1"),
+        root.join("generated-man/*/release/rust-toy-app.1"),
+        // Legacy OUT_DIR location, retained for older build artefacts.
         root.join("debug/build/rust-toy-app-*/out/rust-toy-app.1"),
         root.join("release/build/rust-toy-app-*/out/rust-toy-app.1"),
     ];

--- a/rust-toy-app/tests/cucumber.rs
+++ b/rust-toy-app/tests/cucumber.rs
@@ -25,6 +25,7 @@
 
 use std::process::{Command, Output};
 
+use anyhow::Context;
 use cucumber::{given, then, when, World};
 use rust_toy_app::cli::Cli;
 
@@ -62,9 +63,13 @@ fn name_is_provided(world: &mut GreetingWorld, name: String) {
 }
 
 #[when("the greeting is generated")]
-fn greeting_is_generated(world: &mut GreetingWorld) {
-    let cli = world.cli.as_ref().expect("CLI not configured; missing 'Given' step");
+fn greeting_is_generated(world: &mut GreetingWorld) -> anyhow::Result<()> {
+    let cli = world
+        .cli
+        .as_ref()
+        .context("CLI not configured; missing 'Given' step")?;
     world.greeting = Some(cli.run());
+    Ok(())
 }
 
 #[then(expr = "the output should be {string}")]
@@ -103,31 +108,35 @@ fn binary_exists(world: &mut GreetingWorld) {
 }
 
 #[when(expr = "I run it with {string}")]
-fn run_with_args(world: &mut GreetingWorld, args: String) {
+fn run_with_args(world: &mut GreetingWorld, args: String) -> anyhow::Result<()> {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_rust-toy-app"));
     for arg in args.split_whitespace() {
         cmd.arg(arg);
     }
-    world.output = Some(cmd.output().expect("failed to execute binary"));
+    world.output = Some(cmd.output().context("failed to execute binary")?);
+    Ok(())
 }
 
 #[when("I run it without arguments")]
-fn run_without_args(world: &mut GreetingWorld) {
+fn run_without_args(world: &mut GreetingWorld) -> anyhow::Result<()> {
     let output = Command::new(env!("CARGO_BIN_EXE_rust-toy-app"))
         .output()
-        .expect("failed to execute binary");
+        .context("failed to execute binary")?;
     world.output = Some(output);
+    Ok(())
 }
 
 #[then(expr = "the exit code should be {int}")]
-fn exit_code_should_be(world: &mut GreetingWorld, expected: i32) {
-    let output = world.output.as_ref().expect("no output captured");
-    let actual = output.status.code().expect("no exit code");
-    assert_eq!(
-        actual, expected,
+fn exit_code_should_be(world: &mut GreetingWorld, expected: i32) -> anyhow::Result<()> {
+    let output = world.output.as_ref().context("no output captured")?;
+    let actual = output.status.code().context("no exit code")?;
+    anyhow::ensure!(
+        actual == expected,
         "Expected exit code {} but got {}",
-        expected, actual
+        expected,
+        actual
     );
+    Ok(())
 }
 
 /// Enum to select which output stream to check.
@@ -137,29 +146,34 @@ enum OutputStream {
 }
 
 /// Helper function to check if an output stream contains the expected string.
-fn check_output_stream_contains(world: &mut GreetingWorld, stream: OutputStream, expected: String) {
-    let output = world.output.as_ref().expect("no output captured");
+fn check_output_stream_contains(
+    world: &mut GreetingWorld,
+    stream: OutputStream,
+    expected: String,
+) -> anyhow::Result<()> {
+    let output = world.output.as_ref().context("no output captured")?;
     let (content, stream_name) = match stream {
         OutputStream::Stdout => (String::from_utf8_lossy(&output.stdout), "stdout"),
         OutputStream::Stderr => (String::from_utf8_lossy(&output.stderr), "stderr"),
     };
-    assert!(
+    anyhow::ensure!(
         content.contains(&expected),
         "Expected {} to contain '{}' but got: {}",
         stream_name,
         expected,
         content
     );
+    Ok(())
 }
 
 #[then(expr = "the output should contain {string}")]
-fn output_contains(world: &mut GreetingWorld, expected: String) {
-    check_output_stream_contains(world, OutputStream::Stdout, expected);
+fn output_contains(world: &mut GreetingWorld, expected: String) -> anyhow::Result<()> {
+    check_output_stream_contains(world, OutputStream::Stdout, expected)
 }
 
 #[then(expr = "the stderr should contain {string}")]
-fn stderr_contains(world: &mut GreetingWorld, expected: String) {
-    check_output_stream_contains(world, OutputStream::Stderr, expected);
+fn stderr_contains(world: &mut GreetingWorld, expected: String) -> anyhow::Result<()> {
+    check_output_stream_contains(world, OutputStream::Stderr, expected)
 }
 
 fn main() {

--- a/rust-toy-app/tests/runtime.rs
+++ b/rust-toy-app/tests/runtime.rs
@@ -145,6 +145,8 @@ fn replace_uv_binary_override(bin: Option<OsString>) -> Option<OsString> {
 
 #[cfg(test)]
 mod tests {
+    //! Unit tests for the runtime-availability probe, using temporary
+    //! fixture modules and override guards to avoid touching real runtimes.
     use super::*;
     use std::fs;
     use std::mem;

--- a/rust-toy-app/tests/rust_build_release.rs
+++ b/rust-toy-app/tests/rust_build_release.rs
@@ -3,7 +3,6 @@
 mod common;
 
 use assert_cmd::prelude::*;
-use common::assert_manpage_exists_in;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -47,8 +46,18 @@ fn builds_release_binary_and_manpage() {
         assert!(project_dir
             .join(format!("target/{target}/release/rust-toy-app"))
             .exists());
-        // The build script writes the man page beneath the top-level target
-        // root (target/generated-man/<target>/release), so search from there.
-        assert_manpage_exists_in(project_dir.join("target"));
+        // build.rs writes the man page to the deterministic path
+        // target/generated-man/<target>/release, so assert the exact file for
+        // the current target rather than globbing the whole target root;
+        // otherwise an artefact left by an earlier target or a debug build
+        // would satisfy the assertion.
+        let manpage = project_dir.join(format!(
+            "target/generated-man/{target}/release/rust-toy-app.1"
+        ));
+        assert!(
+            manpage.exists(),
+            "man page for {target} not found at {}",
+            manpage.display()
+        );
     }
 }

--- a/rust-toy-app/tests/rust_build_release.rs
+++ b/rust-toy-app/tests/rust_build_release.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use assert_cmd::prelude::*;
-use common::{assert_manpage_exists, assert_manpage_exists_in};
+use common::assert_manpage_exists_in;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -47,7 +47,8 @@ fn builds_release_binary_and_manpage() {
         assert!(project_dir
             .join(format!("target/{target}/release/rust-toy-app"))
             .exists());
-        let target_root = project_dir.join(format!("target/{target}"));
-        assert_manpage_exists_in(&target_root);
+        // The build script writes the man page beneath the top-level target
+        // root (target/generated-man/<target>/release), so search from there.
+        assert_manpage_exists_in(project_dir.join("target"));
     }
 }


### PR DESCRIPTION
## Summary

This pull request adopts the Whitaker Dylint suite (v0.2.5) in this repository's lint gate and CI, as part of the estate-wide rollout (reference adoption: leynos/netsuke#410).

Because this repository's CI and actions are consumed estate-wide, the change is tightly scoped. The only first-party Rust code exercised by the repository's own CI is the `rust-toy-app` crate (built by the `rust-toy-app.yml` PR workflow and used by the coverage and packaging action self-tests); the remaining Rust code consists of minimal Cargo fixtures under `.github/actions/*/tests/fixtures/`. Whitaker is therefore wired into the repository's own `make lint` path and the `ci.yml` lint leg only, scoped to `rust-toy-app`. No reusable workflow or composite action consumed by other repositories is modified. The crate has no Cranelift configuration, so the plain `whitaker-installer` is used.

Adopting the suite surfaced one pre-existing test failure on a clean checkout: `builds_manpage_into_out_dir` still searched the legacy `OUT_DIR` man-page layout after #260 moved the build script's output to `target/generated-man`. The shared helper now knows the stable location.

## Review walkthrough

- [`Makefile`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/Makefile) — adds the `WHITAKER` tool variable (following the existing resolution convention) and a `lint-whitaker` target run from the `rust-toy-app` Cargo root with warnings denied; `lint` invokes it after ruff and action-validator.
- [`.github/workflows/ci.yml`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/.github/workflows/ci.yml) — on the Ubuntu lint leg, sets up Rust via the repository's own `setup-rust` action (which provides cargo-binstall), caches the pinned `whitaker-installer` binary, and installs the suite before `make lint`, with a `cargo install` fallback when cargo-binstall is unavailable.
- [`rust-toy-app/dylint.toml`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/rust-toy-app/dylint.toml) — excludes the build script and the `runtime` and `rust_build_release` test crates from `no_std_fs_operations`, with rationale.
- [`rust-toy-app/build.rs`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/rust-toy-app/build.rs) — extracts `derive_target_root` to resolve `bumpy_road_function` and allows `dead_code` on the included CLI module.
- [`rust-toy-app/tests/cucumber.rs`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/rust-toy-app/tests/cucumber.rs) — converts the step functions to fallible steps returning `anyhow::Result`, removing `expect` calls flagged by `no_expect_outside_tests`.
- [`rust-toy-app/tests/common/mod.rs`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/rust-toy-app/tests/common/mod.rs) — swaps an unfulfillable `#[expect(dead_code)]` for `#[allow]` and teaches `assert_manpage_exists_in` the stable `target/generated-man` layout.
- [`AGENTS.md`](https://github.com/leynos/shared-actions/blob/adopt-whitaker/AGENTS.md) — documents the `WHITAKER` variable in the Makefile tool resolution table.

## Validation

- `whitaker --all -- --all-targets --all-features` (from `rust-toy-app`, `RUSTFLAGS="-D warnings"`) — exit 0.
- `cargo test --all-targets --all-features` (from `rust-toy-app`, `RUSTFLAGS="-D warnings"`) — all suites pass, including the previously failing `builds_manpage_into_out_dir`.
- `make check-fmt lint typecheck` — pass; the `lint` gate now runs ruff, action-validator, and the Whitaker suite.
- `make test` — 995 passed, 14 skipped.
- `make markdownlint` — 0 errors; `make nixie` — all diagrams validated.
- `action-validator .github/workflows/ci.yml` — valid.
