### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/mutation-testing-caller.yml
+++ b/.github/workflows/mutation-testing-caller.yml
@@ -1,0 +1,31 @@
+# Thin caller of this repository's own mutation-mutmut reusable
+# workflow, pinned by SHA like any external consumer; caller guide:
+# docs/mutation-mutmut-workflow.md. Named mutation-testing-caller.yml
+# (precedent: dependabot-automerge-caller.yml) because this repository
+# hosts the reusable mutation workflows themselves.
+name: Mutation testing
+
+on:
+  schedule:
+    - cron: "50 11 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@859416a90eb3987b46a57682c5d6b8964ad3f0a6
+    with:
+      # Mutable Python source lives in workflow_scripts/, not src/.
+      paths: "workflow_scripts/"
+      # Flat package layout: changed-file paths already start at the
+      # package directory, so nothing is stripped before module-glob
+      # translation.
+      module-prefix-strip: ""

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ target/
 
 # Memtrace local database
 .memdb/
+
+# mutmut mutation-testing working copy
+/mutants/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,23 @@ typing = "typ"
 # Enforce NumPy docstring style
 convention = "numpy"
 
+[tool.mutmut]
+# Mutate only the reusable-workflow helper scripts. The .github/actions
+# scripts are excluded: mutmut's sandbox does not copy .github/, their
+# tests are co-located with the action sources, and several rely on
+# GITHUB_ACTION_PATH discovery and subprocess execution that mutmut's
+# in-process attribution cannot see.
+source_paths = ["workflow_scripts/"]
+# Select only the in-process unit tests; the act-gated workflow tests
+# under tests/workflows (ACT_WORKFLOW_TESTS) must stay out of mutmut's
+# selection.
+pytest_add_cli_args_test_selection = ["workflow_scripts/tests/"]
+do_not_mutate = ["workflow_scripts/tests/*"]
+# The root conftest.py makes workflow_scripts importable from the
+# sandbox and registers the cmd-mox plugin; pytest.ini keeps the pytest
+# configuration identical inside mutants/.
+also_copy = ["conftest.py", "pytest.ini"]
+
 [tool.pytest.ini_options]
 # Ensure asyncio fixtures create a new event loop for each test
 asyncio_default_fixture_loop_scope = "function"

--- a/workflow_scripts/tests/test_mutation_detect_changes.py
+++ b/workflow_scripts/tests/test_mutation_detect_changes.py
@@ -51,6 +51,11 @@ def git_repo(tmp_path: Path) -> Path:
     """Initialize a git repository with one old commit on ``main``."""
     repo = tmp_path / "repo"
     repo.mkdir()
+    # mutmut's mutation trampoline resolves the configured source_paths
+    # strictly against the current working directory on every hit; tests
+    # that chdir into this repository need the directory to exist or the
+    # mutation run's baseline fails with FileNotFoundError.
+    (repo / "workflow_scripts").mkdir()
     _git(repo, "init", "-q", "-b", "main")
     _commit_file(repo, "README.md", commit_date=OLD_COMMIT_DATE, content="hi\n")
     return repo

--- a/workflow_scripts/tests/test_mutation_testing_caller.py
+++ b/workflow_scripts/tests/test_mutation_testing_caller.py
@@ -1,0 +1,150 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in this repository's own reusable workflow,
+``.github/workflows/mutation-mutmut.yml``, which carries its own unit
+and integration tests; the caller
+(``.github/workflows/mutation-testing-caller.yml``) is declarative
+configuration pinned by SHA like any external consumer. These tests
+parse the caller with PyYAML and pin the contract it must uphold, so
+drift (repointing the pin at a branch, widening permissions, or losing
+the flat-layout configuration) fails CI on the pull request rather than
+surfacing in a scheduled or manual run.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "mutation-testing-caller.yml"
+)
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW_PATH.exists(),
+    reason="workflow file not present in this working copy (e.g. inside "
+    "mutmut's mutants/ sandbox, which does not copy .github/)",
+)
+
+#: The shared-actions commit the caller pins. Bump the workflow and this
+#: constant together.
+PINNED_SHA = "859416a90eb3987b46a57682c5d6b8964ad3f0a6"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+)
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return typ.cast("dict[str, object]", triggers)
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    job = typ.cast("dict[str, object]", jobs)["mutation"]
+    assert isinstance(job, dict), "jobs.mutation must be a mapping"
+    return typ.cast("dict[str, object]", job)
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the reusable workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert isinstance(uses, str), "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
+        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the workflow and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch declares no inputs."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "50 11 * * *"}], (
+        f"on.schedule must be the daily 11:50 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    assert isinstance(dispatch, dict)
+    assert not dispatch.get("inputs"), (
+        "on.workflow_dispatch must not declare inputs; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller sets the flat-layout paths and prefix strip, nothing else."""
+    with_block = _mutation_job(_load()).get("with")
+    assert with_block == {
+        "paths": "workflow_scripts/",
+        "module-prefix-strip": "",
+    }, (
+        "jobs.mutation.with must set exactly paths 'workflow_scripts/' "
+        "(the mutable source lives there, not under src/) and "
+        "module-prefix-strip '' (flat layout: changed-file paths already "
+        f"start at the package directory), got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

Enrols this repository in the estate-wide scheduled mutation-testing
rollout. The caller invokes this repository's own reusable
[mutation-mutmut.yml](https://github.com/leynos/shared-actions/blob/main/.github/workflows/mutation-mutmut.yml)
workflow pinned to `859416a` — by SHA, exactly as an external consumer
would. The workflow is informational only: a daily scoped guard (25-hour
change window over `workflow_scripts/`) plus full runs on manual
dispatch; it reports survivors without failing the build.

Because this repository hosts the reusable mutation workflows
themselves, the caller is named
[mutation-testing-caller.yml](https://github.com/leynos/shared-actions/blob/add-mutation-testing/.github/workflows/mutation-testing-caller.yml)
(precedent: `dependabot-automerge-caller.yml`) rather than
`mutation-testing.yml`, to avoid confusion with `mutation-mutmut.yml`,
`mutation-cargo.yml`, and the `test-mutation-*.yml` suites.

## Configuration

[`[tool.mutmut]`](https://github.com/leynos/shared-actions/blob/add-mutation-testing/pyproject.toml) in
`pyproject.toml`:

- `source_paths = ["workflow_scripts/"]` — the reusable-workflow helper
  scripts, which have a dedicated in-process unit-test suite under
  `workflow_scripts/tests/`. The `.github/actions/*/` Python scripts are
  **not** enrolled: mutmut's `mutants/` sandbox does not copy
  `.github/`, their tests are co-located with the action sources, and
  several depend on `GITHUB_ACTION_PATH` discovery and subprocess
  execution that mutmut's in-process attribution cannot see. They can be
  revisited separately if desired.
- `pytest_add_cli_args_test_selection = ["workflow_scripts/tests/"]` —
  keeps the act-gated `tests/workflows` suite (`ACT_WORKFLOW_TESTS`
  opt-in) and the action tests out of mutation runs.
- `do_not_mutate = ["workflow_scripts/tests/*"]` — the tests ride inside
  the source tree and must not be mutated.
- `also_copy = ["conftest.py", "pytest.ini"]` — the root `conftest.py`
  makes `workflow_scripts` importable from the sandbox and registers the
  cmd-mox plugin; `pytest.ini` keeps pytest configuration identical
  inside `mutants/`.

Caller `with:` block:

- `paths: "workflow_scripts/"` — change detection matches the mutable
  source (the default is `src/`).
- `module-prefix-strip: ""` — flat package layout; changed-file paths
  already start at the package directory.

All other inputs keep their defaults (Python 3.13, mutmut 3.6.0,
25-hour window, 90-minute step budget).

## Contract test

[workflow_scripts/tests/test_mutation_testing_caller.py](https://github.com/leynos/shared-actions/blob/add-mutation-testing/workflow_scripts/tests/test_mutation_testing_caller.py)
pins the caller's contract in the repository's own pytest suite: exact
SHA pin, least-privilege permissions (`contents: read`,
`id-token: write`; top-level `{}`), per-ref non-cancelling concurrency,
the `50 11 * * *` schedule with a plain dispatch, and the exact
`with:` block. It carries a `skipif` guard for mutmut's `mutants/`
sandbox, which does not copy `.github/`.

One pre-existing test needed a one-line accommodation:
[test_mutation_detect_changes.py](https://github.com/leynos/shared-actions/blob/add-mutation-testing/workflow_scripts/tests/test_mutation_detect_changes.py)'s
`git_repo` fixture now creates an empty `workflow_scripts/` directory,
because mutmut's mutation trampoline strictly resolves the configured
`source_paths` against the current working directory on every hit, and
two tests `chdir` into the fixture repository; without it the mutation
baseline fails with `FileNotFoundError`.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` and `actionlint` pass
  on the caller.
- `uv run ruff check` / `ruff format --check` / `ty check` pass on the
  new and modified files.
- The contract tests pass (6 passed); negative test confirmed the pin
  guard fails when the `uses:` reference is switched to `@v1`.
- `uv run --with 'mutmut==3.6.0' mutmut results` emits no configuration
  deprecation warnings.
- A full local `mutmut run` completed against this configuration:
  baseline green, 1463 mutants evaluated (971 killed, 482 survived,
  5 without tests, 5 timeouts) at 37.65 mutations/second.

## References

- Caller guide: <https://github.com/leynos/shared-actions/blob/main/docs/mutation-mutmut-workflow.md>
- Estate template: <https://github.com/leynos/wireframe/pull/572>
