### PR TITLE
Fix CodeScene CLI install and preserve line records in coverage exports

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Omit `--summary-only` from `cargo llvm-cov` for the file formats
+  (`lcov`, `cobertura`). With the flag, cargo-llvm-cov exports only
+  summary information, so reports lacked per-line execution records
+  (LCOV `DA` lines, Cobertura `<line>` elements) and changed-line
+  coverage gates (e.g. CodeScene) had nothing to evaluate. Streamed
+  formats keep the flag so stdout remains parseable.
 - Ensure a pinned `cargo-binstall` (`v1.19.1`) is present before installing
   Rust coverage tooling. The new "Ensure cargo-binstall" step verifies any
   existing binary against the pinned version and reuses it only on a match;

--- a/.github/actions/generate-coverage/scripts/run_rust.py
+++ b/.github/actions/generate-coverage/scripts/run_rust.py
@@ -146,11 +146,21 @@ def get_cargo_coverage_cmd(
     with_default: bool,
     use_nextest: bool,
 ) -> list[str]:
-    """Return the cargo llvm-cov command arguments."""
+    """Return the cargo llvm-cov command arguments.
+
+    File formats (lcov, cobertura) omit ``--summary-only``: with it,
+    cargo-llvm-cov exports only summary information, so the report lacks
+    per-line execution records (LCOV ``DA`` lines, Cobertura ``<line>``
+    elements) and consumers such as CodeScene cannot evaluate changed-line
+    coverage. Other formats keep the flag so the streamed summary output
+    remains parseable.
+    """
     args = ["llvm-cov"]
     if use_nextest:
         args.append("nextest")
-    args += ["--manifest-path", str(manifest_path), "--workspace", "--summary-only"]
+    args += ["--manifest-path", str(manifest_path), "--workspace"]
+    if fmt not in ("lcov", "cobertura"):
+        args.append("--summary-only")
     if not with_default:
         args.append("--no-default-features")
     if features:

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -511,6 +511,7 @@ def test_get_cargo_coverage_cmd_summary_only_by_format(
     run_rust_module: ModuleType,
     output_format: str,
     out_name: str,
+    *,
     expect_summary_only: bool,
 ) -> None:
     """File formats omit ``--summary-only``; streamed formats keep it."""

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -500,34 +500,29 @@ def test_get_cargo_coverage_cmd_variants(
     assert args == [*expected, str(out)]
 
 
-def test_get_cargo_coverage_cmd_keeps_summary_only_for_stream_formats(
+@pytest.mark.parametrize(
+    ("output_format", "out_name", "expect_summary_only"),
+    [
+        ("text", "cov.txt", True),
+        ("cobertura", "cov.xml", False),
+    ],
+)
+def test_get_cargo_coverage_cmd_summary_only_by_format(
     run_rust_module: ModuleType,
+    output_format: str,
+    out_name: str,
+    expect_summary_only: bool,
 ) -> None:
-    """Non-file formats keep ``--summary-only`` for parseable stdout."""
+    """File formats omit ``--summary-only``; streamed formats keep it."""
     args = run_rust_module.get_cargo_coverage_cmd(
-        "text",
-        Path("cov.txt"),
+        output_format,
+        Path(out_name),
         "",
         manifest_path=Path("Cargo.toml"),
         with_default=True,
         use_nextest=False,
     )
-    assert "--summary-only" in args
-
-
-def test_get_cargo_coverage_cmd_omits_summary_only_for_cobertura(
-    run_rust_module: ModuleType,
-) -> None:
-    """Cobertura output needs per-line records, so the flag is omitted."""
-    args = run_rust_module.get_cargo_coverage_cmd(
-        "cobertura",
-        Path("cov.xml"),
-        "",
-        manifest_path=Path("Cargo.toml"),
-        with_default=True,
-        use_nextest=False,
-    )
-    assert "--summary-only" not in args
+    assert ("--summary-only" in args) is expect_summary_only
 
 
 def _run_rust_main_variant(

--- a/.github/actions/generate-coverage/tests/test_scripts.py
+++ b/.github/actions/generate-coverage/tests/test_scripts.py
@@ -369,7 +369,6 @@ def test_run_rust_success(
         "--manifest-path",
         "Cargo.toml",
         "--workspace",
-        "--summary-only",
         "--no-default-features",
         "--features",
         "fast",
@@ -404,7 +403,6 @@ def test_run_rust_nextest_command(
         "--manifest-path",
         "Cargo.toml",
         "--workspace",
-        "--summary-only",
         "--lcov",
         "--output-path",
         str(out),
@@ -461,7 +459,6 @@ def test_run_rust_omitted_manifest_arg_ignores_blank_detected_manifest(
                 "--manifest-path",
                 "Cargo.toml",
                 "--workspace",
-                "--summary-only",
                 "--no-default-features",
                 "--features",
                 "fast",
@@ -479,7 +476,6 @@ def test_run_rust_omitted_manifest_arg_ignores_blank_detected_manifest(
                 "--manifest-path",
                 "rust-toy-app/Cargo.toml",
                 "--workspace",
-                "--summary-only",
                 "--lcov",
                 "--output-path",
             ],
@@ -502,6 +498,36 @@ def test_get_cargo_coverage_cmd_variants(
         use_nextest=use_nextest,
     )
     assert args == [*expected, str(out)]
+
+
+def test_get_cargo_coverage_cmd_keeps_summary_only_for_stream_formats(
+    run_rust_module: ModuleType,
+) -> None:
+    """Non-file formats keep ``--summary-only`` for parseable stdout."""
+    args = run_rust_module.get_cargo_coverage_cmd(
+        "text",
+        Path("cov.txt"),
+        "",
+        manifest_path=Path("Cargo.toml"),
+        with_default=True,
+        use_nextest=False,
+    )
+    assert "--summary-only" in args
+
+
+def test_get_cargo_coverage_cmd_omits_summary_only_for_cobertura(
+    run_rust_module: ModuleType,
+) -> None:
+    """Cobertura output needs per-line records, so the flag is omitted."""
+    args = run_rust_module.get_cargo_coverage_cmd(
+        "cobertura",
+        Path("cov.xml"),
+        "",
+        manifest_path=Path("Cargo.toml"),
+        with_default=True,
+        use_nextest=False,
+    )
+    assert "--summary-only" not in args
 
 
 def _run_rust_main_variant(
@@ -1279,7 +1305,6 @@ def test_run_rust_with_cucumber(tmp_path: Path, shell_stubs: StubManager) -> Non
         "--manifest-path",
         "rust-toy-app/Cargo.toml",
         "--workspace",
-        "--summary-only",
         "--lcov",
         "--output-path",
         str(cuc_file),

--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -61,3 +61,12 @@
 
 - Treat empty `path` input the same as `__auto__` to avoid artefact upload
   failures.
+
+## Unreleased
+
+- Adapt to the rewritten CodeScene installer script, which no longer
+  embeds a version literal and instead accepts the version as its first
+  positional argument. The removed `grep` extraction failed under
+  `pipefail` and broke every upload. A new `cli-version` input (default
+  `latest`) selects the CLI version; the CLI cache participates only
+  when a version is pinned, so `latest` always fetches a fresh copy.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -10,12 +10,16 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 | format             | Coverage format (`cobertura` or `lcov`)                      | no       | `cobertura` |
 | access-token       | CodeScene project access token                               | yes      |             |
 | installer-checksum | SHA-256 checksum of the installer script                     | no       |             |
+| cli-version        | cs-coverage CLI version to install (`latest` or `x.y.z`)     | no       | `latest`    |
 
 If `path` is empty or `__auto__`, the action looks for `lcov.info` when
 `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`. The
-CodeScene CLI is cached using its release version extracted from the installer
-script. If the optional `installer-checksum` input is set, the installer is
-validated before execution. Any other value for `format` results in an error.
+installer accepts the CLI version as an argument; `cli-version` selects it.
+The CLI is cached only when `cli-version` pins a concrete version — with
+`latest`, a fresh copy is fetched on every run so the cache can never pin a
+stale binary. If the optional `installer-checksum` input is set, the
+installer is validated before execution. Any other value for `format`
+results in an error.
 
 The action exports the `access-token` and `installer-checksum` inputs as
 `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` for use by later steps.

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -16,6 +16,13 @@ inputs:
   installer-checksum:
     description: SHA-256 checksum of the installer script
     required: false
+  cli-version:
+    description: >-
+      cs-coverage CLI version to install (e.g. "2.1.0"). Defaults to
+      "latest", which skips the CLI cache so a fresh copy is always
+      fetched; pin a version to enable caching.
+    required: false
+    default: latest
 runs:
   using: composite
   steps:
@@ -49,19 +56,24 @@ runs:
         echo "path=$file" >> "$GITHUB_OUTPUT"
       shell: bash
 
+    # The installer no longer embeds a version literal; it takes the
+    # version as its first positional argument (defaulting to "latest"),
+    # so the version comes from the cli-version input rather than being
+    # extracted from the script.
     - name: Download installer
       id: installer
+      env:
+        CLI_VERSION: ${{ inputs.cli-version }}
       run: |
         script=$(mktemp)
         curl -fsSL -o "$script" https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
         if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
           echo "${CODESCENE_CLI_SHA256}  $script" | sha256sum -c -
         fi
-        version=$(grep -oE 'version="([0-9]+\.[0-9]+\.[0-9]+)"' "$script" | cut -d'"' -f2)
-        major_minor=${version%.*}
+        major_minor=${CLI_VERSION%.*}
         echo "script=$script" >> "$GITHUB_OUTPUT"
-        echo "version=$version" >> "$GITHUB_OUTPUT"
-        echo "major_minor=$major_minor" >> "$GITHUB_OUTPUT"
+        echo "version=${CLI_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Upload coverage GitHub artefact
@@ -70,8 +82,11 @@ runs:
         name: coverage
         path: ${{ steps.cov-file.outputs.path }}
 
+    # Caching a "latest" binary would pin whatever version was first
+    # cached, so the cache only participates when a version is pinned.
     - name: Cache CodeScene Coverage CLI
       id: cs-cache
+      if: inputs.cli-version != 'latest'
       uses: actions/cache@v4
       with:
         path: ~/.local/bin/cs-coverage
@@ -81,9 +96,11 @@ runs:
 
     - name: Install CodeScene Coverage CLI
       if: env.CS_ACCESS_TOKEN != '' && steps.cs-cache.outputs.cache-hit != 'true'
+      env:
+        CLI_VERSION: ${{ inputs.cli-version }}
       run: |
         script="${{ steps.installer.outputs.script }}"
-        bash "$script" -y
+        bash "$script" -y "${CLI_VERSION}"
         rm "$script"
       shell: bash
 


### PR DESCRIPTION
## Summary

This branch fixes two coverage defects surfaced by review feedback on
[leynos/mxd#362](https://github.com/leynos/mxd/pull/362).

First, `upload-codescene-coverage` is currently broken for every
consumer: it extracted the CLI version by grepping a `version="x.y.z"`
literal from the downloaded installer script, but CodeScene rewrote the
installer to take the version as its first positional argument
(`version="${1:-latest}"`). The grep now matches nothing and, under
`pipefail`, the "Download installer" step exits 1 before any upload
happens. A new `cli-version` input (default `latest`) is passed to the
installer via environment indirection; the CLI cache participates only
when a concrete version is pinned, so `latest` always fetches fresh and
can never be frozen by a stale cache entry.

Second, `generate-coverage` passed `--summary-only` to `cargo llvm-cov`
unconditionally. cargo-llvm-cov documents that this exports only
summary information, so LCOV files lacked `DA` line-hit records and
Cobertura files lacked `<line>` elements — changed-line coverage gates
(CodeScene's PR gate among them) had nothing to evaluate even when the
upload succeeded. The flag is now omitted for the file formats and kept
for streamed formats, whose stdout must remain parseable. Reported
percentages are unaffected: for `lcov` and `cobertura` the percentage
is computed from the report file, not stdout.

## Review walkthrough

- Start with [.github/actions/upload-codescene-coverage/action.yml](https://github.com/leynos/shared-actions/blob/fix-summary-only-coverage/.github/actions/upload-codescene-coverage/action.yml)
  — the `cli-version` input, the rewritten "Download installer" step,
  and the conditional cache.
- Then [.github/actions/generate-coverage/scripts/run_rust.py](https://github.com/leynos/shared-actions/blob/fix-summary-only-coverage/.github/actions/generate-coverage/scripts/run_rust.py)
  — `get_cargo_coverage_cmd` appends `--summary-only` only for
  non-file formats, with the rationale in its docstring.
- Finish with [.github/actions/generate-coverage/tests/test_scripts.py](https://github.com/leynos/shared-actions/blob/fix-summary-only-coverage/.github/actions/generate-coverage/tests/test_scripts.py)
  — lcov expectations updated, plus two new format-specific cases
  (`--summary-only` kept for `text`, omitted for `cobertura`).

## Validation

- `make test`: 997 passed, 14 skipped.
- Local reproduction of the installer breakage: downloading
  `install-cs-coverage-tool.sh` and running the removed grep exits 1
  (no `version="…"` literal exists in the current script).
