### PR TITLE
Add a check mode for the CodeScene PR coverage gate

### DIFF
--- a/.github/actions/upload-codescene-coverage/CHANGELOG.md
+++ b/.github/actions/upload-codescene-coverage/CHANGELOG.md
@@ -70,3 +70,13 @@
   `pipefail` and broke every upload. A new `cli-version` input (default
   `latest`) selects the CLI version; the CLI cache participates only
   when a version is pinned, so `latest` always fetches a fresh copy.
+
+## Unreleased (check mode)
+
+- Add a `mode` input (`upload` | `check`). CodeScene accepts `upload`
+  only for branches the project analyses (typically `main`); the
+  pull-request coverage gate is driven by `cs-coverage check`, which
+  diffs the PR against its merge base. `check` requires the new
+  `project-url` input (exported as `CS_PROJECT_URL`) and a
+  `fetch-depth: 0` checkout, and requires LCOV files to end in `.info`
+  because the CLI infers the format from the extension.

--- a/.github/actions/upload-codescene-coverage/README.md
+++ b/.github/actions/upload-codescene-coverage/README.md
@@ -11,6 +11,8 @@ Upload coverage reports to CodeScene and cache the CLI for faster runs.
 | access-token       | CodeScene project access token                               | yes      |             |
 | installer-checksum | SHA-256 checksum of the installer script                     | no       |             |
 | cli-version        | cs-coverage CLI version to install (`latest` or `x.y.z`)     | no       | `latest`    |
+| mode               | `upload` (analysed branches) or `check` (PR coverage gate)   | no       | `upload`    |
+| project-url        | CodeScene project API URL; required when `mode` is `check`   | no       |             |
 
 If `path` is empty or `__auto__`, the action looks for `lcov.info` when
 `format` is `lcov`, or `coverage.xml` when `format` is `cobertura`. The
@@ -23,6 +25,18 @@ results in an error.
 
 The action exports the `access-token` and `installer-checksum` inputs as
 `CS_ACCESS_TOKEN` and `CODESCENE_CLI_SHA256` for use by later steps.
+
+## Modes
+
+`upload` sends the report to CodeScene for an analysed branch; CodeScene
+rejects uploads for branches the project does not analyse (typically
+anything but `main`), so it belongs in push/main workflows. `check` runs
+the pull-request changed-line coverage gate (`cs-coverage check`), which
+diffs the PR against its merge base — the job must check out with
+`fetch-depth: 0`, pass `project-url`
+(`https://api.codescene.io/v2/projects/<id>`), and, for LCOV, name the
+report file `*.info` because the CLI infers the format from the file
+extension.
 
 ## Environment variables
 

--- a/.github/actions/upload-codescene-coverage/action.yml
+++ b/.github/actions/upload-codescene-coverage/action.yml
@@ -23,6 +23,22 @@ inputs:
       fetched; pin a version to enable caching.
     required: false
     default: latest
+  mode:
+    description: >-
+      "upload" sends coverage for an analysed branch (CodeScene accepts
+      uploads only for branches the project analyses, typically main);
+      "check" runs the pull-request changed-line coverage gate, which
+      diffs the PR against its merge base (requires a fetch-depth: 0
+      checkout) and needs project-url.
+    required: false
+    default: upload
+  project-url:
+    description: >-
+      CodeScene project API URL (e.g.
+      "https://api.codescene.io/v2/projects/<id>"). Required when mode
+      is "check".
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -30,6 +46,9 @@ runs:
       run: |
         printf 'CS_ACCESS_TOKEN=%s\n' "${{ inputs.access-token }}" >>"${GITHUB_ENV}"
         printf 'CODESCENE_CLI_SHA256=%s\n' "${{ inputs.installer-checksum }}" >>"${GITHUB_ENV}"
+        if [ -n "${{ inputs.project-url }}" ]; then
+          printf 'CS_PROJECT_URL=%s\n' "${{ inputs.project-url }}" >>"${GITHUB_ENV}"
+        fi
       shell: bash
     - name: Validate inputs
       run: |
@@ -37,6 +56,19 @@ runs:
           cobertura|lcov) ;;
           *)
             echo "Unsupported format: ${{ inputs.format }}" >&2
+            exit 1
+            ;;
+        esac
+        case "${{ inputs.mode }}" in
+          upload) ;;
+          check)
+            if [ -z "${{ inputs.project-url }}" ]; then
+              echo "mode: check requires project-url" >&2
+              exit 1
+            fi
+            ;;
+          *)
+            echo "Unsupported mode: ${{ inputs.mode }}" >&2
             exit 1
             ;;
         esac
@@ -109,7 +141,7 @@ runs:
       shell: bash
 
     - name: Upload coverage to CodeScene
-      if: env.CS_ACCESS_TOKEN != ''
+      if: env.CS_ACCESS_TOKEN != '' && inputs.mode == 'upload'
       run: |
         command -v cs-coverage >/dev/null 2>&1 || { echo "cs-coverage CLI not found" >&2; exit 1; }
         file="${{ steps.cov-file.outputs.path }}"
@@ -124,5 +156,30 @@ runs:
           --format "${{ inputs.format }}" \
           --metric "line-coverage" \
           "$file"
+      shell: bash
+
+    # `cs-coverage check` infers the report format from the file
+    # extension and requires LCOV files to end in ".info".
+    - name: Check coverage against CodeScene gates
+      if: env.CS_ACCESS_TOKEN != '' && inputs.mode == 'check'
+      run: |
+        command -v cs-coverage >/dev/null 2>&1 || { echo "cs-coverage CLI not found" >&2; exit 1; }
+        file="${{ steps.cov-file.outputs.path }}"
+        if [ ! -f "$file" ]; then
+          echo "Coverage file not found!" >&2
+          echo "  Expected file: $file" >&2
+          echo "  Current working directory: $(pwd)" >&2
+          exit 1
+        fi
+        if [ "${{ inputs.format }}" = "lcov" ]; then
+          case "$file" in
+            *.info) ;;
+            *)
+              echo "cs-coverage check requires LCOV files to end in .info (got: $file)" >&2
+              exit 1
+              ;;
+          esac
+        fi
+        cs-coverage check --coverage-files "$file"
       shell: bash
 


### PR DESCRIPTION
## Summary

This branch adds a `mode` input to `upload-codescene-coverage` so the
action can drive CodeScene's pull-request coverage gate. Testing the
estate rollout on [leynos/mxd#362](https://github.com/leynos/mxd/pull/362)
showed `cs-coverage upload` is rejected for PR heads ("CodeScene only
analyse the following branches: (main)"): uploads are only accepted for
analysed branches, so the "CodeScene Code Coverage" PR check can never
be satisfied that way. The PR gate is instead driven by
`cs-coverage check`, which diffs the PR against its merge base and
evaluates changed-line coverage — verified locally against the mxd
project (`Code coverage gates: PASS`, exit 0) with `CS_PROJECT_URL`
set.

`mode: check` requires the new `project-url` input (exported as
`CS_PROJECT_URL`), a `fetch-depth: 0` checkout so the merge base is
reachable, and, for LCOV, a report file ending in `.info` (the CLI
infers the format from the extension); the action validates all of
this before invoking the CLI. `mode: upload` (the default) is
byte-for-byte the existing behaviour.

## Review walkthrough

- [.github/actions/upload-codescene-coverage/action.yml](https://github.com/leynos/shared-actions/blob/codescene-check-mode/.github/actions/upload-codescene-coverage/action.yml)
  — the `mode`/`project-url` inputs, extended validation, the
  conditional export of `CS_PROJECT_URL`, and the new gated
  "Check coverage against CodeScene gates" step.
- [README](https://github.com/leynos/shared-actions/blob/codescene-check-mode/.github/actions/upload-codescene-coverage/README.md)
  and [CHANGELOG](https://github.com/leynos/shared-actions/blob/codescene-check-mode/.github/actions/upload-codescene-coverage/CHANGELOG.md)
  document the two modes and their requirements.

## Validation

- `make lint` (action-validator over all action manifests): clean.
- `make test`: 997 passed, 14 skipped.
- `cs-coverage check --coverage-files <file>.info` with
  `CS_ACCESS_TOKEN` + `CS_PROJECT_URL` run locally from an mxd clone:
  `Code coverage gates: PASS`, exit 0.
