### PR TITLE
Relocate workflow-src out of the caller's workspace during mutation runs

### DIFF
--- a/.github/workflows/mutation-cargo.yml
+++ b/.github/workflows/mutation-cargo.yml
@@ -115,8 +115,34 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           python-version: '3.13'
+          # Workspace-relative on purpose: this glob is hashed before the
+          # relocation step below moves workflow-src out of the workspace.
           cache-dependency-glob: |
             **/workflow_scripts/*.py
+
+      - name: Relocate workflow source
+        # Move the workflow checkout out of the caller's workspace so
+        # tree-scanning tests in the caller's suite (manifest sweeps,
+        # file inventories, lint-everything globs) never see foreign
+        # files during the mutation baseline or mutant runs. Runs after
+        # "Setup uv" so cache-dependency-glob still hashes the workflow
+        # scripts while they sit inside the workspace. Under act the
+        # workspace itself is the workflow source, so nothing moves.
+        id: relocate-workflow-source
+        shell: bash
+        env:
+          CHECKOUT: ${{ steps.workflow-source.outputs.checkout }}
+          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+        run: |
+          set -euo pipefail
+          if [[ "${CHECKOUT}" == "true" ]]; then
+            dest="${RUNNER_TEMP}/workflow-src"
+            rm -rf "${dest}"
+            mv "${WORKFLOW_DIR}" "${dest}"
+            echo "workflow_dir=${dest}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "workflow_dir=${WORKFLOW_DIR}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Detect changed files
         id: detect
@@ -129,7 +155,7 @@ jobs:
           INPUT_PATHSPEC: "*.rs"
           INPUT_SHARD_COUNT: ${{ inputs.shard-count }}
           INPUT_BASE_REF: ${{ inputs.base-ref }}
-          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+          WORKFLOW_DIR: ${{ steps.relocate-workflow-source.outputs.workflow_dir }}
         run: |
           set -euo pipefail
           if [[ "${ACT:-}" == "true" ]]; then
@@ -216,8 +242,35 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           python-version: '3.13'
+          # Workspace-relative on purpose: this glob is hashed before the
+          # relocation step below moves workflow-src out of the workspace.
           cache-dependency-glob: |
             **/workflow_scripts/*.py
+
+      - name: Relocate workflow source
+        # Move the workflow checkout out of the caller's workspace so
+        # tree-scanning tests in the caller's suite (manifest sweeps,
+        # file inventories, lint-everything globs) never see foreign
+        # files during the mutation baseline or mutant runs. Runs after
+        # "Setup Rust" (which needs the workspace-local action path) and
+        # "Setup uv" (whose cache-dependency-glob hashes the workflow
+        # scripts while they sit inside the workspace). Under act the
+        # workspace itself is the workflow source, so nothing moves.
+        id: relocate-workflow-source
+        shell: bash
+        env:
+          CHECKOUT: ${{ steps.workflow-source.outputs.checkout }}
+          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+        run: |
+          set -euo pipefail
+          if [[ "${CHECKOUT}" == "true" ]]; then
+            dest="${RUNNER_TEMP}/workflow-src"
+            rm -rf "${dest}"
+            mv "${WORKFLOW_DIR}" "${dest}"
+            echo "workflow_dir=${dest}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "workflow_dir=${WORKFLOW_DIR}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Run mutation testing
         shell: bash
@@ -231,7 +284,7 @@ jobs:
           INPUT_TIMEOUT_MULTIPLIER: ${{ inputs.timeout-multiplier }}
           INPUT_EXCLUDE_GLOBS: ${{ inputs.exclude-globs }}
           INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
-          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+          WORKFLOW_DIR: ${{ steps.relocate-workflow-source.outputs.workflow_dir }}
         run: |
           set -euo pipefail
           if [[ "${ACT:-}" == "true" ]]; then
@@ -291,14 +344,39 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           python-version: '3.13'
+          # Workspace-relative on purpose: this glob is hashed before the
+          # relocation step below moves workflow-src out of the workspace.
           cache-dependency-glob: |
             **/workflow_scripts/*.py
+
+      - name: Relocate workflow source
+        # This job checks out no caller code, but the relocation keeps
+        # the invariant uniform across jobs: after this step no
+        # workflow-src files remain inside the workspace. Runs after
+        # "Setup uv" so cache-dependency-glob still hashes the workflow
+        # scripts while they sit inside the workspace. Under act the
+        # workspace itself is the workflow source, so nothing moves.
+        id: relocate-workflow-source
+        shell: bash
+        env:
+          CHECKOUT: ${{ steps.workflow-source.outputs.checkout }}
+          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+        run: |
+          set -euo pipefail
+          if [[ "${CHECKOUT}" == "true" ]]; then
+            dest="${RUNNER_TEMP}/workflow-src"
+            rm -rf "${dest}"
+            mv "${WORKFLOW_DIR}" "${dest}"
+            echo "workflow_dir=${dest}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "workflow_dir=${WORKFLOW_DIR}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Post summary
         shell: bash
         env:
           INPUT_REPORT_ROOT: reports
-          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+          WORKFLOW_DIR: ${{ steps.relocate-workflow-source.outputs.workflow_dir }}
         run: |
           set -euo pipefail
           if [[ "${ACT:-}" == "true" ]]; then

--- a/.github/workflows/mutation-mutmut.yml
+++ b/.github/workflows/mutation-mutmut.yml
@@ -114,10 +114,36 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           python-version: ${{ inputs.python-version }}
+          # Workspace-relative on purpose: this glob is hashed before the
+          # relocation step below moves workflow-src out of the workspace.
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
             **/workflow_scripts/*.py
+
+      - name: Relocate workflow source
+        # Move the workflow checkout out of the caller's workspace so
+        # tree-scanning tests in the caller's suite (manifest sweeps,
+        # file inventories, lint-everything globs) never see foreign
+        # files during the mutation baseline or mutant runs. Runs after
+        # "Setup uv" so cache-dependency-glob still hashes the workflow
+        # scripts while they sit inside the workspace. Under act the
+        # workspace itself is the workflow source, so nothing moves.
+        id: relocate-workflow-source
+        shell: bash
+        env:
+          CHECKOUT: ${{ steps.workflow-source.outputs.checkout }}
+          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+        run: |
+          set -euo pipefail
+          if [[ "${CHECKOUT}" == "true" ]]; then
+            dest="${RUNNER_TEMP}/workflow-src"
+            rm -rf "${dest}"
+            mv "${WORKFLOW_DIR}" "${dest}"
+            echo "workflow_dir=${dest}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "workflow_dir=${WORKFLOW_DIR}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Detect changed files
         id: detect
@@ -130,7 +156,7 @@ jobs:
           INPUT_PATHSPEC: "*.py"
           INPUT_SHARD_COUNT: "1"
           INPUT_BASE_REF: ${{ inputs.base-ref }}
-          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+          WORKFLOW_DIR: ${{ steps.relocate-workflow-source.outputs.workflow_dir }}
         run: |
           set -euo pipefail
           if [[ "${ACT:-}" == "true" ]]; then
@@ -149,7 +175,7 @@ jobs:
           INPUT_MODULE_PREFIX_STRIP: ${{ inputs.module-prefix-strip }}
           INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
           INPUT_RESULTS_FILE: mutation-mutmut-results.txt
-          WORKFLOW_DIR: ${{ steps.workflow-source.outputs.workflow_dir }}
+          WORKFLOW_DIR: ${{ steps.relocate-workflow-source.outputs.workflow_dir }}
         run: |
           set -euo pipefail
           if [[ "${ACT:-}" == "true" ]]; then

--- a/workflow_scripts/tests/test_mutation_workflow_shape.py
+++ b/workflow_scripts/tests/test_mutation_workflow_shape.py
@@ -1,0 +1,113 @@
+"""Shape tests for the mutation-testing reusable workflows.
+
+The workflows check out their own source into ``workflow-src/`` inside
+the caller's workspace. Left there, the checkout pollutes the tree
+under test: callers with tree-scanning hygiene tests (manifest sweeps,
+file inventories, lint-everything globs) fail their unmutated baseline
+on every real run (issue #343). These tests parse both workflows with
+PyYAML and pin the corrective invariant: every job that checks out the
+workflow repository must relocate it to ``$RUNNER_TEMP`` before any
+step consumes it, and every ``WORKFLOW_DIR`` consumer must read the
+relocated path.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+WORKFLOW_NAMES = ("mutation-cargo.yml", "mutation-mutmut.yml")
+
+CHECKOUT_STEP = "Checkout workflow repository"
+RELOCATE_STEP = "Relocate workflow source"
+RELOCATED_DIR_EXPR = "${{ steps.relocate-workflow-source.outputs.workflow_dir }}"
+
+pytestmark = pytest.mark.skipif(
+    not all((WORKFLOWS_DIR / name).exists() for name in WORKFLOW_NAMES),
+    reason="workflow files not present in this working copy (e.g. inside "
+    "mutmut's mutants/ sandbox, which does not copy .github/)",
+)
+
+
+def _jobs(workflow_name: str) -> dict[str, dict[str, object]]:
+    """Parse a workflow file and return its jobs mapping."""
+    workflow = yaml.safe_load(
+        (WORKFLOWS_DIR / workflow_name).read_text(encoding="utf-8")
+    )
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), f"{workflow_name} must declare a jobs mapping"
+    return typ.cast("dict[str, dict[str, object]]", jobs)
+
+
+def _steps(job: dict[str, object]) -> list[dict[str, object]]:
+    """Return a job's step list."""
+    steps = job.get("steps")
+    assert isinstance(steps, list), "job must declare a steps list"
+    return typ.cast("list[dict[str, object]]", steps)
+
+
+def _step_names(steps: list[dict[str, object]]) -> list[object]:
+    """Return the step names in order."""
+    return [step.get("name") for step in steps]
+
+
+@pytest.mark.parametrize("workflow_name", WORKFLOW_NAMES)
+def test_every_workflow_checkout_is_followed_by_relocation(
+    workflow_name: str,
+) -> None:
+    """Each job checking out workflow-src relocates it out of the workspace."""
+    for job_name, job in _jobs(workflow_name).items():
+        steps = _steps(job)
+        names = _step_names(steps)
+        if CHECKOUT_STEP not in names:
+            continue
+        assert RELOCATE_STEP in names, (
+            f"{workflow_name}:{job_name} checks out the workflow repository "
+            f"but never relocates it; the checkout pollutes the caller's "
+            f"tree during mutation runs (issue #343)"
+        )
+        assert names.index(RELOCATE_STEP) > names.index(CHECKOUT_STEP), (
+            f"{workflow_name}:{job_name} must relocate workflow-src after "
+            f"checking it out"
+        )
+        relocate = steps[names.index(RELOCATE_STEP)]
+        run = relocate.get("run")
+        assert isinstance(run, str), (
+            f"{workflow_name}:{job_name} relocation step must have a run block"
+        )
+        assert '"${RUNNER_TEMP}/workflow-src"' in run, (
+            f"{workflow_name}:{job_name} relocation must move workflow-src "
+            f"to $RUNNER_TEMP, outside the caller's workspace"
+        )
+
+
+@pytest.mark.parametrize("workflow_name", WORKFLOW_NAMES)
+def test_workflow_dir_consumers_read_the_relocated_path(
+    workflow_name: str,
+) -> None:
+    """Steps after relocation take WORKFLOW_DIR from the relocation output."""
+    for job_name, job in _jobs(workflow_name).items():
+        steps = _steps(job)
+        names = _step_names(steps)
+        if RELOCATE_STEP not in names:
+            continue
+        relocate_index = names.index(RELOCATE_STEP)
+        consumers = [
+            (step.get("name"), typ.cast("dict[str, object]", step.get("env", {})))
+            for step in steps[relocate_index + 1 :]
+            if isinstance(step.get("env"), dict) and "WORKFLOW_DIR" in step["env"]
+        ]
+        assert consumers, (
+            f"{workflow_name}:{job_name} relocates workflow-src but no later "
+            f"step consumes WORKFLOW_DIR; the relocation step is vestigial"
+        )
+        for step_name, env in consumers:
+            assert env["WORKFLOW_DIR"] == RELOCATED_DIR_EXPR, (
+                f"{workflow_name}:{job_name} step {step_name!r} must take "
+                f"WORKFLOW_DIR from the relocation step's output, got "
+                f"{env['WORKFLOW_DIR']!r}"
+            )


### PR DESCRIPTION
Closes #343.

The mutation workflows check out their own source into `workflow-src/` inside the caller's workspace, so cargo-mutants and mutmut run against a tree containing foreign files. Callers with tree-scanning hygiene tests (manifest sweeps, file inventories, lint-everything globs) fail their unmutated baseline on every real run — netsuke's first full run failed every shard this way — while ordinary CI stays green and scheduled skip-path runs hide the fault.

## What changed

Every job that checks out the workflow repository now relocates it out of the workspace before any script consumes it: a new **Relocate workflow source** step moves `workflow-src` to `$RUNNER_TEMP/workflow-src` and emits the relocated path as an output; all downstream `WORKFLOW_DIR` consumers read that output. Under act the workspace itself is the workflow source, so the step passes the original path through unchanged.

## Review walkthrough

- [.github/workflows/mutation-cargo.yml](https://github.com/leynos/shared-actions/blob/fix-mutation-baseline/.github/workflows/mutation-cargo.yml) — relocation step added to the `detect`, `mutants`, and `summarize` jobs. Placement is deliberate: after **Setup uv**, so the workspace-relative `cache-dependency-glob` (`**/workflow_scripts/*.py`) still hashes the workflow scripts while they sit inside the workspace (a comment marks this), and in `mutants` after **Setup Rust**, which needs the workspace-local composite action path (`./workflow-src/...`). `summarize` checks out no caller code, but relocating there too keeps the invariant uniform. Relocation always precedes the steps that run the detection and mutation scripts, so no foreign files remain in the tree under test.
- [.github/workflows/mutation-mutmut.yml](https://github.com/leynos/shared-actions/blob/fix-mutation-baseline/.github/workflows/mutation-mutmut.yml) — same step in the single `mutants` job, before change detection and the mutmut run.
- [workflow_scripts/tests/test_mutation_workflow_shape.py](https://github.com/leynos/shared-actions/blob/fix-mutation-baseline/workflow_scripts/tests/test_mutation_workflow_shape.py) — regression guard in the style of the existing caller contract tests: parses both workflows and asserts (a) every job with a **Checkout workflow repository** step has a later **Relocate workflow source** step that moves to `$RUNNER_TEMP`, and (b) every subsequent `WORKFLOW_DIR` consumer references the relocation step's output. Red-green verified: with the workflow edits stashed, the relocation-exists tests fail for both workflows; with them applied, all four pass.

`resolve-workflow-source` is untouched: its `workflow_dir` output still names the checkout destination, and the workflows themselves own the relocation, so no action pin bump is needed.

## Validation

- `make fmt`, `make lint` (ruff, action-validator), `make typecheck`, `make test` — 1007 passed, 14 skipped.
- Act-gated integration tests: `tests/workflows/test_mutation_workflows.py` — both skip-path tests pass under act (exercising the relocation step's passthrough branch).
- `actionlint` clean on both workflows; `zizmor` reports no findings.

## Roll-out

Callers pick up the fix on their next pin bump of `mutation-cargo.yml` / `mutation-mutmut.yml`; existing pins keep the old behaviour until then.
