### PR TITLE
Wire CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,84 @@ jobs:
           PYTHONIOENCODING: utf-8
         shell: bash
 
+  coverage:
+    name: coverage
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # Full history so a future `cs-coverage check` gate can reach the
+          # pull request's merge base (see the deferred-gate note below).
+          fetch-depth: 0
+          # This job runs third-party tooling (uv, nfpm, the Rust toolchain)
+          # and never pushes back to the repository, so drop the checkout
+          # credential rather than persisting GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            **/scripts/*.py
+      # Mirror the python-tests ubuntu leg so the same tests execute (rather
+      # than skip) under coverage, giving a representative baseline. nfpm
+      # unblocks the linux-packages tests; setup-rust unblocks the
+      # rust-build-release tests (their autouse fixture skips the whole
+      # directory when rustup is absent). Whitaker, Bun, and action-validator
+      # are lint/validation tooling that no collected test needs, so they are
+      # omitted here.
+      - name: Install nfpm
+        uses: ./.github/actions/install-nfpm
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      # Build and cache the project like the python-tests job does. Several
+      # tests shell out to `uv run --script`, which builds shared-actions into
+      # the script environment; without a warm build cache that emits `Using
+      # CPython` / `Installed N packages` on stderr, which those tests assert
+      # to be empty (setup-rust test_validate_workspaces).
+      - name: Sync project dependencies
+        run: uv sync --group dev
+        env:
+          PYTHONIOENCODING: utf-8
+        shell: bash
+      # Coverage runs on pull requests via the shared generate-coverage
+      # action. Pushes to main upload their own coverage and advance the
+      # ratchet baseline via coverage-main.yml; ci.yml never runs on main, so
+      # there is no duplicate generation for a given commit.
+      - name: Generate coverage
+        uses: ./.github/actions/generate-coverage
+        with:
+          output-path: coverage.xml
+          # Python project: detect.py classifies this repo as Python because
+          # there is no root Cargo.toml (rust-toy-app is a test fixture, not a
+          # coverage target). cobertura is mandatory — the shared action
+          # rejects lcov for non-Rust projects.
+          format: cobertura
+          # No-op for a Python-detected project (the Rust coverage leg never
+          # runs); kept explicit per the first-run checklist.
+          use-cargo-nextest: 'false'
+          # ci.yml runs the suite serially (`uv run pytest`); keep the
+          # coverage run serial too for deterministic coverage and a stable
+          # ratchet baseline. Follow-up 4 can adopt pytest-xdist (`make test`
+          # already runs `-n auto`) once determinism under slipcover is
+          # confirmed.
+          pytest-workers: ''
+          with-ratchet: 'true'
+      # The `mode: check` CodeScene gate is deliberately not wired in yet:
+      # project 72004 has no coverage-gates configuration, so `cs-coverage
+      # check` fails every run with "HTTP call succeeded, but the received
+      # project-config isn't valid. Lacks the gates configuration." — a
+      # CodeScene-side per-project setting, not a CI defect (ddlint and
+      # chutoro hit the byte-identical error). Add the check step in a
+      # fast-follow PR once the project's coverage gate is enabled.
+
   python-tests-windows:
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,79 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests generate
+# coverage (and, in a future fast-follow, run the changed-line
+# `cs-coverage check` gate) in ci.yml instead. This workflow also advances
+# the coverage ratchet baseline: caches saved on main are readable by every
+# pull-request run, so the baseline written here is the one PR ratchet
+# checks compare against. workflow_dispatch allows re-running the upload on
+# demand (a run's secret context is fixed at dispatch).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: coverage-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage-upload:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - name: Checkout repository
+        # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # Match ci.yml's coverage checkout: full history keeps the ratchet
+          # and any future gate consistent with pull-request runs.
+          fetch-depth: 0
+          # This job runs third-party tooling (uv, nfpm, the Rust toolchain)
+          # and never pushes back to the repository, so drop the checkout
+          # credential rather than persisting GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            **/scripts/*.py
+      # Mirror ci.yml's coverage job exactly so the ratchet baseline written
+      # here is comparable to what pull requests compute.
+      - name: Install nfpm
+        uses: ./.github/actions/install-nfpm
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      # Warm the project build so tests that shell out to `uv run --script`
+      # do not emit uv build/install noise on stderr (see the note in ci.yml).
+      - name: Sync project dependencies
+        run: uv sync --group dev
+        env:
+          PYTHONIOENCODING: utf-8
+        shell: bash
+      - name: Generate coverage
+        uses: ./.github/actions/generate-coverage
+        with:
+          output-path: coverage.xml
+          format: cobertura
+          use-cargo-nextest: 'false'
+          pytest-workers: ''
+          with-ratchet: 'true'
+      - name: Upload coverage to CodeScene
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: ./.github/actions/upload-codescene-coverage
+        with:
+          format: cobertura
+          path: coverage.xml
+          mode: upload
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,28 @@ def _default_action_path() -> str:
     return str(Path(__file__).resolve().parent / ".github" / "actions")
 
 
-os.environ.setdefault("GITHUB_ACTION_PATH", _default_action_path())
+def _pin_action_path() -> None:
+    """Point ``GITHUB_ACTION_PATH`` at this repository's actions directory.
+
+    The suite discovers action scripts relative to ``GITHUB_ACTION_PATH``.
+    When the tests run inside a composite action — as they do when CI
+    generates coverage through the shared ``generate-coverage`` action — the
+    runner sets ``GITHUB_ACTION_PATH`` to *that* action's directory. Discovery
+    then misfires for tests belonging to other actions (e.g.
+    ``release-to-pypi-uv`` looks for its scripts under
+    ``generate-coverage/scripts``). Re-point the variable at the repository
+    actions root in that case; otherwise preserve the historical default,
+    which sets the variable only when it is unset.
+    """
+    repo_actions = _default_action_path()
+    ambient = os.environ.get("GITHUB_ACTION_PATH")
+    if ambient and Path(ambient).resolve().is_relative_to(Path(repo_actions).resolve()):
+        os.environ["GITHUB_ACTION_PATH"] = repo_actions
+    else:
+        os.environ.setdefault("GITHUB_ACTION_PATH", repo_actions)
+
+
+_pin_action_path()
 
 CMD_MOX_UNSUPPORTED = pytest.mark.skipif(
     sys.platform == "win32", reason="cmd-mox does not support Windows"


### PR DESCRIPTION
## Summary

Onboards this repository to the CodeScene coverage upload, following the
Python pathfinder pattern proven in
[cmd-mox#190](https://github.com/leynos/cmd-mox/pull/190). CodeScene
project id is **72004**.

This repository is a Python project for coverage purposes: it has no root
`Cargo.toml`, so `generate-coverage`'s `detect.py` classifies it as
Python (`rust-toy-app/` is a test fixture, not a coverage target). The
shared action therefore emits **cobertura** (`coverage.xml`); it rejects
lcov for non-Rust projects.

The changes are deliberately scoped to this repository's own CI. The
`.github/actions/*` action implementations — which the wider estate
consumes — are untouched.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/shared-actions/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  gains a dedicated, non-required `coverage` job. It is a new job (not a
  matrix key on an existing required check), so it renames none of the
  required checks (`python-tests`, `build-release`, the action-test
  jobs). It mirrors the `python-tests` ubuntu leg (uv, nfpm, setup-rust)
  so the same tests execute under slipcover rather than skipping — the
  `rust-build-release` suite has an autouse fixture that skips the whole
  directory when `rustup` is absent, and `nfpm` unblocks the
  `linux-packages` tests. Whitaker, Bun and action-validator are
  lint/validation tooling that no collected test needs, so they are
  omitted. The run is kept **serial** (`pytest-workers: ''`) to match
  ci.yml's `uv run pytest` and to keep coverage deterministic for a
  stable ratchet baseline (`make test` already uses `-n auto`, so a
  future follow-up can adopt xdist once determinism under slipcover is
  confirmed). The ratchet is enabled.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/shared-actions/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  runs the same generation on push to `main` (and on
  `workflow_dispatch`), advancing the authoritative ratchet baseline that
  pull-request runs compare against, then uploads to CodeScene behind a
  token guard (`mode: upload`, which CodeScene accepts only from analysed
  branches). ci.yml never runs on `main`, so there is no duplicate
  generation for a given commit.

### Deferred changed-line gate

The `mode: check` changed-line CodeScene gate is intentionally **not**
wired in. Project 72004 has no coverage-gates configuration, so
`cs-coverage check` fails every run with "HTTP call succeeded, but the
received project-config isn't valid. Lacks the gates configuration." —
a per-project CodeScene setting, not a CI defect (ddlint and chutoro hit
the byte-identical error). A comment in ci.yml records this; a
fast-follow can add the check step once the gate is enabled server-side.
The `coverage` check is **not** a repository-required check, so it gates
merges only through the status rollup, not the branch ruleset.

### Pin policy

The shared coverage actions are consumed **locally**
(`./.github/actions/...`), as elsewhere in this repository, so they
already sit at or beyond the required `927edd4` revision — no pin bump is
needed for coverage. The pre-existing remote `leynos/shared-actions@…`
pins (dependabot-automerge, mutation-mutmut, resolve-workflow-source) are
unrelated to coverage and are left untouched; the mutation-mutmut pin in
particular is a contract-tested reference already being bumped separately
by Dependabot (#348).

## Validation

- Both workflows parse as YAML (`yaml.safe_load`).
- No workflow-contract test pins `ci.yml` or enumerates the workflow set;
  the only such test targets `mutation-testing-caller.yml`, which is
  unchanged.
- CI on this PR exercises the new `coverage` job end to end (see checks).

## Summary by Sourcery

Add dedicated CI coverage job and main-branch workflow to generate, ratchet, and upload Python coverage data to CodeScene.

New Features:
- Introduce a non-required coverage job in ci.yml that generates slipcover-based Python coverage for pull requests.
- Add a Coverage (main) workflow that runs on pushes to main and workflow_dispatch to update the coverage ratchet baseline and upload results to CodeScene.

Enhancements:
- Align coverage generation between PR and main workflows to ensure deterministic, comparable ratchet baselines.
- Guard CodeScene coverage upload behind repository secrets and environment configuration without altering existing shared actions.