### PR TITLE
Fix coverage ratchet baseline freeze in generate-coverage

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+- Fix the coverage ratchet baseline freeze. The "Save baselines" step wrote a
+  constant, run-id-less cache key (`ratchet-baseline-<os>`) guarded by
+  `cache-hit != 'true'`, while "Restore baselines" recovered a run-id-suffixed
+  key (`ratchet-baseline-<os>-<run_id>`) via a prefix restore-key. Because
+  GitHub Actions cache entries are immutable, the constant key could only be
+  written once and then froze the baseline until the 7-day eviction, so the
+  ratchet never advanced when coverage improved and false-tripped "Coverage
+  decreased" on pull requests for repositories with any coverage
+  nondeterminism. The save step now uses the same run-id-suffixed key as the
+  restore step's primary key and drops the `cache-hit` guard, so every main run
+  persists a fresh baseline that later runs recover via the restore-key prefix
+  (newest matching entry wins). No inputs change.
+- Add a provisional symmetric +/-1 percentage-point dead-band to the coverage
+  ratchet comparison (`ratchet_coverage.py`). Coverage within one absolute
+  percentage point of the stored baseline is treated as noise: the run passes
+  and the baseline is held. A drop of more than one point below the baseline
+  still fails ("Coverage decreased"); a rise of more than one point above the
+  baseline advances it. Holding the baseline within the band prevents a
+  nondeterministic low run from false-tripping the gate and a lucky-high run
+  from inflating the baseline so the next normal run fails. The tolerance is a
+  single named constant (`RATCHET_TOLERANCE_PP = 1.0`).
 - Omit `--summary-only` from `cargo llvm-cov` for the file formats
   (`lcov`, `cobertura`). With the flag, cargo-llvm-cov exports only
   summary information, so reports lacked per-line execution records

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -139,7 +139,7 @@ Known limitations:
 | use-cargo-nextest | Use cargo-nextest for Rust coverage runs (default); set to `false` to use `cargo llvm-cov` directly | no | `true` |
 | output-path | Output file path | yes | |
 | format | Formats: `lcov`*, `cobertura`, `coveragepy`* | no | `cobertura` |
-| with-ratchet | Fail if coverage drops below baseline | no | `false` |
+| with-ratchet | Fail if coverage drops more than 1pp below baseline | no | `false` |
 | artefact-name-suffix | Additional suffix appended to the uploaded coverage artefact | no | |
 | baseline-rust-file | Rust baseline path | no | `.coverage-baseline.rust` |
 | baseline-python-file | Python baseline path | no | `.coverage-baseline.python` |
@@ -212,6 +212,15 @@ Enable ratcheting:
     output-path: coverage.xml
     with-ratchet: true
 ```
+
+The ratchet compares the current coverage against a stored baseline within a
+provisional symmetric ±1 percentage-point dead-band. Coverage within one
+absolute percentage point of the baseline is treated as noise: the run passes
+and the baseline is held. A drop of more than one point below the baseline
+fails the run; a rise of more than one point above the baseline advances the
+baseline. On pushes to the default branch the advanced baseline is persisted to
+the Actions cache and restored on subsequent runs, so the baseline tracks the
+latest default-branch coverage.
 
 Enable cucumber-rs:
 

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -262,13 +262,23 @@ runs:
         fi
       shell: bash
     - name: Save baselines
-      if: success() && inputs.with-ratchet == 'true' && steps.restore-baselines.outputs.cache-hit != 'true'
+      # Save under the same run-id-suffixed key the restore step uses as its
+      # primary key. GitHub Actions cache entries are immutable, so a constant
+      # key (`ratchet-baseline-${{ runner.os }}`) can only ever be written once
+      # and then freezes the baseline until the 7-day eviction. A per-run key
+      # is unique, so every main run persists a fresh baseline that later runs
+      # pick up via the `ratchet-baseline-${{ runner.os }}-` restore-key prefix
+      # (newest matching entry wins). The `cache-hit` guard is intentionally
+      # dropped: the restore primary key never matches within the same run, so
+      # `cache-hit` is always false here and the guard only ever suppressed the
+      # save on the constant key.
+      if: success() && inputs.with-ratchet == 'true'
       uses: actions/cache@v4
       with:
         path: |
           ${{ inputs.baseline-rust-file }}
           ${{ inputs.baseline-python-file }}
-        key: ratchet-baseline-${{ runner.os }}
+        key: ratchet-baseline-${{ runner.os }}-${{ github.run_id }}
 
     - id: out
       run: uv run --script "${{ github.action_path }}/scripts/set_outputs.py"

--- a/.github/actions/generate-coverage/scripts/ratchet_coverage.py
+++ b/.github/actions/generate-coverage/scripts/ratchet_coverage.py
@@ -3,13 +3,27 @@
 # requires-python = ">=3.12"
 # dependencies = ["plumbum", "typer"]
 # ///
-"""Compare current coverage with a baseline and update if higher."""
+"""Compare current coverage with a baseline within a symmetric dead-band.
+
+Coverage within +/-``RATCHET_TOLERANCE_PP`` percentage points of the stored
+baseline is treated as noise: the run passes and the baseline is held. A drop
+beyond the band fails the gate; a rise beyond the band advances the baseline.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import typer
+
+# Provisional symmetric dead-band, in absolute percentage points, around the
+# stored baseline. Coverage within +/- this many points of the baseline is
+# treated as noise: the run passes and the baseline is left untouched. This
+# guards against coverage nondeterminism (flaky per-run line counts) both from
+# tripping a false "Coverage decreased" failure on a low run and from inflating
+# the baseline on a lucky-high run (which would then make the next normal run
+# fail). The baseline only advances on a genuine improvement beyond the band.
+RATCHET_TOLERANCE_PP = 1.0
 
 BASELINE_FILE_OPT = typer.Option(
     Path(".coverage-baseline"), envvar="INPUT_BASELINE_FILE"
@@ -32,19 +46,33 @@ def main(
     *,
     current: float = CURRENT_OPT,
 ) -> None:
-    """Compare ``current`` coverage with the stored baseline and update it."""
+    """Gate ``current`` coverage against the baseline within the dead-band.
+
+    Fails when ``current`` is more than ``RATCHET_TOLERANCE_PP`` below the
+    baseline, advances the baseline when ``current`` is more than
+    ``RATCHET_TOLERANCE_PP`` above it, and otherwise passes while leaving the
+    baseline unchanged.
+    """
     baseline = round(read_baseline(baseline_file), 2)
     current = round(current, 2)
 
     typer.echo(f"Current coverage: {current}%")
     typer.echo(f"Baseline coverage: {baseline}%")
+    typer.echo(f"Tolerance: +/-{RATCHET_TOLERANCE_PP:.2f} percentage points")
 
-    if current < baseline:
+    # Fail only when coverage falls more than the tolerance band below the
+    # baseline.
+    if current < baseline - RATCHET_TOLERANCE_PP:
         typer.echo("Coverage decreased", err=True)
         raise typer.Exit(code=1)
 
-    baseline_file.parent.mkdir(parents=True, exist_ok=True)
-    baseline_file.write_text(f"{current:.2f}")
+    # Advance the baseline only on a genuine improvement beyond the band. Within
+    # +/- the band (either side of the baseline) the run passes and the baseline
+    # is held: a low run is not failed and a lucky-high run does not inflate the
+    # baseline (which would then make the next normal run fail).
+    if current > baseline + RATCHET_TOLERANCE_PP:
+        baseline_file.parent.mkdir(parents=True, exist_ok=True)
+        baseline_file.write_text(f"{current:.2f}")
 
 
 if __name__ == "__main__":

--- a/.github/actions/generate-coverage/tests/test_ratchet_baseline.py
+++ b/.github/actions/generate-coverage/tests/test_ratchet_baseline.py
@@ -1,0 +1,211 @@
+"""Tests for the coverage ratchet baseline contract.
+
+Two properties are exercised here:
+
+* The ``action.yml`` cache save/restore key contract. GitHub Actions cache
+  entries are immutable, so a constant save key freezes the ratchet baseline at
+  whatever the first post-eviction run measured. The save key must therefore
+  vary per run and match the restore step's run-id-suffixed primary key, and
+  the save step must not be gated on ``cache-hit`` (which would suppress the
+  write once a constant key existed). This is a regression guard for the
+  baseline-freeze bug that caused downstream repositories to false-trip
+  "Coverage decreased" on pull requests.
+* The ``ratchet_coverage.py`` script's baseline-advance semantics: the stored
+  baseline rises when coverage improves, holds when coverage is unchanged, and
+  the gate fails when coverage drops below the baseline.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import typing as typ
+from pathlib import Path
+
+import pytest
+import typer
+import yaml
+
+if typ.TYPE_CHECKING:  # pragma: no cover - type hints only
+    from types import ModuleType
+
+ACTION_DIR = Path(__file__).resolve().parents[1]
+ACTION_YML = ACTION_DIR / "action.yml"
+
+
+def _load_ratchet_module() -> ModuleType:
+    """Import ``ratchet_coverage`` from the action's ``scripts`` directory."""
+    script = ACTION_DIR / "scripts" / "ratchet_coverage.py"
+    sys.modules.pop("ratchet_coverage", None)
+    spec = importlib.util.spec_from_file_location("ratchet_coverage", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _steps() -> list[dict[str, typ.Any]]:
+    """Return the composite action's step definitions."""
+    data = yaml.safe_load(ACTION_YML.read_text())
+    return data["runs"]["steps"]
+
+
+def _step_by_name(name: str) -> dict[str, typ.Any]:
+    """Return the single step whose ``name`` matches ``name``."""
+    matches = [step for step in _steps() if step.get("name") == name]
+    assert len(matches) == 1, f"expected exactly one {name!r} step, got {len(matches)}"
+    return matches[0]
+
+
+def test_restore_baselines_uses_run_id_primary_key_and_prefix() -> None:
+    """The restore step keys on the run id with a shared prefix restore-key."""
+    restore = _step_by_name("Restore baselines")
+    key = restore["with"]["key"]
+    restore_keys = restore["with"]["restore-keys"]
+    assert "${{ github.run_id }}" in key
+    assert key.startswith("ratchet-baseline-${{ runner.os }}-")
+    # The restore-key prefix must match the per-run save key so the newest
+    # baseline is recovered on subsequent runs.
+    assert restore_keys.strip() == "ratchet-baseline-${{ runner.os }}-"
+
+
+def test_save_baselines_key_varies_per_run() -> None:
+    """The save key must include the run id so a fresh baseline is written.
+
+    A constant key such as ``ratchet-baseline-${{ runner.os }}`` is immutable
+    after its first write and freezes the ratchet. The save key must instead
+    match the restore step's run-id-suffixed primary key.
+    """
+    save = _step_by_name("Save baselines")
+    key = save["with"]["key"]
+    assert "${{ github.run_id }}" in key, (
+        "save key is constant; the baseline will freeze after the first write"
+    )
+    assert key == _step_by_name("Restore baselines")["with"]["key"]
+
+
+def test_save_baselines_not_gated_on_cache_hit() -> None:
+    """The save step must not be suppressed by a ``cache-hit`` guard.
+
+    The historical ``cache-hit != 'true'`` guard, combined with the constant
+    save key, meant the improved baseline was never persisted.
+    """
+    save = _step_by_name("Save baselines")
+    condition = save["if"]
+    assert "cache-hit" not in condition, (
+        "cache-hit guard reintroduced; the advanced baseline will not persist"
+    )
+    assert "inputs.with-ratchet == 'true'" in condition
+    assert "success()" in condition
+
+
+def test_tolerance_constant_is_one_percentage_point() -> None:
+    """The provisional tolerance band is one absolute percentage point."""
+    module = _load_ratchet_module()
+    assert module.RATCHET_TOLERANCE_PP == 1.0
+
+
+def test_baseline_advances_when_coverage_rises(tmp_path: Path) -> None:
+    """A higher current percentage overwrites the stored baseline."""
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.rust"
+    baseline.write_text("85.20")
+
+    module.main(baseline_file=baseline, current=90.05)
+
+    assert baseline.read_text() == "90.05"
+
+
+def test_exactly_equal_passes_and_holds(tmp_path: Path) -> None:
+    """An equal current percentage keeps the baseline and does not fail."""
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.python"
+    baseline.write_text("85.23")
+
+    module.main(baseline_file=baseline, current=85.23)
+
+    assert baseline.read_text() == "85.23"
+
+
+def test_within_tolerance_dip_passes_without_lowering_baseline(
+    tmp_path: Path,
+) -> None:
+    """A dip inside the tolerance band passes but must not lower the baseline.
+
+    This is the chutoro scenario: 85.20% on a pull request against an 85.23%
+    baseline is a 0.03pp dip, well within the 1.0pp band. It must pass and
+    leave the baseline unchanged so the band cannot erode it downwards.
+    """
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.rust"
+    baseline.write_text("85.23")
+
+    module.main(baseline_file=baseline, current=85.20)
+
+    assert baseline.read_text() == "85.23"
+
+
+def test_dip_at_tolerance_edge_passes_and_holds(tmp_path: Path) -> None:
+    """A drop of exactly the tolerance band passes and holds the baseline."""
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.rust"
+    baseline.write_text("90.00")
+
+    module.main(baseline_file=baseline, current=89.00)
+
+    assert baseline.read_text() == "90.00"
+
+
+def test_within_tolerance_rise_passes_without_raising_baseline(
+    tmp_path: Path,
+) -> None:
+    """A rise inside the band passes but must not inflate the baseline.
+
+    A lucky-high run within +/- the band must not raise the baseline, otherwise
+    the next normal run could fall outside the band and fail.
+    """
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.rust"
+    baseline.write_text("85.00")
+
+    module.main(baseline_file=baseline, current=85.50)
+
+    assert baseline.read_text() == "85.00"
+
+
+def test_rise_at_tolerance_edge_holds_baseline(tmp_path: Path) -> None:
+    """A rise of exactly the tolerance band holds the baseline.
+
+    Only a strictly greater improvement advances it.
+    """
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.rust"
+    baseline.write_text("85.00")
+
+    module.main(baseline_file=baseline, current=86.00)
+
+    assert baseline.read_text() == "85.00"
+
+
+def test_gate_fails_when_coverage_drops_beyond_tolerance(tmp_path: Path) -> None:
+    """A drop beyond the tolerance band fails and leaves the baseline intact."""
+    module = _load_ratchet_module()
+    baseline = tmp_path / ".coverage-baseline.rust"
+    baseline.write_text("85.23")
+
+    with pytest.raises(typer.Exit) as excinfo:
+        module.main(baseline_file=baseline, current=84.00)
+
+    assert excinfo.value.exit_code == 1
+    assert baseline.read_text() == "85.23"
+
+
+def test_missing_baseline_is_treated_as_zero(tmp_path: Path) -> None:
+    """A first run with no stored baseline records the current percentage."""
+    module = _load_ratchet_module()
+    baseline = tmp_path / "nested" / ".coverage-baseline.rust"
+
+    module.main(baseline_file=baseline, current=42.5)
+
+    assert baseline.read_text() == "42.50"


### PR DESCRIPTION
## Summary

Two coherent coverage-ratchet corrections to the `generate-coverage` action.

### 1. Baseline-freeze cache-key fix

The ratchet **restored** the baseline with a run-id-suffixed primary cache key
(`ratchet-baseline-<os>-<run_id>`) plus a prefix restore-key
(`ratchet-baseline-<os>-`), but **saved** it with a constant, run-id-less key
(`ratchet-baseline-<os>`) guarded by `cache-hit != 'true'`.

GitHub Actions cache entries are immutable, so the constant save key could only
ever be written once. After the first save, every later run reported
`Cache hit occurred on the primary key ratchet-baseline-<os>, not saving cache`
and the baseline froze at whatever the first post-eviction run measured — it
only ever changed when the 7-day cache eviction forced a fresh save at a random
value.

**Estate impact:** because the baseline could not advance when coverage
improved, and drifted stale, the ratchet false-tripped "Coverage decreased" on
pull requests. This is the root cause of chutoro's ratchet false-trip: a PR
measuring **85.20%** against a stale, frozen **85.23%** baseline.

The fix aligns the save key with the restore step's run-id-suffixed primary key
and removes the `cache-hit` guard, so every main run persists a fresh baseline
that later runs recover via the restore-key prefix (newest matching entry
wins).

### 2. Symmetric ±1pp tolerance dead-band

`ratchet_coverage.py` now compares coverage within a provisional symmetric ±1
percentage-point dead-band (single named constant `RATCHET_TOLERANCE_PP = 1.0`):

- `current < baseline - 1.0` → **fail** ("Coverage decreased").
- `current > baseline + 1.0` → **pass and advance** the baseline to `current`.
- within ±1.0 of the baseline → **pass and hold** (baseline unchanged).

Treating ±1pp as noise stops a nondeterministic low run false-tripping the gate
and, crucially, stops a lucky-high run inflating the baseline so the next normal
run fails. Both values are rounded to 2dp before comparison.

**No inputs or user-facing contract change.**

## Review walkthrough

- **`action.yml`** — the "Save baselines" step now keys on
  `ratchet-baseline-${{ runner.os }}-${{ github.run_id }}` (matching the restore
  primary key) and its `if` drops the `cache-hit != 'true'` guard, keeping only
  `success() && inputs.with-ratchet == 'true'`. A comment explains why. The
  restore step is unchanged.
- **`scripts/ratchet_coverage.py`** — adds `RATCHET_TOLERANCE_PP` and the
  three-way dead-band comparison; the baseline is written only on a genuine
  improvement beyond the band.
- **`tests/test_ratchet_baseline.py`** — new regression tests. Three assert the
  `action.yml` cache-key contract (save key varies per run, equals the restore
  primary key, not gated on `cache-hit`) and fail against the pre-fix
  `action.yml`. The remainder cover the dead-band: within-band dip and rise pass
  and hold the baseline (incl. the 85.23→85.20 chutoro figures and both band
  edges), a drop beyond the band fails and preserves the baseline, a rise beyond
  the band advances it, exact equality holds, and a missing baseline is treated
  as zero.
- **`CHANGELOG.md` / `README.md`** — document both changes and the dead-band
  semantics.

## Validation

- `uv run pytest .github/actions/generate-coverage/tests/test_ratchet_baseline.py` — 12 passed.
- Confirmed the cache-key contract tests fail against the pre-fix `action.yml`.
- `uv run pytest --co -q` — full suite collects with no errors.
- `ruff check` / `ruff format --check` — clean.
- `ty check` on `ratchet_coverage.py` — clean.
- `action-validator .github/actions/generate-coverage/action.yml` — exit 0.
- `markdownlint-cli2` and `typos` (en-GB-oxendict) on the docs — clean.

Downstream consumers must bump their `generate-coverage` pin to a shared-actions
SHA that includes this fix to pick up the advancing baseline and the dead-band.
