### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       MERMAN_CLI_VERSION: '0.7.0'
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed and why

This bumps the pinned `whitaker-installer` version in CI from 0.2.5 to
0.2.6. The Whitaker Dylint suite's rolling release now pins toolchain
`nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer 0.2.5
provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that
nightly, so the CI lint step has been red. `whitaker-installer` 0.2.6
fixes this by provisioning `cargo-dylint` 6.0.1, and its prebuilt
dependency binaries are now published.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/shared-actions/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
