### PR TITLE
Add a language input to force generate-coverage scope

### DIFF
--- a/.github/actions/generate-coverage/CHANGELOG.md
+++ b/.github/actions/generate-coverage/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Add a `language` input (`auto`, `rust`, `python`, `mixed`; default `auto`) to
+  force the coverage scope. `auto` preserves the existing manifest-based
+  detection. Explicit values fail fast when their prerequisites are absent:
+  `rust` requires a resolved Cargo manifest and ignores a configuration-only
+  `pyproject.toml` (no `[project]` table); `python` requires a syncable
+  `pyproject.toml` with a `[project]` table, matching the action's `uv sync`
+  contract; `mixed` requires both. This lets a Rust-only repository that keeps a
+  tooling-only `pyproject.toml` (for Ruff, Pylint, ty, etc.) set `language: rust`
+  and keep generating `lcov`, which `auto` would otherwise reject by classifying
+  the repository as mixed. Callers that omit `language` are unaffected.
+
 - Fix the coverage ratchet baseline freeze. The "Save baselines" step wrote a
   constant, run-id-less cache key (`ratchet-baseline-<os>`) guarded by
   `cache-hit != 'true'`, while "Restore baselines" recovered a run-id-suffixed

--- a/.github/actions/generate-coverage/README.md
+++ b/.github/actions/generate-coverage/README.md
@@ -135,6 +135,7 @@ Known limitations:
 | --- | --- | --- | --- |
 | features | Enable Cargo (Rust) features; space- or comma-separated. | no | |
 | with-default-features | Enable default Cargo features (Rust) | no | `true` |
+| language | Coverage language scope: `auto`, `rust`, `python`, or `mixed`. `auto` keeps manifest-based detection; explicit values force the scope and fail fast when its prerequisites are missing. See below. | no | `auto` |
 | cargo-manifest | Optional path to Cargo.toml if root Cargo.toml is missing | no | |
 | use-cargo-nextest | Use cargo-nextest for Rust coverage runs (default); set to `false` to use `cargo llvm-cov` directly | no | `true` |
 | output-path | Output file path | yes | |
@@ -151,6 +152,37 @@ Known limitations:
 
 \* `lcov` is only supported for Rust projects, while `coveragepy` is only
 supported for Python projects. Mixed projects must use `cobertura`.
+
+### Selecting the coverage language
+
+By default (`language: auto`) the action infers the scope from the manifests
+present: a root `Cargo.toml` means Rust, a root `pyproject.toml` means Python,
+and both together mean mixed. This inference treats *any* `pyproject.toml` as a
+Python project, including a configuration-only one that exists solely to hold
+tooling settings (for example Ruff, Pylint, or ty) with no `[project]` table.
+
+Set `language` explicitly to force the scope and skip that inference:
+
+- `rust` requires a resolved Cargo manifest (root `Cargo.toml` or
+  `cargo-manifest`) and **ignores** a configuration-only `pyproject.toml`.
+- `python` requires a syncable `pyproject.toml` with a `[project]` table (the
+  prerequisite for the action's `uv sync`).
+- `mixed` requires both of the above.
+
+Explicit values fail fast with a clear error when their prerequisites are
+absent.
+
+Use `language: rust` for a Rust repository that keeps a tooling-only
+`pyproject.toml` (so `auto` would otherwise misclassify it as mixed and reject
+`lcov`):
+
+```yaml
+- uses: leynos/shared-actions/.github/actions/generate-coverage@v1
+  with:
+    language: rust
+    output-path: lcov.info
+    format: lcov
+```
 
 ## Outputs
 

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -8,6 +8,17 @@ inputs:
     description: Enable default features
     required: false
     default: "true"
+  language:
+    description: |
+      Coverage language scope. `auto` (the default) keeps the historical
+      manifest-based detection: a root `Cargo.toml` selects Rust, a root
+      `pyproject.toml` selects Python, and both together select mixed. Explicit
+      values force the requested scope and fail fast when its prerequisites are
+      absent: `rust` requires a resolved Cargo manifest and ignores a
+      configuration-only `pyproject.toml`; `python` requires a syncable
+      `pyproject.toml` with a `[project]` table; `mixed` requires both.
+    required: false
+    default: auto
   cargo-manifest:
     description: Optional path to Cargo.toml when the repository root has none
     required: false
@@ -82,6 +93,7 @@ runs:
       env:
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_CARGO_MANIFEST: ${{ inputs.cargo-manifest }}
+        INPUT_LANGUAGE: ${{ inputs.language }}
       shell: bash
     - name: Restore baselines
       id: restore-baselines

--- a/.github/actions/generate-coverage/scripts/detect.py
+++ b/.github/actions/generate-coverage/scripts/detect.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import enum
 import os
+import tomllib
+import typing as typ
 from pathlib import Path
 
 import typer
@@ -25,6 +27,20 @@ class CoverageFmt(enum.StrEnum):
 class Lang(enum.StrEnum):
     """Project languages supported by the action."""
 
+    RUST = "rust"
+    PYTHON = "python"
+    MIXED = "mixed"
+
+
+class LangMode(enum.StrEnum):
+    """Requested coverage language mode from the ``language`` input.
+
+    ``AUTO`` preserves manifest-based detection; the remaining values force the
+    requested coverage scope and reject repositories that lack the matching
+    prerequisites.
+    """
+
+    AUTO = "auto"
     RUST = "rust"
     PYTHON = "python"
     MIXED = "mixed"
@@ -55,9 +71,33 @@ def _resolve_cargo_manifest(cargo_manifest: str) -> Path | None:
     return None
 
 
-def get_lang(cargo_manifest: str = "") -> tuple[Lang, Path | None]:
-    """Detect project language and selected Cargo manifest (if any)."""
-    selected_manifest = _resolve_cargo_manifest(cargo_manifest)
+def _has_python_project() -> bool:
+    """Return whether the repository root holds a uv-syncable Python project.
+
+    This mirrors the ``uv sync`` contract that :mod:`run_python` depends on:
+    the coverage run installs project dependencies with
+    ``uv sync --inexact --python``, which only succeeds when
+    ``pyproject.toml`` declares a project that uv is allowed to manage. A
+    configuration-only ``pyproject.toml`` used solely for tooling (for
+    example Ruff, Pylint, ty) declares no ``[project]`` table and typically
+    sets ``[tool.uv] managed = false``; such a file is not a Python coverage
+    project and must not force a Python or mixed coverage run.
+    """
+    manifest = Path("pyproject.toml")
+    if not manifest.is_file():
+        return False
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    tool_uv = data.get("tool", {}).get("uv", {})
+    if tool_uv.get("managed") is False:
+        return False
+    return "project" in data or "workspace" in tool_uv
+
+
+def _auto_lang(selected_manifest: Path | None) -> tuple[Lang, Path | None]:
+    """Detect the language from present manifests (historical behaviour)."""
     python = Path("pyproject.toml").is_file()
     if selected_manifest is not None:
         return (Lang.MIXED if python else Lang.RUST), selected_manifest
@@ -67,31 +107,117 @@ def get_lang(cargo_manifest: str = "") -> tuple[Lang, Path | None]:
     raise typer.Exit(code=1)
 
 
-def main(
-    fmt: str = FMT_OPT,
-    github_output: Path = GITHUB_OUTPUT_OPT,
-    cargo_manifest: str = "",
-) -> None:
-    """Detect the project language and write it plus the format to ``GITHUB_OUTPUT``."""
-    if not cargo_manifest:
-        cargo_manifest = os.getenv("INPUT_CARGO_MANIFEST", "")
-    lang, selected_manifest = get_lang(cargo_manifest)
+def _fail(message: str) -> typ.NoReturn:
+    """Emit ``message`` on stderr and exit with code 1."""
+    typer.echo(message, err=True)
+    raise typer.Exit(code=1)
+
+
+def _forced_rust(selected_manifest: Path | None) -> tuple[Lang, Path | None]:
+    """Resolve ``language=rust``; a configuration-only pyproject is ignored."""
+    if selected_manifest is None:
+        _fail("language=rust requires a Cargo manifest, but none was found")
+    return Lang.RUST, selected_manifest
+
+
+def _forced_python(selected_manifest: Path | None) -> tuple[Lang, Path | None]:
+    """Resolve ``language=python``; requires a syncable ``[project]`` table."""
+    if not _has_python_project():
+        _fail(
+            "language=python requires a syncable pyproject.toml with a "
+            "[project] table, but none was found"
+        )
+    return Lang.PYTHON, None
+
+
+def _forced_mixed(selected_manifest: Path | None) -> tuple[Lang, Path | None]:
+    """Resolve ``language=mixed``; requires both Rust and Python prerequisites."""
+    missing = [
+        need
+        for ok, need in (
+            (selected_manifest is not None, "a Cargo manifest"),
+            (_has_python_project(), "a syncable pyproject.toml with a [project] table"),
+        )
+        if not ok
+    ]
+    if missing:
+        _fail(
+            f"language=mixed requires {' and '.join(missing)}, but not all "
+            "prerequisites were found"
+        )
+    return Lang.MIXED, selected_manifest
+
+
+# Explicit (non-``auto``) language modes dispatch to a single-responsibility
+# resolver that validates the mode's prerequisites.
+_FORCED_RESOLVERS: dict[
+    LangMode, typ.Callable[[Path | None], tuple[Lang, Path | None]]
+] = {
+    LangMode.RUST: _forced_rust,
+    LangMode.PYTHON: _forced_python,
+    LangMode.MIXED: _forced_mixed,
+}
+
+
+def get_lang(
+    cargo_manifest: str = "", mode: LangMode = LangMode.AUTO
+) -> tuple[Lang, Path | None]:
+    """Detect project language and selected Cargo manifest (if any)."""
+    selected_manifest = _resolve_cargo_manifest(cargo_manifest)
+    if mode is LangMode.AUTO:
+        return _auto_lang(selected_manifest)
+    return _FORCED_RESOLVERS[mode](selected_manifest)
+
+
+def _parse_lang_mode(raw: str) -> LangMode:
+    """Parse the requested language mode, rejecting unsupported values."""
     try:
-        fmt_enum = CoverageFmt(fmt.lower())
+        return LangMode(raw.strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in LangMode)
+        typer.echo(f"Unsupported language: {raw} (expected one of: {valid})", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _parse_format(fmt: str) -> CoverageFmt:
+    """Parse the coverage format, rejecting unsupported values."""
+    try:
+        return CoverageFmt(fmt.lower())
     except ValueError as exc:
         typer.echo(f"Unsupported format: {fmt}", err=True)
         raise typer.Exit(code=1) from exc
 
-    match (lang, fmt_enum):
+
+def _resolve_detect_inputs(cargo_manifest: str, language: str) -> tuple[str, str]:
+    """Fill unset detector inputs from the environment."""
+    cargo_manifest = cargo_manifest or os.getenv("INPUT_CARGO_MANIFEST", "")
+    language = language or os.getenv("INPUT_LANGUAGE", "") or LangMode.AUTO.value
+    return cargo_manifest, language
+
+
+def _check_format_compatibility(lang: Lang, fmt: CoverageFmt) -> None:
+    """Reject language/format combinations the action cannot produce."""
+    match (lang, fmt):
         case (Lang.RUST, CoverageFmt.COVERAGEPY):
-            typer.echo("coveragepy format only supported for Python projects", err=True)
-            raise typer.Exit(code=1)
+            _fail("coveragepy format only supported for Python projects")
         case (Lang.PYTHON, CoverageFmt.LCOV):
-            typer.echo("lcov format only supported for Rust projects", err=True)
-            raise typer.Exit(code=1)
-        case (Lang.MIXED, fmt_case) if fmt_case != CoverageFmt.COBERTURA:
-            typer.echo("Mixed projects only support cobertura format", err=True)
-            raise typer.Exit(code=1)
+            _fail("lcov format only supported for Rust projects")
+        case (Lang.MIXED, other) if other != CoverageFmt.COBERTURA:
+            _fail("Mixed projects only support cobertura format")
+
+
+def main(
+    fmt: str = FMT_OPT,
+    github_output: Path = GITHUB_OUTPUT_OPT,
+    cargo_manifest: str = "",
+    language: str = "",
+) -> None:
+    """Detect the project language and write it plus the format to ``GITHUB_OUTPUT``."""
+    cargo_manifest, language = _resolve_detect_inputs(cargo_manifest, language)
+    mode = _parse_lang_mode(language)
+    lang, selected_manifest = get_lang(cargo_manifest, mode)
+    fmt_enum = _parse_format(fmt)
+    _check_format_compatibility(lang, fmt_enum)
 
     with github_output.open("a") as fh:
         fh.write(f"lang={lang.value}\nfmt={fmt_enum.value}\n")

--- a/.github/actions/generate-coverage/tests/test_detect.py
+++ b/.github/actions/generate-coverage/tests/test_detect.py
@@ -209,3 +209,146 @@ def test_detect_errors_when_only_missing_manifest_configured(
 
     assert _exit_code(exc.value) == 1
     assert "Neither Cargo.toml nor pyproject.toml found" in capsys.readouterr().err
+
+
+# A configuration-only pyproject.toml: tooling settings, no [project] table,
+# and explicitly opted out of uv management. `auto` still treats it as Python.
+_TOOLING_PYPROJECT = "[tool.ruff]\nline-length = 88\n\n[tool.uv]\nmanaged = false\n"
+_REAL_PYPROJECT = '[project]\nname = "demo"\nversion = "0.1.0"\n'
+
+
+def test_auto_preserves_mixed_detection(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+) -> None:
+    """`language=auto` still classifies Cargo + any pyproject.toml as mixed."""
+    _project_dir, out = setup_project(
+        {"Cargo.toml": "", "pyproject.toml": _TOOLING_PYPROJECT}
+    )
+
+    detect.main("cobertura", out, "", "auto")
+
+    assert out.read_text() == "lang=mixed\nfmt=cobertura\ncargo_manifest=Cargo.toml\n"
+
+
+def test_forced_rust_ignores_tooling_pyproject(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+) -> None:
+    """`language=rust` emits `lang=rust` with lcov despite a config-only pyproject."""
+    _project_dir, out = setup_project(
+        {"Cargo.toml": "", "pyproject.toml": _TOOLING_PYPROJECT}
+    )
+
+    detect.main("lcov", out, "", "rust")
+
+    assert out.read_text() == "lang=rust\nfmt=lcov\ncargo_manifest=Cargo.toml\n"
+
+
+def test_forced_rust_reads_language_from_env(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INPUT_LANGUAGE forces the scope when no positional language is provided."""
+    _project_dir, out = setup_project(
+        {"Cargo.toml": "", "pyproject.toml": _TOOLING_PYPROJECT}
+    )
+    monkeypatch.setenv("INPUT_LANGUAGE", "rust")
+
+    detect.main("lcov", out)
+
+    assert out.read_text() == "lang=rust\nfmt=lcov\ncargo_manifest=Cargo.toml\n"
+
+
+def test_forced_python_accepts_real_project(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+) -> None:
+    """`language=python` succeeds for a syncable pyproject with a [project] table."""
+    _project_dir, out = setup_project({"pyproject.toml": _REAL_PYPROJECT})
+
+    detect.main("coveragepy", out, "", "python")
+
+    assert out.read_text() == "lang=python\nfmt=coveragepy\n"
+
+
+def test_forced_mixed_accepts_both(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+) -> None:
+    """`language=mixed` succeeds when both prerequisites are satisfied."""
+    _project_dir, out = setup_project(
+        {"crate/Cargo.toml": "", "pyproject.toml": _REAL_PYPROJECT}
+    )
+
+    detect.main("cobertura", out, "crate/Cargo.toml", "mixed")
+
+    assert (
+        out.read_text()
+        == "lang=mixed\nfmt=cobertura\ncargo_manifest=crate/Cargo.toml\n"
+    )
+
+
+class _ErrorCase(typ.NamedTuple):
+    """A forced-language failure scenario and its expected stderr fragment."""
+
+    files: dict[str, str]
+    fmt: str
+    language: str
+    expected_error: str
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            _ErrorCase(
+                {"pyproject.toml": _REAL_PYPROJECT},
+                "lcov",
+                "rust",
+                "language=rust requires a Cargo manifest",
+            ),
+            id="rust-without-manifest",
+        ),
+        pytest.param(
+            _ErrorCase(
+                {"pyproject.toml": _TOOLING_PYPROJECT},
+                "coveragepy",
+                "python",
+                "language=python requires",
+            ),
+            id="python-with-tooling-only-pyproject",
+        ),
+        pytest.param(
+            _ErrorCase(
+                {"pyproject.toml": _REAL_PYPROJECT},
+                "cobertura",
+                "mixed",
+                "language=mixed requires a Cargo manifest",
+            ),
+            id="mixed-without-manifest",
+        ),
+        pytest.param(
+            _ErrorCase(
+                {"Cargo.toml": "", "pyproject.toml": _TOOLING_PYPROJECT},
+                "cobertura",
+                "mixed",
+                "syncable pyproject.toml",
+            ),
+            id="mixed-with-tooling-only-pyproject",
+        ),
+        pytest.param(
+            _ErrorCase({"Cargo.toml": ""}, "lcov", "elvish", "Unsupported language"),
+            id="invalid-language-value",
+        ),
+    ],
+)
+def test_forced_language_errors(
+    setup_project: typ.Callable[[dict[str, str] | None, str | None], tuple[Path, Path]],
+    capsys: pytest.CaptureFixture[str],
+    case: _ErrorCase,
+) -> None:
+    """Forced-language modes fail fast when prerequisites are unmet or invalid."""
+    _project_dir, out = setup_project(case.files)
+
+    with pytest.raises(detect.typer.Exit) as exc:
+        detect.main(case.fmt, out, "", case.language)
+
+    assert _exit_code(exc.value) == 1
+    assert case.expected_error in capsys.readouterr().err


### PR DESCRIPTION
## Summary

The `generate-coverage` detector (`scripts/detect.py`) treats **any** root
`pyproject.toml` as proof of a Python project. A Rust repository that keeps a
*configuration-only* `pyproject.toml` — holding Ruff, Pylint, ty, and similar
tool settings with **no `[project]` table** — is therefore classified as
`mixed`, and mixed runs only support Cobertura. That breaks Rust-only `lcov`
coverage (e.g. Wildside, which generates `lcov.info` for CodeScene).

This adds a backwards-compatible `language` input to force the coverage scope.

## Behaviour

| `language` | Effect |
| --- | --- |
| `auto` (default) | Unchanged manifest-based detection: `Cargo.toml`→rust, `pyproject.toml`→python, both→mixed. |
| `rust` | Requires a resolved Cargo manifest; **ignores** a configuration-only `pyproject.toml`. Emits `lang=rust`. |
| `python` | Requires a *syncable* `pyproject.toml` with a `[project]` table (matches the `uv sync --inexact --python` contract in `run_python.py`). Emits `lang=python`. |
| `mixed` | Requires both prerequisites. Emits `lang=mixed`. |

Explicit values fail fast with a clear stderr diagnostic and non-zero exit when
their prerequisite is absent. Existing format validation is preserved: `lcov`
only for Rust, `coveragepy` only for Python, Cobertura for mixed.

The Python prerequisite deliberately mirrors what the action genuinely needs:
`run_python.py` runs `uv sync --inexact --python`, which only succeeds against a
project uv can manage — a `[project]` table (or a `[tool.uv.workspace]` root),
and not opted out via `[tool.uv] managed = false`. A tooling-only config is not
a Python coverage project.

## Changes

- `action.yml`: new `language` input (default `auto`), passed to the detector as `INPUT_LANGUAGE`.
- `scripts/detect.py`: typed `LangMode` enum; reads `INPUT_LANGUAGE`; forced-mode validation via `_forced_lang` / `_has_python_project`; `auto` path unchanged.
- `tests/test_detect.py`: 10 new cases (auto still detects mixed; forced `rust` ignores a tooling-only `pyproject` and emits `lang=rust` with `lcov`; forced `python`/`mixed` prerequisite failures; invalid `language`). Existing Cargo-manifest precedence tests intact. 24/24 pass.
- `README.md`: `language` input row, a "Selecting the coverage language" section, and a Rust-only example.
- `CHANGELOG.md`: entry under Unreleased.

## Validation

- `pytest .../generate-coverage/tests/test_detect.py` — 24 passed.
- `ruff check` (repo-wide) — clean; `ruff format --check` — clean.
- `make typecheck` (ty) — all checks passed.
- `action-validator action.yml` — clean; `markdownlint-cli2` on README/CHANGELOG — 0 errors.

## Downstream

Wildside will set `language: rust` on its `Generate Rust coverage` steps and pin
to this change's merged SHA so its Rust-only `lcov`/CodeScene path is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a configurable language scope to the generate-coverage action so callers can override automatic manifest-based language detection while preserving existing default behaviour.

New Features:
- Introduce a language input to the generate-coverage action to explicitly select Rust, Python, mixed, or automatic coverage detection.
- Support reading the requested coverage language from both workflow inputs and environment variables for the detector script.

Enhancements:
- Refine language detection in the coverage detector to distinguish real Python projects from configuration-only pyproject.toml files based on uv-syncability.
- Improve error reporting in the detector by validating explicit language selections and failing fast with clear diagnostics when prerequisites are missing.
- Extend test coverage for the detector to cover explicit language modes, environment-driven configuration, and invalid language values.
- Update documentation and changelog to describe the new language input, its semantics, and usage patterns for Rust-only repositories with tooling-only pyproject.toml files.

Tests:
- Add new detector tests that cover auto vs forced language modes, handling of tooling-only vs real pyproject.toml files, mixed-language prerequisite checks, and invalid language values.