### PR TITLE
Pass --locked to the cargo-mutants install fallback (#364)

### DIFF
--- a/.github/workflows/mutation-cargo.yml
+++ b/.github/workflows/mutation-cargo.yml
@@ -213,10 +213,19 @@ jobs:
           CARGO_MUTANTS_VERSION: ${{ inputs.cargo-mutants-version }}
         run: |
           set -euo pipefail
+          # `--locked` is forwarded to the source-build fallback that
+          # cargo-binstall runs when no prebuilt binary matches the runner.
+          # Without it the fallback resolves cargo-mutants' dependency tree
+          # to the newest permitted versions, which can pull in a transitive
+          # crate whose MSRV exceeds the pinned nightly toolchain (e.g.
+          # cargo-platform 0.3.3 requiring rustc 1.91) and fail the install.
+          # Building against the crate's committed Cargo.lock keeps the
+          # install reproducible against the pinned toolchain (issue #364).
+          # Mirrors the cargo-nextest install in the generate-coverage action.
           if [[ -n "${CARGO_MUTANTS_VERSION}" ]]; then
-            cargo binstall --no-confirm "cargo-mutants@${CARGO_MUTANTS_VERSION}"
+            cargo binstall --no-confirm --locked "cargo-mutants@${CARGO_MUTANTS_VERSION}"
           else
-            cargo binstall --no-confirm cargo-mutants
+            cargo binstall --no-confirm --locked cargo-mutants
           fi
 
       - name: Run setup commands

--- a/workflow_scripts/tests/test_mutation_workflow_shape.py
+++ b/workflow_scripts/tests/test_mutation_workflow_shape.py
@@ -55,6 +55,35 @@ def _step_names(steps: list[dict[str, object]]) -> list[object]:
     return [step.get("name") for step in steps]
 
 
+def test_cargo_mutants_install_is_locked() -> None:
+    """The cargo-mutants install pins its dependency resolution with --locked.
+
+    ``cargo binstall`` falls back to a source build when no prebuilt binary
+    matches the runner. Without ``--locked`` that fallback resolves the
+    dependency tree to the newest permitted versions and can pull in a
+    transitive crate whose MSRV exceeds the pinned nightly toolchain, failing
+    the install before any mutant runs (issue #364).
+    """
+    steps = [
+        step
+        for job in _jobs("mutation-cargo.yml").values()
+        for step in _steps(job)
+        if step.get("name") == "Install cargo-mutants"
+    ]
+    assert steps, "mutation-cargo.yml must install cargo-mutants"
+    for step in steps:
+        run = step.get("run")
+        assert isinstance(run, str), "install step must have a run block"
+        binstall_lines = [line for line in run.splitlines() if "cargo binstall" in line]
+        assert binstall_lines, "install step must invoke cargo binstall"
+        for line in binstall_lines:
+            assert "--locked" in line, (
+                f"cargo binstall must pass --locked so the source-build "
+                f"fallback honours the committed Cargo.lock (issue #364): "
+                f"{line.strip()!r}"
+            )
+
+
 @pytest.mark.parametrize("workflow_name", WORKFLOW_NAMES)
 def test_every_workflow_checkout_is_followed_by_relocation(
     workflow_name: str,


### PR DESCRIPTION
## Summary

`cargo binstall` falls back to a source build when no prebuilt binary matches
the runner. The `Install cargo-mutants` step ran binstall without `--locked`,
so that fallback resolved cargo-mutants' dependency tree to the newest
permitted versions and pulled in a transitive crate whose MSRV exceeded the
pinned nightly toolchain — `cargo-platform 0.3.3` requiring rustc 1.91 broke a
scheduled run against `nightly-2025-06-26`, failing the install before any
mutant ran.

This adds `--locked` to both binstall invocations. cargo-binstall forwards
`--locked` to the source-build fallback, which then resolves against
cargo-mutants' committed `Cargo.lock` and stays reproducible on the pinned
toolchain. This mirrors the existing `cargo-nextest` install in the
`generate-coverage` action, which already passes `--locked`.

### Design note

Two options were considered: (a) add `--locked`, or (b) disable the compile
strategy (`--disable-strategies compile`) and fail fast when no prebuilt binary
exists. Option (a) is chosen: it keeps the resilient source-build fallback
working (so a runner without a matching prebuilt binary still installs) while
removing the MSRV-drift failure mode, and it matches the established pattern in
this repo. Failing fast would trade a latent fragility for a hard outage
whenever a prebuilt binary is briefly unavailable.

Closes #364.

## Review walkthrough

- `.github/workflows/mutation-cargo.yml` — `cargo binstall --no-confirm --locked`
  in both branches of `Install cargo-mutants`, with an explanatory comment.
- `workflow_scripts/tests/test_mutation_workflow_shape.py` — new invariant
  `test_cargo_mutants_install_is_locked`.

## Validation

- `pytest workflow_scripts/tests/test_mutation_workflow_shape.py` — 5 passed.
- `ruff format --check` / `ruff check` — clean.

## Note for maintainers

The axinite sweep noted a `cargo-nextest` fallback missing `--locked`. In
shared-actions the nextest install (`generate-coverage/scripts/install_cargo_nextest.py`)
already passes `--locked`, so any remaining gap is in a caller repository, not
here.
