### PR TITLE
Document Python docstring conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,28 @@ make lint UV=uv
 - Keep root‑level `README.md` updated with a table of published actions and
   latest majors.
 
+### Python docstring guidance
+
+- **Document public APIs comprehensively.** Public functions, classes, and
+  methods must have comprehensive NumPy-style docstrings, including clear
+  examples that demonstrate usage and outcome where appropriate.
+- **Keep private helper docstrings concise.** Prefer single-line docstrings for
+  private helpers. When a private helper needs an explanatory paragraph,
+  inspect whether that need exposes conflated responsibilities, an unclear
+  command/query boundary, or another CQRS or cohesion failure:
+  - Split the helper when it performs distinct query and command
+    responsibilities or combines unrelated concerns.
+  - Extract a focused helper when doing so makes the invariant or boundary
+    local and simpler.
+  - Keep the helper intact when its responsibility is cohesive and the
+    explanation documents an unavoidable local constraint; retain the
+    paragraph in that case.
+- **Structure private helper docstrings selectively.** Use structured
+  NumPy-style sections for private helpers only when they describe non-obvious
+  behaviour.
+- **Keep test documentation meaningful.** Test documentation should omit
+  examples that only restate the test logic.
+
 ## 7  Deprecation & Removal
 
 1. Open an issue labelled `deprecation` with: rationale, EOL date (≥ 90 days),

--- a/docs/execplans/add-mutation-testing-workflows.md
+++ b/docs/execplans/add-mutation-testing-workflows.md
@@ -494,7 +494,7 @@ A justifies.
 `workflow_dispatch`. Stub `cargo-mutants`/`mutmut` binaries on `PATH` that emit
 synthetic reports; assert the skip path (no changes), the dispatch path (full
 run), summary content, and artefact presence via `act --json` output and the
-artifact server path.
+artefact server path.
 
 ### Stage E: documentation
 


### PR DESCRIPTION
## Summary

This change adds the canonical Python docstring subsection to [AGENTS.md](https://github.com/leynos/shared-actions/blob/aff62349180d59c3efc8707437106a214f734343/AGENTS.md) while retaining the repository’s Rust and shared-action guidance.

It also applies one existing, mechanically required Oxford-spelling correction in [the mutation-testing ExecPlan](https://github.com/leynos/shared-actions/blob/aff62349180d59c3efc8707437106a214f734343/docs/execplans/add-mutation-testing-workflows.md). Generated `.coverage` churn was restored and is not part of the branch.

## Validation

- `make fmt`
- `make check-fmt`
- `make markdownlint` — 69 Markdown files, no errors; three spelling-policy tests passed; 95.45% coverage
- `make nixie` — passed on the first sequential run; a later unchanged-diagram rerun timed out in `merman-cli`
- `git diff --check origin/main...HEAD`
- Confirmed the remote branch matches `aff62349180d59c3efc8707437106a214f734343`
- Confirmed the worktree is clean

## References

- https://lody.ai/leynos/sessions/1ea20429-7392-4e76-8d9b-b7ee0adfa2ee

## Summary by Sourcery

Document Python-specific docstring conventions and align terminology in documentation with existing spelling policies.

Documentation:
- Add Python docstring guidance covering expectations for public APIs, private helpers, and test documentation in AGENTS.md.
- Update mutation-testing ExecPlan documentation to use consistent Oxford spelling for 'artefact'.